### PR TITLE
feat: 规则仓库添加复制下载URL功能

### DIFF
--- a/frontend/src/views/RuleLibrary.vue
+++ b/frontend/src/views/RuleLibrary.vue
@@ -144,6 +144,14 @@
           <el-button
             class="list-btn"
             size="small"
+            @click="copyRuleUrl(rule)"
+            title="复制下载URL"
+          >
+            <el-icon><CopyDocument /></el-icon>
+          </el-button>
+          <el-button
+            class="list-btn"
+            size="small"
             @click="editRule(rule)"
             title="编辑"
           >
@@ -222,6 +230,14 @@
           >
             <el-icon><Plus /></el-icon>
             添加规则
+          </el-button>
+          <el-button
+            class="card-btn ghost"
+            size="small"
+            @click="copyRuleUrl(rule)"
+          >
+            <el-icon><CopyDocument /></el-icon>
+            复制URL
           </el-button>
           <el-button
             class="card-btn ghost"
@@ -438,7 +454,8 @@ import {
   Link,
   Document,
   List,
-  Grid
+  Grid,
+  CopyDocument
 } from '@element-plus/icons-vue'
 import api from '@/api'
 import Sortable from 'sortablejs'
@@ -1157,6 +1174,38 @@ const handleSaveProxyDomains = async () => {
   } catch (error) {
     ElMessage.error('保存代理域名配置失败')
     console.error('保存代理域名配置失败:', error)
+  }
+}
+
+// 生成规则的可下载 URL
+const getRuleDownloadUrl = (rule: RuleLibraryItem): string => {
+  if (rule.source_type === 'content') {
+    const baseUrl = `${window.location.protocol}//${window.location.host}`
+    return `${baseUrl}/api/rule-library/content/${rule.id}`
+  }
+  return rule.url || ''
+}
+
+// 复制 URL 到剪贴板
+const copyRuleUrl = async (rule: RuleLibraryItem) => {
+  const url = getRuleDownloadUrl(rule)
+  if (!url) {
+    ElMessage.warning('该规则没有可用的URL')
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(url)
+    ElMessage.success('URL已复制到剪贴板')
+  } catch (err) {
+    // 降级方案
+    const input = document.createElement('input')
+    input.value = url
+    document.body.appendChild(input)
+    input.select()
+    document.execCommand('copy')
+    document.body.removeChild(input)
+    ElMessage.success('URL已复制到剪贴板')
   }
 }
 


### PR DESCRIPTION
## 功能描述

在规则仓库页面添加"复制下载URL"功能，方便用户快速获取规则集的可下载链接。

## 改动详情

### 新增功能
- **列表视图**：在规则操作按钮组中添加"复制URL"图标按钮
- **卡片视图**：在规则卡片底部添加"复制URL"文字按钮

### 实现细节
- 对于 `content` 类型的规则，生成 `/api/rule-library/content/{id}` 格式的内网URL
- 对于 `url` 类型的规则，直接返回原始URL
- 使用 `navigator.clipboard` API 实现复制，并提供降级方案兼容旧浏览器
- 复制成功后显示 Element Plus 成功提示

### 技术亮点
- 完整的降级方案：当 `navigator.clipboard` 不可用时，自动使用 `document.execCommand('copy')`
- 统一的错误处理和用户反馈机制
- 保持与现有UI风格一致的设计

## 文件变更
- `frontend/src/views/RuleLibrary.vue`

## 测试验证
- [x] 列表视图按钮显示正常
- [x] 卡片视图按钮显示正常
- [x] content类型规则URL生成正确
- [x] url类型规则返回原始URL
- [x] 复制功能工作正常
- [x] 降级方案可用
