### PR TITLE
Add 策略管理页面添加预览按钮

### DIFF
--- a/backend/routes/proxy_groups.py
+++ b/backend/routes/proxy_groups.py
@@ -1,9 +1,64 @@
 """策略组管理路由"""
+import re
+
 from flask import request, jsonify
 
 from backend.routes import proxy_groups_bp
 from backend.common.auth import require_auth
 from backend.common.config import get_config, save_config
+from backend.utils.subscription_cache import load_subscription_cache
+
+
+def _get_subscription_nodes(config_data, sub_id):
+    """Get nodes for a subscription from cache first, then imported nodes."""
+    nodes = []
+    cache = load_subscription_cache(sub_id)
+    if cache and isinstance(cache.get('nodes'), list):
+        nodes.extend(cache.get('nodes', []))
+
+    existing_names = {node.get('name') for node in nodes if node.get('name')}
+    for node in config_data.get('nodes', []):
+        if node.get('subscription_id') == sub_id and node.get('enabled', True):
+            if node.get('name') not in existing_names:
+                nodes.append(node)
+                existing_names.add(node.get('name'))
+
+    return nodes
+
+
+def _get_manual_nodes(config_data, node_ids):
+    """Resolve manually selected node ids to node objects."""
+    result = []
+    for node_id in node_ids:
+        if node_id in ['DIRECT', 'REJECT']:
+            result.append({
+                'id': node_id,
+                'name': node_id,
+                'type': 'builtin',
+                'source_type': 'manual'
+            })
+            continue
+
+        node = next(
+            (n for n in config_data.get('nodes', []) if n.get('id') == node_id and n.get('enabled', True)),
+            None
+        )
+        if node:
+            result.append(node)
+
+    return result
+
+
+def _add_source_meta(nodes, source_type, source_id, source_name):
+    """Return shallow node copies with display source metadata."""
+    enriched = []
+    for node in nodes:
+        item = dict(node)
+        item['source_type'] = source_type
+        item['source_id'] = source_id
+        item['source_name'] = source_name
+        enriched.append(item)
+    return enriched
 
 
 @proxy_groups_bp.route('', methods=['GET', 'POST'])
@@ -55,6 +110,91 @@ def handle_proxy_group(group_id):
                 save_config()
                 return jsonify({'success': True, 'data': group_data})
         return jsonify({'success': False, 'message': 'Group not found'}), 404
+
+
+@proxy_groups_bp.route('/preview-regex', methods=['POST'])
+@require_auth
+def preview_proxy_group_regex():
+    """Preview nodes matched by a proxy-group regex without saving config."""
+    try:
+        config_data = get_config()
+        payload = request.get_json() or {}
+        source = payload.get('source')
+        regex_text = (payload.get('regex') or '').strip()
+
+        if source not in ['subscription', 'aggregation']:
+            return jsonify({'success': False, 'message': 'Invalid preview source'}), 400
+
+        if not regex_text:
+            return jsonify({'success': False, 'message': '请输入正则表达式'}), 400
+
+        try:
+            regex = re.compile(regex_text)
+        except re.error as exc:
+            return jsonify({'success': False, 'message': f'正则表达式无效: {exc}'}), 400
+
+        candidates = []
+
+        if source == 'subscription':
+            subscription_ids = payload.get('subscriptions') or []
+            subscriptions = config_data.get('subscriptions', [])
+            for sub_id in subscription_ids:
+                sub = next((s for s in subscriptions if s.get('id') == sub_id and s.get('enabled', True)), None)
+                if not sub:
+                    continue
+                nodes = _get_subscription_nodes(config_data, sub_id)
+                candidates.extend(_add_source_meta(nodes, 'subscription', sub_id, sub.get('name', sub_id)))
+
+        if source == 'aggregation':
+            aggregation_ids = payload.get('aggregations') or []
+            aggregations = config_data.get('subscription_aggregations', [])
+            subscriptions = config_data.get('subscriptions', [])
+
+            for agg_id in aggregation_ids:
+                agg = next((a for a in aggregations if a.get('id') == agg_id and a.get('enabled', True)), None)
+                if not agg:
+                    continue
+
+                agg_name = agg.get('name', agg_id)
+                for sub_id in agg.get('subscriptions', []):
+                    sub = next((s for s in subscriptions if s.get('id') == sub_id and s.get('enabled', True)), None)
+                    if not sub:
+                        continue
+                    nodes = _get_subscription_nodes(config_data, sub_id)
+                    candidates.extend(_add_source_meta(nodes, 'aggregation', agg_id, agg_name))
+
+                manual_nodes = _get_manual_nodes(config_data, agg.get('nodes', []))
+                candidates.extend(_add_source_meta(manual_nodes, 'aggregation', agg_id, agg_name))
+
+        matched = []
+        seen_names = set()
+        for node in candidates:
+            name = node.get('name', '')
+            if not name or not regex.search(name):
+                continue
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            matched.append({
+                'id': node.get('id', name),
+                'name': name,
+                'type': node.get('type') or node.get('protocol') or 'unknown',
+                'subscription_id': node.get('subscription_id'),
+                'subscription_name': node.get('subscription_name'),
+                'source_type': node.get('source_type'),
+                'source_id': node.get('source_id'),
+                'source_name': node.get('source_name')
+            })
+
+        return jsonify({
+            'success': True,
+            'count': len(matched),
+            'total_candidates': len(candidates),
+            'nodes': matched
+        })
+
+    except Exception as exc:
+        return jsonify({'success': False, 'message': str(exc)}), 500
 
 
 @proxy_groups_bp.route('/reorder', methods=['POST'])

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -77,7 +77,8 @@ export const proxyGroupApi = {
   getAll: () => api.get('/proxy-groups'),
   create: (data: any) => api.post('/proxy-groups', data),
   update: (id: string, data: any) => api.put(`/proxy-groups/${id}`, data),
-  delete: (id: string) => api.delete(`/proxy-groups/${id}`)
+  delete: (id: string) => api.delete(`/proxy-groups/${id}`),
+  previewRegex: (data: any) => api.post('/proxy-groups/preview-regex', data)
 }
 
 // 获取服务域名配置（优先使用配置的域名，否则使用当前页面的 base URL）

--- a/frontend/src/views/ProxyGroups.vue
+++ b/frontend/src/views/ProxyGroups.vue
@@ -97,7 +97,18 @@
 
               <div v-if="group.aggregation_regex" class="card-section">
                 <div class="section-label"><el-icon><Filter /></el-icon>聚合正则</div>
-                <div class="section-content code-box small">{{ group.aggregation_regex }}</div>
+                <div class="regex-display-row">
+                  <div class="section-content code-box small">{{ group.aggregation_regex }}</div>
+                  <el-button
+                    class="preview-btn compact-preview"
+                    size="small"
+                    :loading="regexPreviewLoading && regexPreviewSource === 'aggregation'"
+                    @click.stop="previewSavedRegexMatches(group, 'aggregation')"
+                  >
+                    <el-icon><View /></el-icon>
+                    预览
+                  </el-button>
+                </div>
               </div>
 
               <div v-if="hasSubscriptions(group) && !hasAggregations(group)" class="card-section">
@@ -105,9 +116,20 @@
                 <div class="section-content">{{ getSubscriptionDisplay(group) }}</div>
               </div>
 
-              <div v-if="group.regex && hasSubscriptions(group) && !hasAggregations(group)" class="card-section">
+              <div v-if="group.regex && hasSubscriptions(group)" class="card-section">
                 <div class="section-label"><el-icon><Filter /></el-icon>订阅正则</div>
-                <div class="section-content code-box small">{{ group.regex }}</div>
+                <div class="regex-display-row">
+                  <div class="section-content code-box small">{{ group.regex }}</div>
+                  <el-button
+                    class="preview-btn compact-preview"
+                    size="small"
+                    :loading="regexPreviewLoading && regexPreviewSource === 'subscription'"
+                    @click.stop="previewSavedRegexMatches(group, 'subscription')"
+                  >
+                    <el-icon><View /></el-icon>
+                    预览
+                  </el-button>
+                </div>
               </div>
 
               <div v-if="hasManualNodes(group) && !hasAggregations(group)" class="card-section">
@@ -236,11 +258,21 @@
             </el-select>
           </el-form-item>
           <el-form-item label="正则过滤" v-if="form.subscriptions && form.subscriptions.length > 0">
-            <el-input
-              v-model="form.regex"
-              clearable
-              placeholder="输入正则表达式（可选，过滤订阅节点名称）"
-            />
+            <div class="regex-preview-row">
+              <el-input
+                v-model="form.regex"
+                clearable
+                placeholder="输入正则表达式（可选，过滤订阅节点名称）"
+              />
+              <el-button
+                class="preview-btn"
+                :loading="regexPreviewLoading && regexPreviewSource === 'subscription'"
+                @click="previewRegexMatches('subscription')"
+              >
+                <el-icon><View /></el-icon>
+                预览
+              </el-button>
+            </div>
           </el-form-item>
         </template>
 
@@ -293,11 +325,21 @@
         </el-form-item>
         <!-- 聚合正则过滤 -->
         <el-form-item label="正则过滤" v-if="enabledSources.includes('aggregation') && form.aggregations && form.aggregations.length > 0">
-          <el-input
-            v-model="form.aggregation_regex"
-            clearable
-            placeholder="输入正则表达式（可选，过滤聚合节点名称）"
-          />
+          <div class="regex-preview-row">
+            <el-input
+              v-model="form.aggregation_regex"
+              clearable
+              placeholder="输入正则表达式（可选，过滤聚合节点名称）"
+            />
+            <el-button
+              class="preview-btn"
+              :loading="regexPreviewLoading && regexPreviewSource === 'aggregation'"
+              @click="previewRegexMatches('aggregation')"
+            >
+              <el-icon><View /></el-icon>
+              预览
+            </el-button>
+          </div>
           <div style="margin-top: 8px; color: #909399; font-size: 12px">
             此正则过滤将应用于聚合中的节点，不使用聚合自带的正则过滤器
           </div>
@@ -385,6 +427,46 @@
         <el-button type="primary" @click="saveGroup">保存</el-button>
       </template>
     </el-dialog>
+
+    <el-dialog
+      v-model="regexPreviewVisible"
+      class="groups-helper-dialog"
+      :title="regexPreviewTitle"
+      width="680px"
+      :close-on-click-modal="false"
+    >
+      <div v-loading="regexPreviewLoading">
+        <el-alert
+          v-if="regexPreviewResult"
+          :title="`匹配 ${regexPreviewNodes.length} 个节点，候选 ${regexPreviewResult.total_candidates} 个`"
+          type="success"
+          :closable="false"
+          class="dialog-alert"
+        />
+        <div v-if="regexPreviewNodes.length > 0" class="preview-section">
+          <el-scrollbar max-height="420px">
+            <div class="node-list">
+              <div v-for="node in regexPreviewNodes" :key="`${node.source_id || ''}-${node.name}`" class="node-item preview-node-item">
+                <div class="preview-node-main">
+                  <el-icon><Connection /></el-icon>
+                  <span class="preview-node-name">{{ node.name }}</span>
+                </div>
+                <div class="preview-node-meta">
+                  <el-tag size="small" type="info">{{ getPreviewSourceLabel(node) }}</el-tag>
+                  <el-tag size="small" type="success">{{ (node.type || 'unknown').toUpperCase() }}</el-tag>
+                </div>
+              </div>
+            </div>
+          </el-scrollbar>
+        </div>
+        <div v-if="regexPreviewNodes.length === 0 && !regexPreviewLoading" class="empty-helper">
+          当前正则没有匹配到节点
+        </div>
+      </div>
+      <template #footer>
+        <el-button @click="regexPreviewVisible = false">关闭</el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 <script setup lang="ts">
@@ -404,6 +486,12 @@ const savingStatus = ref<Record<string, boolean>>({})
 const dialogVisible = ref(false)
 const isEdit = ref(false)
 const enabledSources = ref<string[]>([])
+const regexPreviewVisible = ref(false)
+const regexPreviewLoading = ref(false)
+const regexPreviewSource = ref<'subscription' | 'aggregation' | ''>('')
+const regexPreviewResult = ref<{ total_candidates: number } | null>(null)
+const regexPreviewNodes = ref<any[]>([])
+const regexPreviewTitle = ref('正则匹配预览')
 
 const groupsContainer = ref<HTMLElement | null>(null)
 const orderedProxiesRef = ref<HTMLElement | null>(null)
@@ -925,6 +1013,100 @@ const getSourceSummary = (group: ProxyGroup) => {
   }
 
   return sources.length > 0 ? sources.join(' + ') : '无来源'
+}
+
+const getPreviewSourceLabel = (node: any) => {
+  if (node.source_type === 'subscription') {
+    return node.source_name ? `订阅: ${node.source_name}` : '订阅'
+  }
+  if (node.source_type === 'aggregation') {
+    return node.source_name ? `聚合: ${node.source_name}` : '聚合'
+  }
+  return node.subscription_name || '节点'
+}
+
+const previewRegexMatches = async (source: 'subscription' | 'aggregation') => {
+  const regex = source === 'subscription' ? form.value.regex : form.value.aggregation_regex
+  const sourceIds = source === 'subscription' ? (form.value.subscriptions || []) : (form.value.aggregations || [])
+
+  if (!sourceIds.length) {
+    ElMessage.warning(source === 'subscription' ? '请先选择订阅' : '请先选择聚合')
+    return
+  }
+
+  if (!regex || !regex.trim()) {
+    ElMessage.warning('请先输入正则表达式')
+    return
+  }
+
+  regexPreviewVisible.value = true
+  regexPreviewLoading.value = true
+  regexPreviewSource.value = source
+  regexPreviewResult.value = null
+  regexPreviewNodes.value = []
+  regexPreviewTitle.value = source === 'subscription' ? '订阅正则匹配预览' : '聚合正则匹配预览'
+
+  try {
+    const payload = source === 'subscription'
+      ? { source, regex, subscriptions: sourceIds }
+      : { source, regex, aggregations: sourceIds }
+    const { data } = await proxyGroupApi.previewRegex(payload)
+
+    if (data.success) {
+      regexPreviewResult.value = {
+        total_candidates: data.total_candidates || 0
+      }
+      regexPreviewNodes.value = data.nodes || []
+    } else {
+      ElMessage.error(data.message || '预览失败')
+    }
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || '预览失败')
+  } finally {
+    regexPreviewLoading.value = false
+  }
+}
+
+const previewSavedRegexMatches = async (group: ProxyGroup, source: 'subscription' | 'aggregation') => {
+  const regex = source === 'subscription' ? group.regex : group.aggregation_regex
+  const sourceIds = source === 'subscription' ? (group.subscriptions || []) : (group.aggregations || [])
+
+  if (!sourceIds.length) {
+    ElMessage.warning(source === 'subscription' ? '该策略组没有订阅来源' : '该策略组没有聚合来源')
+    return
+  }
+
+  if (!regex || !regex.trim()) {
+    ElMessage.warning('该策略组没有配置正则表达式')
+    return
+  }
+
+  regexPreviewVisible.value = true
+  regexPreviewLoading.value = true
+  regexPreviewSource.value = source
+  regexPreviewResult.value = null
+  regexPreviewNodes.value = []
+  regexPreviewTitle.value = `${group.name} - ${source === 'subscription' ? '订阅正则匹配预览' : '聚合正则匹配预览'}`
+
+  try {
+    const payload = source === 'subscription'
+      ? { source, regex, subscriptions: sourceIds }
+      : { source, regex, aggregations: sourceIds }
+    const { data } = await proxyGroupApi.previewRegex(payload)
+
+    if (data.success) {
+      regexPreviewResult.value = {
+        total_candidates: data.total_candidates || 0
+      }
+      regexPreviewNodes.value = data.nodes || []
+    } else {
+      ElMessage.error(data.message || '预览失败')
+    }
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || '预览失败')
+  } finally {
+    regexPreviewLoading.value = false
+  }
 }
 
 const loadProxyGroups = async () => {
@@ -1996,6 +2178,34 @@ onUnmounted(() => {
   color: #9099bf;
 }
 
+.regex-preview-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.regex-display-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+}
+
+.preview-btn.el-button {
+  border-radius: var(--group-radius-md, 16px);
+  border: 1px solid rgba(107, 115, 255, 0.25);
+  background: rgba(107, 115, 255, 0.1);
+  color: #4e5eff;
+  font-weight: 600;
+}
+
+.preview-btn.compact-preview {
+  flex-shrink: 0;
+  min-width: 78px;
+}
+
 .dialog-footer {
   display: flex;
   justify-content: flex-end;
@@ -2092,6 +2302,36 @@ onUnmounted(() => {
   border-bottom: none;
 }
 
+.preview-section {
+  margin-top: 14px;
+}
+
+.preview-node-item {
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.preview-node-main {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #35405f;
+}
+
+.preview-node-name {
+  word-break: break-all;
+}
+
+.preview-node-meta {
+  flex-shrink: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 @media (max-width: 1024px) {
   .proxy-groups-page {
     padding: 24px;
@@ -2135,6 +2375,22 @@ onUnmounted(() => {
 
   .card-btn.el-button {
     width: 100%;
+  }
+
+  .regex-preview-row {
+    grid-template-columns: 1fr;
+  }
+
+  .regex-display-row {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-node-item {
+    flex-direction: column;
+  }
+
+  .preview-node-meta {
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
现在策略管理的编辑/新增弹窗里，订阅正则和聚合正则输入框右侧都有“预览”按钮，可以按当前输入的正则查看匹配节点、候选总数和来源。
后端预览接口是只读的，会读取订阅本地缓存和已导入节点，不会保存配置，也不会主动刷新订阅，避免点预览带来副作用。