### PR TITLE
fix: 修复 Surge anytls 导出、地区策略组过滤及 Sub-Store 并发撞名

### DIFF
--- a/backend/converters/surge.py
+++ b/backend/converters/surge.py
@@ -695,6 +695,25 @@ def convert_node_to_surge(node: Dict[str, Any]) -> tuple:
 
         return ', '.join(parts), None
 
+    elif node_type == 'anytls':
+        # AnyTLS: name = anytls, server, port, password=pwd, ...
+        password = params.get('password', '')
+        sni = params.get('sni', '')
+        skip_cert = params.get('skip-cert-verify', False)
+
+        parts = [f"{name} = anytls", server, str(port), f"password={password}"]
+
+        if sni:
+            parts.append(f"sni={sni}")
+        if skip_cert:
+            parts.append("skip-cert-verify=true")
+
+        # 添加 UDP 支持
+        if params.get('udp') or params.get('udp-relay'):
+            parts.append('udp-relay=true')
+
+        return ', '.join(parts), None
+
     elif node_type == 'wireguard' or node_type == 'wg':
         # WireGuard: name = wireguard, section-name = xxx
         # 需要生成两部分：1) 引用行 2) WireGuard section配置
@@ -1005,9 +1024,15 @@ def convert_proxy_group_to_surge(group: Dict[str, Any], config_data: Dict[str, A
         return None
 
     # 添加 policy-path 参数
+    # 若策略组配置了 regex（地区过滤），转换为 Surge 的 policy-regex-filter，
+    # 使各地区策略组在同一订阅源下按节点名正则过滤，与 Mihomo 的 filter 行为一致
     if policy_paths:
+        regex_filter = (group.get('regex') or '').strip()
         for policy_path in policy_paths:
-            group_line += f", policy-path = {policy_path}, update-interval = 86400"
+            group_line += f", policy-path = {policy_path}"
+            if regex_filter:
+                group_line += f", policy-regex-filter = {regex_filter}"
+            group_line += ", update-interval = 86400"
 
     logger.debug(f"Group '{name}' final line: {group_line}")
     return group_line

--- a/backend/utils/sub_store_client.py
+++ b/backend/utils/sub_store_client.py
@@ -10,6 +10,7 @@ Sub-Store API 参考:
   - GET  /download/:name/:target — 下载订阅 (target 放在路径中)
 """
 import os
+import uuid
 from urllib.parse import quote
 
 import requests
@@ -164,8 +165,9 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
     base = _get_base_url()
     logger.info(f"Sub-Store base URL: {base}")
 
-    # 使用带前缀的临时名称，避免和 Sub-Store 中已有订阅冲突
-    temp_name = f"_cf_tmp_{sub_id}"
+    # 使用带前缀和随机后缀的临时名称，避免和 Sub-Store 中已有订阅冲突，
+    # 也避免并发请求同一订阅时临时订阅撞名导致 500
+    temp_name = f"_cf_tmp_{sub_id}_{uuid.uuid4().hex[:8]}"
     # 创建临时订阅
     _create_subscription(base, temp_name, url)
 
@@ -207,9 +209,6 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
         )
 
 
-_TEMP_NODE_SUB_NAME = '_cf_tmp_node_convert'
-
-
 def convert_proxy_string(proxy_string, target='ClashMeta'):
     """通过 Sub-Store 将单个节点字符串（URI / YAML）转换为 mihomo 格式的 proxy dict。
 
@@ -224,11 +223,13 @@ def convert_proxy_string(proxy_string, target='ClashMeta'):
     logger.info(f"节点转换: proxy_string={proxy_string[:80]}...")
 
     # 创建临时订阅（需要一个名字才能调用 download）
-    _create_subscription(base, _TEMP_NODE_SUB_NAME, 'https://example.com')
+    # 随机后缀避免并发节点转换时撞名导致 500
+    temp_name = f"_cf_tmp_node_convert_{uuid.uuid4().hex[:8]}"
+    _create_subscription(base, temp_name, 'https://example.com')
 
     try:
         # 通过 content 参数直接传入节点内容，覆盖订阅 URL
-        download_url = f'{base}/download/{quote(_TEMP_NODE_SUB_NAME, safe="")}/{target}'
+        download_url = f'{base}/download/{quote(temp_name, safe="")}/{target}'
         logger.info(f"节点转换下载: {download_url}")
         resp = requests.get(
             download_url,
@@ -256,7 +257,7 @@ def convert_proxy_string(proxy_string, target='ClashMeta'):
         logger.warning(f"Sub-Store 节点转换失败: {e}")
         return None
     finally:
-        _delete_subscription(base, _TEMP_NODE_SUB_NAME)
+        _delete_subscription(base, temp_name)
 
 
 def parse_proxies_from_yaml(yaml_text):


### PR DESCRIPTION
修复三个 issue。

## #22 — Surge policy-path 在 AnyTLS 节点下返回空内容
`convert_node_to_surge` 此前没有处理 `anytls`，节点被直接跳过，导致订阅仅含 anytls 节点时 policy-path 返回空。补上 anytls 分支（password / sni / skip-cert-verify / udp-relay）。

## #21 — Surge 地区策略组缺少 policy-regex-filter
地区策略组只拼了 `policy-path`，丢掉了策略组的 `regex`，导致各地区组实际引用同一批节点。现把 `regex` 转换为 `policy-regex-filter`，与 Mihomo 的 `filter` 行为一致。

## #23 — Sub-Store 临时订阅名固定，并发撞名导致 500
临时订阅名固定，多个策略组并发拉取同一订阅会创建同名资源，Sub-Store 返回 500。给 `get_subscription_proxies_yaml` 和 `convert_proxy_string` 的临时订阅名加 uuid 随机后缀。

## 验证
项目无测试套件，已直接调用受影响函数做断言验证：anytls 节点正常转换、policy-path 文本非空、地区组带 policy-regex-filter（且无 regex 时不输出）、临时订阅名带随机后缀。

Closes #21
Closes #22
Closes #23