### PR TITLE
fix: push-config 成功后自动重启服务加载新配置

### DIFF
--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -714,6 +714,19 @@ def push_config_to_agent(agent_id):
                 if ruleset_downloads:
                     result['ruleset_downloads'] = ruleset_downloads
             save_config()
+
+            # 推送成功后自动重启服务加载新配置
+            # Agent 的 /api/config/update 只落盘文件，不重启进程；
+            # 不重启的话新配置不会生效。可通过请求体 {"restart": false} 关闭
+            if data.get('restart', True):
+                logger.info(f"配置推送成功，触发服务重启: {agent_id}")
+                restart_result = agent_manager.restart_agent_service(agent_id)
+                result['restart'] = restart_result
+                if not restart_result.get('success'):
+                    logger.warning(
+                        f"配置已推送但服务重启失败: {restart_result.get('message')}，"
+                        f"需手动重启服务后新配置才会生效"
+                    )
         else:
             logger.error(f"配置推送失败: {result.get('message')}")
 


### PR DESCRIPTION
## 问题
Agent 的 `/api/config/update` 只落盘配置文件、不重启进程，导致「推送配置」后新配置实际不生效。今天的实测中 mihomo 和 mosdns 两次推送都需要手动重启/热重载才加载（mosdns 推送后进程仍跑旧配置 27 分钟，直到手动 `rc-service mosdns restart`）。

## 修复
`push_config_to_agent` 推送成功后复用现有 `restart_agent_service` 链路自动重启目标服务：
- 重启结果附加在响应 `restart` 字段，前端可展示
- 重启失败仅记录告警、不改变推送本身的成功状态
- 请求体传 `{"restart": false}` 可关闭（保留手动控制场景）

## 验证证据
- `python3 -m py_compile backend/routes/agents.py` 通过
- 所调用的重启链路已线上实测：`POST /api/agents/<id>/restart` → agent `/api/restart` → `rc-service mosdns restart`，进程成功重启（etime 归零）且 DNS 解析正常
- `data` 变量在函数内既有定义（原 base_url 解析处），无作用域问题
- 端到端「推送→自动重启」需 .2 部署本次镜像后验证，届时任推送一次即可确认响应中的 `restart.success`