### PR TITLE
UI fixes

### DIFF
--- a/frontend/src/components/AgentStatus.vue
+++ b/frontend/src/components/AgentStatus.vue
@@ -85,7 +85,7 @@
 
           <!-- 3. 网络速率 -->
           <div class="metric-item">
-            <div class="metric-header">
+            <div class="metric-header metric-header-network">
               <span class="metric-name">网络速率</span>
               <span class="metric-value metric-network">
                 <span class="upload">↑{{ formatSpeed(agent.system_metrics.network?.speed_sent) }}</span>
@@ -105,7 +105,7 @@
 
           <!-- 4. 流量统计 -->
           <div class="metric-item" v-if="trafficStats[agent.id]">
-            <div class="metric-header">
+            <div class="metric-header metric-header-network">
               <span class="metric-name">流量统计</span>
               <span class="metric-value metric-network">
                 <span class="upload">↑{{ formatBytes(trafficStats[agent.id].total?.bytes_sent) }}</span>
@@ -906,10 +906,37 @@ onUnmounted(() => {
 @media (max-width: 768px) {
   .agent-metrics-section {
     grid-template-columns: repeat(2, 1fr);
+    gap: 16px 12px;
   }
 
   .agent-row {
     padding: 20px;
+  }
+
+  .metric-header {
+    gap: 4px 8px;
+  }
+
+  .metric-header-network {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: flex-start;
+    min-height: 44px;
+  }
+
+  .metric-header-network .metric-value.metric-network {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 2px 8px;
+    line-height: 16px;
+    min-height: 0;
+    width: 100%;
+  }
+
+  .metric-header-network .upload,
+  .metric-header-network .download {
+    white-space: nowrap;
   }
 }
 </style>

--- a/frontend/src/components/AgentStatus.vue
+++ b/frontend/src/components/AgentStatus.vue
@@ -266,6 +266,12 @@ const loadAllMetricsHistory = async () => {
   }
 }
 
+const chartTooltipBase = {
+  appendToBody: true,
+  confine: false,
+  extraCssText: 'z-index: 9999; pointer-events: none;'
+}
+
 // CPU 图表配置
 const getCpuChartOption = (agentId: string) => {
   const history = metricsHistory.value[agentId] || []
@@ -276,6 +282,7 @@ const getCpuChartOption = (agentId: string) => {
     xAxis: { type: 'category', show: false, boundaryGap: false },
     yAxis: { type: 'value', show: false, max: 100 },
     tooltip: {
+      ...chartTooltipBase,
       trigger: 'axis',
       formatter: '{c}%',
       axisPointer: { type: 'line' }
@@ -310,6 +317,7 @@ const getMemoryChartOption = (agentId: string) => {
     xAxis: { type: 'category', show: false, boundaryGap: false },
     yAxis: { type: 'value', show: false, max: 100 },
     tooltip: {
+      ...chartTooltipBase,
       trigger: 'axis',
       formatter: '{c}%',
       axisPointer: { type: 'line' }
@@ -344,6 +352,7 @@ const getDiskChartOption = (agentId: string) => {
     xAxis: { type: 'category', show: false, boundaryGap: false },
     yAxis: { type: 'value', show: false, max: 100 },
     tooltip: {
+      ...chartTooltipBase,
       trigger: 'axis',
       formatter: '{c}%',
       axisPointer: { type: 'line' }
@@ -379,6 +388,7 @@ const getNetworkChartOption = (agentId: string) => {
     xAxis: { type: 'category', show: false, boundaryGap: false },
     yAxis: { type: 'value', show: false },
     tooltip: {
+      ...chartTooltipBase,
       trigger: 'axis',
       formatter: (params: any) => `↑${params[0].value} KB/s<br/>↓${params[1].value} KB/s`,
       axisPointer: { type: 'line' }
@@ -421,7 +431,7 @@ const getTrafficTrendChartOption = (agentId: string) => {
   const todayDownload = stats?.today?.bytes_recv_delta || 0
 
   return {
-    grid: { left: 35, right: 10, top: 15, bottom: 20 },
+    grid: { left: 8, right: 10, top: 15, bottom: 20, containLabel: true },
     xAxis: {
       type: 'category',
       data: timestamps,
@@ -433,11 +443,13 @@ const getTrafficTrendChartOption = (agentId: string) => {
       axisLabel: {
         fontSize: 10,
         color: '#666',
+        margin: 8,
         formatter: (value: number) => `${value} GB`
       },
       splitLine: { lineStyle: { color: '#f0f0f0' } }
     },
     tooltip: {
+      ...chartTooltipBase,
       trigger: 'axis',
       formatter: (params: any) => {
         const time = params[0].axisValue
@@ -579,7 +591,7 @@ onUnmounted(() => {
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .agent-row::before {
@@ -592,6 +604,7 @@ onUnmounted(() => {
   background: linear-gradient(180deg, #6b7dff 0%, #5b6dff 100%);
   opacity: 0;
   transition: opacity 0.3s;
+  border-radius: 20px 0 0 20px;
 }
 
 .agent-row:hover {
@@ -801,7 +814,7 @@ onUnmounted(() => {
   background: rgba(107, 115, 255, 0.02);
   border-radius: 8px;
   border: 1px solid rgba(107, 115, 255, 0.06);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .no-data {

--- a/frontend/src/components/AgentStatus.vue
+++ b/frontend/src/components/AgentStatus.vue
@@ -272,6 +272,14 @@ const chartTooltipBase = {
   extraCssText: 'z-index: 9999; pointer-events: none;'
 }
 
+const formatTrafficAxisLabel = (value: number) => {
+  if (value >= 1024) {
+    const tb = value / 1024
+    return `${tb >= 10 ? tb.toFixed(0) : tb.toFixed(1)} TB`
+  }
+  return `${value.toFixed(0)} GB`
+}
+
 // CPU 图表配置
 const getCpuChartOption = (agentId: string) => {
   const history = metricsHistory.value[agentId] || []
@@ -431,7 +439,7 @@ const getTrafficTrendChartOption = (agentId: string) => {
   const todayDownload = stats?.today?.bytes_recv_delta || 0
 
   return {
-    grid: { left: 8, right: 10, top: 15, bottom: 20, containLabel: true },
+    grid: { left: 8, right: 10, top: 8, bottom: 0, containLabel: true },
     xAxis: {
       type: 'category',
       data: timestamps,
@@ -440,11 +448,13 @@ const getTrafficTrendChartOption = (agentId: string) => {
     },
     yAxis: {
       type: 'value',
+      min: 0,
+      splitNumber: 4,
       axisLabel: {
         fontSize: 10,
         color: '#666',
         margin: 8,
-        formatter: (value: number) => `${value} GB`
+        formatter: formatTrafficAxisLabel
       },
       splitLine: { lineStyle: { color: '#f0f0f0' } }
     },

--- a/frontend/src/components/AgentStatus.vue
+++ b/frontend/src/components/AgentStatus.vue
@@ -771,10 +771,13 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 4px;
+  min-height: 24px;
+  margin-bottom: 0;
+  min-width: 0;
 }
 
 .metric-name {
+  flex: 0 0 auto;
   font-size: 12px;
   font-weight: 700;
   color: #7d88af;
@@ -783,16 +786,22 @@ onUnmounted(() => {
 }
 
 .metric-value {
+  flex: 0 1 auto;
   font-size: 14px;
   font-weight: 700;
   font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+  line-height: 20px;
   padding: 2px 8px;
   border-radius: 6px;
+  white-space: nowrap;
 }
 
 .metric-value.metric-network {
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: 8px;
+  min-height: 24px;
   padding: 0;
   font-size: 11px;
 }


### PR DESCRIPTION

<img width="3696" height="796" alt="QQ_1781765976359" src="https://github.com/user-attachments/assets/cd4122ef-e7d3-4f95-86c5-5d1560b9707d" />

## 这几次主要修的是 Agent 数据统计卡片里的图表 UI 问题，集中在 [AgentStatus.vue](https://github.com/thsrite/configflow/tree/main/frontend/src/components/AgentStatus.vue)。

### 修复图表 tooltip 被遮挡
鼠标悬停图表时，浮动提示会被卡片或图表容器裁掉。
处理方式：让 ECharts tooltip 挂到 body 上，并提高层级，同时放开相关容器的 overflow。

###  修复流量统计左侧刻度显示不全
流量图 y 轴出现 30 GB、1200 GB 这种标签时，左侧数字会被裁掉。
处理方式：启用 grid.containLabel，让图表自动给坐标轴文字预留空间。

### 调整流量图上下间距
流量统计图看起来太靠上、不平衡
处理方式：缩小顶部边距，让图表底部更贴近容器，只保留必要的标签空间。

### 对齐每个指标的标题和图表框
CPU、内存、网络速率、流量统计、磁盘这几个图表的标题行高度不一致，导致下面图表框顶边不在一条线上。
处理方式：统一标题行高度，规范数值 pill 和文字数值的行高/对齐方式。

### 修复手机版文字重叠
手机两列布局下，“网络速率”和“流量统计”的标题和值太长，挤到一起甚至叠到旁边。
处理方式：只在移动端让这两个长标题项上下排列，上传/下载数值在自己的区域内换行，桌面端保持原布局。