### PR TITLE
fix: mosdns 代理分支终止逻辑、补 TCP 53 监听、监控计数器下溢保护

### DIFF
--- a/backend/agents/go-agent/metrics.go
+++ b/backend/agents/go-agent/metrics.go
@@ -231,11 +231,15 @@ func (m *MetricsCollector) collectNetwork() (NetworkMetrics, error) {
 		if elapsed > 0 {
 			if last, exists := m.lastNetStats["all"]; exists {
 				// 计算速度 = (当前值 - 上次值) / 时间差
-				bytesSentDiff := current.BytesSent - last.BytesSent
-				bytesRecvDiff := current.BytesRecv - last.BytesRecv
+				// 计数器重置（容器/接口重启）时当前值小于上次值，
+				// uint64 相减会下溢成极大值，此时速度置零并重建基线
+				if current.BytesSent >= last.BytesSent && current.BytesRecv >= last.BytesRecv {
+					bytesSentDiff := current.BytesSent - last.BytesSent
+					bytesRecvDiff := current.BytesRecv - last.BytesRecv
 
-				speedSent = uint64(float64(bytesSentDiff) / elapsed)
-				speedRecv = uint64(float64(bytesRecvDiff) / elapsed)
+					speedSent = uint64(float64(bytesSentDiff) / elapsed)
+					speedRecv = uint64(float64(bytesRecvDiff) / elapsed)
+				}
 			}
 		}
 	}

--- a/backend/converters/mosdns.py
+++ b/backend/converters/mosdns.py
@@ -852,6 +852,20 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
         }
     })
 
+    # 9.1 代理 DNS 执行序列
+    # fallback 插件通过 exec 执行后不会终止主序列，会导致主序列继续
+    # 往下匹配（甚至在尾部默认转发处重复查询一次）
+    # 包装一层 sequence：执行 $proxy_dns 后 accept 终止，
+    # 代理规则统一通过 goto 跳入本序列
+    plugins.append({
+        'tag': 'proxy_dns_seq',
+        'type': 'sequence',
+        'args': [
+            {'exec': '$proxy_dns'},
+            {'exec': 'accept'}
+        ]
+    })
+
     # 10. 国内 DNS 序列插件
     # 先查缓存，未命中再转发到国内 DNS
     china_dns_args: List[Dict[str, Any]] = []
@@ -1043,10 +1057,10 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
                     'exec': 'goto china_dns'
                 })
             elif item_id in proxy_ruleset_ids:
-                # 代理规则集，使用国外 DNS
+                # 代理规则集，使用国外 DNS（goto 跳转后终止主序列）
                 rule_match_entries.append({
                     'matches': [match_expr],
-                    'exec': '$proxy_dns'
+                    'exec': 'goto proxy_dns_seq'
                 })
         elif item_type == 'rule':
             # 单条规则
@@ -1080,10 +1094,10 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
                     'exec': 'goto china_dns'
                 })
             elif item_id in proxy_rule_ids:
-                # 代理规则，使用国外 DNS
+                # 代理规则，使用国外 DNS（goto 跳转后终止主序列）
                 rule_match_entries.append({
                     'matches': [match_expr],
-                    'exec': '$proxy_dns'
+                    'exec': 'goto proxy_dns_seq'
                 })
 
     # 根据配置决定自定义 match 的插入位置
@@ -1106,7 +1120,7 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
         sequence.append({'exec': 'goto china_dns'})
     else:
         # 使用国外 DNS（带 fallback）
-        sequence.append({'exec': '$proxy_dns'})
+        sequence.append({'exec': 'goto proxy_dns_seq'})
 
     plugins.append({
         'tag': 'sequence_main',
@@ -1118,11 +1132,18 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
 
     # 添加服务器配置
     # 使用简化的服务器配置格式
-    # type: udp_server 表示 UDP 服务器（也会自动监听 TCP）
+    # udp_server 仅监听 UDP，TCP 需单独配置 tcp_server（截断回退场景需要）
     # args.entry: 入口插件标签
     # args.listen: 监听地址和端口
     plugins.append({
         'type': 'udp_server',
+        'args': {
+            'entry': 'sequence_main',
+            'listen': ':53'
+        }
+    })
+    plugins.append({
+        'type': 'tcp_server',
         'args': {
             'entry': 'sequence_main',
             'listen': ':53'


### PR DESCRIPTION
## 变更摘要
家庭网络分析（Bosun #410）落地的三项代码修复：

1. **mosdns 代理域名双重查询**：`proxy_dns` 是 fallback 插件，`exec` 执行后不终止主序列，导致代理规则命中后继续往下匹配、尾部默认转发再查一次。新增 `proxy_dns_seq` 包装序列（`$proxy_dns` + `accept`），代理规则与默认转发改用 `goto` 跳入。
2. **mosdns 缺 TCP 53**：`udp_server` 不会自动监听 TCP（原注释有误），补 `tcp_server`（截断回退场景需要）。
3. **go-agent 速率下溢**：网络计数器重置时 uint64 相减下溢产生 6.15e17 B/s 假峰值，相减前判断当前值不小于上次值。

## 验证证据
- 生成器断言脚本 5/5 通过（proxy_dns_seq 存在且以 accept 结束 / 主序列无裸 $proxy_dns / 默认转发 goto / udp+tcp server 参数一致 / forward_local 回归）
- 线上同款修补实测：TCP 53 从 connection refused → 51ms 正常应答；代理域名解析 71–90ms → 26–58ms（google/youtube 接近直查 mihomo 的 22–25ms）；国内域名回归正常
- go-agent 修复为纯逻辑保护，本机无 go 工具链未编译，改动为单个 if 包裹（CI/部署构建时验证）