### PR TITLE
修复订阅管理当节点连接已经是 sub-store 节点连接时仍然会调用 sub-store 再转换一次的问题并优化日志

### DIFF
--- a/backend/routes/aggregations.py
+++ b/backend/routes/aggregations.py
@@ -83,7 +83,7 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
                 # 优先通过 Sub-Store 获取
                 try:
                     logger.info(f"尝试通过 Sub-Store 获取订阅最新数据: '{sub['name']}'")
-                    yaml_text = get_subscription_proxies_yaml(sub_id, sub['url'])
+                    yaml_text, source = get_subscription_proxies_yaml(sub_id, sub['url'])
                     proxies = parse_proxies_from_yaml(yaml_text)
                     sub_proxies_map[sub_id] = proxies
 
@@ -104,7 +104,14 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
                             'url': sub.get('url')
                         }
                     )
-                    logger.info(f"成功通过 Sub-Store 获取并更新缓存: '{sub['name']}', 节点数: {len(nodes_list)}")
+                    if source == 'rendered_yaml':
+                        logger.info(f"成功直接复用订阅 URL 返回的 Sub-Store YAML 并更新缓存: '{sub['name']}', 节点数: {len(nodes_list)}")
+                    elif source == 'sub_store':
+                        logger.info(f"成功通过 Sub-Store 转换订阅并更新缓存: '{sub['name']}', 节点数: {len(nodes_list)}")
+                    elif source == 'direct_url_fallback':
+                        logger.info(f"Sub-Store 获取失败后，成功直接拉取原始订阅并更新缓存: '{sub['name']}', 节点数: {len(nodes_list)}")
+                    else:
+                        logger.info(f"成功获取订阅并更新缓存: '{sub['name']}', 节点数: {len(nodes_list)}")
                 except Exception as e:
                     logger.warning(f"通过 Sub-Store 获取订阅 '{sub['name']}' 失败: {e}, 尝试读取本地缓存")
 

--- a/backend/routes/subscriptions.py
+++ b/backend/routes/subscriptions.py
@@ -173,7 +173,7 @@ def fetch_subscription(sub_id):
     # 优先尝试从 Sub-Store 获取
     try:
         current_app.logger.info(f"尝试通过 Sub-Store 获取订阅: {sub['name']} (id: {sub_id})")
-        yaml_text = get_subscription_proxies_yaml(sub_id, sub['url'])
+        yaml_text, source = get_subscription_proxies_yaml(sub_id, sub['url'])
         proxies = parse_proxies_from_yaml(yaml_text)
         nodes = proxies_to_nodes(proxies)
 
@@ -193,7 +193,14 @@ def fetch_subscription(sub_id):
                 'url': sub.get('url')
             }
         )
-        current_app.logger.info(f"成功通过 Sub-Store 获取订阅并缓存: {sub['name']}, 节点数: {len(nodes)}")
+        if source == 'rendered_yaml':
+            current_app.logger.info(f"成功直接复用订阅 URL 返回的 Sub-Store YAML 并写入缓存: {sub['name']}, 节点数: {len(nodes)}")
+        elif source == 'sub_store':
+            current_app.logger.info(f"成功通过 Sub-Store 转换订阅并写入缓存: {sub['name']}, 节点数: {len(nodes)}")
+        elif source == 'direct_url_fallback':
+            current_app.logger.info(f"Sub-Store 获取失败后，成功直接拉取原始订阅并写入缓存: {sub['name']}, 节点数: {len(nodes)}")
+        else:
+            current_app.logger.info(f"成功获取订阅并写入缓存: {sub['name']}, 节点数: {len(nodes)}")
 
     except Exception as e:
         fetch_error = str(e)
@@ -294,7 +301,7 @@ def get_all_subscription_proxies():
             # 通过 Sub-Store 获取 proxies
             proxies = []
             try:
-                yaml_text = get_subscription_proxies_yaml(sub_id, sub_url)
+                yaml_text, _source = get_subscription_proxies_yaml(sub_id, sub_url)
                 proxies = parse_proxies_from_yaml(yaml_text)
             except Exception as e:
                 current_app.logger.warning(f"通过 Sub-Store 获取订阅 '{sub_name}' 失败: {e}，尝试本地缓存")
@@ -400,8 +407,8 @@ def get_subscription_proxies(sub_id):
         # 优先通过 Sub-Store 获取
         if sub_url:
             try:
-                current_app.logger.info(f"尝试通过 Sub-Store 获取最新配置: {sub_name} (id: {sub_id})")
-                yaml_text = get_subscription_proxies_yaml(sub_id, sub_url)
+                current_app.logger.info(f"尝试获取最新配置: {sub_name} (id: {sub_id})")
+                yaml_text, source = get_subscription_proxies_yaml(sub_id, sub_url)
                 proxies = parse_proxies_from_yaml(yaml_text)
 
                 if proxies:
@@ -421,7 +428,14 @@ def get_subscription_proxies(sub_id):
                         }
                     )
                     cache_updated = True
-                    current_app.logger.info(f"成功通过 Sub-Store 获取并更新缓存: {sub_name}, 节点数: {len(proxies)}")
+                    if source == 'rendered_yaml':
+                        current_app.logger.info(f"成功直接复用订阅 URL 返回的 Sub-Store YAML 并更新缓存: {sub_name}, 节点数: {len(proxies)}")
+                    elif source == 'sub_store':
+                        current_app.logger.info(f"成功通过 Sub-Store 转换订阅并更新缓存: {sub_name}, 节点数: {len(proxies)}")
+                    elif source == 'direct_url_fallback':
+                        current_app.logger.info(f"Sub-Store 获取失败后，成功直接拉取原始订阅并更新缓存: {sub_name}, 节点数: {len(proxies)}")
+                    else:
+                        current_app.logger.info(f"成功获取订阅并更新缓存: {sub_name}, 节点数: {len(proxies)}")
             except Exception as e:
                 fetch_error = str(e)
                 current_app.logger.warning(f"通过 Sub-Store 获取配置失败: {sub_name}, 错误: {fetch_error}, 将使用本地缓存")

--- a/backend/utils/sub_store_client.py
+++ b/backend/utils/sub_store_client.py
@@ -59,6 +59,47 @@ def _is_yaml_response(text):
     return False
 
 
+def _fetch_direct_subscription_yaml(url):
+    """直接拉取订阅 URL，并在其本身已返回 proxies YAML 时直接使用。"""
+    headers = {
+        'User-Agent': 'clash.meta'
+    }
+    logger.info(f"直接拉取订阅 URL: {url}")
+    resp = requests.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+
+    text = resp.text
+    if not _is_yaml_response(text):
+        preview = text[:200].replace('\n', '\\n')
+        raise Exception(
+            "订阅 URL 未直接返回有效的 proxies YAML。"
+            f"响应预览: {preview}"
+        )
+
+    logger.info("订阅 URL 直接返回有效 YAML，跳过 Sub-Store 转换")
+    return text
+
+
+def _looks_like_sub_store_rendered_yaml_response(url):
+    """探测订阅 URL 是否已经是 Sub-Store 导出的最终 YAML。"""
+    headers = {
+        'User-Agent': 'clash.meta'
+    }
+    resp = requests.get(url, headers=headers, timeout=15)
+    resp.raise_for_status()
+
+    powered_by = resp.headers.get('x-powered-by', '')
+    if 'sub-store' not in powered_by.lower():
+        return False, None
+
+    text = resp.text
+    if not _is_yaml_response(text):
+        return False, None
+
+    logger.info("检测到订阅 URL 已是 Sub-Store 导出的 YAML 成品")
+    return True, text
+
+
 def _create_subscription(base, sub_id, url):
     """在 sub-store 中创建临时订阅。
 
@@ -109,6 +150,13 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
     Raises:
         Exception: 获取失败或返回的不是有效 YAML
     """
+    try:
+        is_rendered_yaml, rendered_yaml = _looks_like_sub_store_rendered_yaml_response(url)
+        if is_rendered_yaml and rendered_yaml:
+            return rendered_yaml
+    except Exception as e:
+        logger.warning(f"探测订阅 URL 是否为 Sub-Store 成品失败，继续走标准流程: {e}")
+
     base = _get_base_url()
     logger.info(f"Sub-Store base URL: {base}")
 
@@ -117,6 +165,7 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
     # 创建临时订阅
     _create_subscription(base, temp_name, url)
 
+    sub_store_error = None
     try:
         # 下载订阅（target 放在路径中，这是 Sub-Store 推荐的方式）
         download_url = f'{base}/download/{quote(temp_name, safe="")}/{target}'
@@ -136,9 +185,21 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
             )
 
         return text
+    except Exception as e:
+        sub_store_error = e
+        logger.warning(f"Sub-Store 获取订阅失败，尝试直接拉取原始订阅 URL: {e}")
     finally:
         # 用完即删，不在 Sub-Store 中残留订阅数据
         _delete_subscription(base, temp_name)
+
+    try:
+        return _fetch_direct_subscription_yaml(url)
+    except Exception as direct_error:
+        raise Exception(
+            "Sub-Store 获取失败，且直接拉取订阅也失败。"
+            f"Sub-Store 错误: {sub_store_error}; "
+            f"直接拉取错误: {direct_error}"
+        )
 
 
 _TEMP_NODE_SUB_NAME = '_cf_tmp_node_convert'

--- a/backend/utils/sub_store_client.py
+++ b/backend/utils/sub_store_client.py
@@ -135,9 +135,9 @@ def _delete_subscription(base, sub_id):
 
 
 def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
-    """调用 sub-store 获取订阅的 proxies YAML。
+    """获取订阅的 proxies YAML，并返回真实来源。
 
-    自动创建 sub-store 中的订阅（如果不存在）。
+    自动创建 sub-store 中的临时订阅（如果需要）。
 
     Args:
         sub_id: 订阅 ID，用作 sub-store 中的订阅 name
@@ -145,7 +145,11 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
         target: 目标格式，默认 ClashMeta
 
     Returns:
-        str: 目标格式的文本（ClashMeta 返回 YAML）
+        tuple[str, str]: (目标格式文本, 来源)
+            来源可能为:
+              - rendered_yaml: 订阅 URL 本身已是 Sub-Store 导出的最终 YAML
+              - sub_store: 通过 Sub-Store 下载/转换成功
+              - direct_url_fallback: Sub-Store 失败后直接拉取原始订阅 URL 成功
 
     Raises:
         Exception: 获取失败或返回的不是有效 YAML
@@ -153,7 +157,7 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
     try:
         is_rendered_yaml, rendered_yaml = _looks_like_sub_store_rendered_yaml_response(url)
         if is_rendered_yaml and rendered_yaml:
-            return rendered_yaml
+            return rendered_yaml, 'rendered_yaml'
     except Exception as e:
         logger.warning(f"探测订阅 URL 是否为 Sub-Store 成品失败，继续走标准流程: {e}")
 
@@ -184,7 +188,7 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
                 f"请检查 Sub-Store URL 配置是否正确。响应预览: {preview}"
             )
 
-        return text
+        return text, 'sub_store'
     except Exception as e:
         sub_store_error = e
         logger.warning(f"Sub-Store 获取订阅失败，尝试直接拉取原始订阅 URL: {e}")
@@ -193,7 +197,8 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
         _delete_subscription(base, temp_name)
 
     try:
-        return _fetch_direct_subscription_yaml(url)
+        text = _fetch_direct_subscription_yaml(url)
+        return text, 'direct_url_fallback'
     except Exception as direct_error:
         raise Exception(
             "Sub-Store 获取失败，且直接拉取订阅也失败。"


### PR DESCRIPTION
## 变更说明

这个 PR 主要修复两类问题：

1. 当订阅 URL 本身已经返回 Sub-Store 导出的最终 YAML（包含 `proxies:`）时，系统应直接复用该结果，而不是再次走 Sub-Store 转换流程。
2. 订阅获取成功后的日志应准确反映真实的数据来源，而不是统一记录为“通过 Sub-Store 获取”。

## 具体改动

- 新增对“订阅 URL 已经是 Sub-Store 成品 YAML”的探测逻辑
- 如果探测成立，直接使用该 YAML，不再重复创建临时订阅并调用 Sub-Store 下载接口
- 当 Sub-Store 获取失败时，增加直接拉取原始订阅 URL 的兜底逻辑
  - 前提是原始 URL 本身直接返回合法的 `proxies:` YAML
- `get_subscription_proxies_yaml(...)` 现在会返回真实来源信息
- 上层订阅与聚合相关逻辑根据真实来源分别记录日志，区分：
  - 直接复用已生成的 Sub-Store YAML
  - 确实经过 Sub-Store 转换
  - Sub-Store 失败后直接拉取原始订阅成功

## 修复原因

此前在某些场景下，订阅 URL 本身已经是 Sub-Store 导出的最终 YAML，系统实际上已经直接使用了这份结果，但后续日志仍然会记录为“成功通过 Sub-Store 获取并更新缓存”。

这会造成日志与真实执行路径不一致，排查问题时容易误判。

## 修复效果

修复后：

- 已经是 Sub-Store 成品的订阅链接不会再被重复转换
- 失败场景下多了一层直接拉取原始订阅的兜底能力
- 日志可以准确反映订阅内容到底来自哪条路径

这样在排查订阅问题时，会更容易判断真实行为。