### PR TITLE
fix: apply_github_proxy_domain 函数添加 config_data 空值检查

### DIFF
--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -29,7 +29,10 @@ def apply_github_proxy_domain(url: str, config_data: Dict[str, Any]) -> str:
     if not url:
         return url
 
-    # 获取代理配置
+    # 获取代理配置（添加空值检查）
+    if not config_data:
+        return url
+
     proxy_url = config_data.get('system_config', {}).get('github_proxy_domain', '').strip()
     if not proxy_url:
         return url


### PR DESCRIPTION
## 修改内容
在 `apply_github_proxy_domain` 函数中添加 `config_data` 参数的空值检查，防止当 `config_data` 为 `None` 时调用 `.get()` 方法导致 `AttributeError`。
## 改动详情
- 文件: `backend/converters/mihomo.py`
- 在获取代理配置之前，先检查 `config_data` 是否为 `None`
- 如果为 `None`，直接返回原始 URL
## 防御性编程
这是一个防御性编程改进，避免潜在的空指针异常。