### PR TITLE
feat: MosDNS 自定义 Hosts 自动同步到 Mihomo 配置

### DIFF
--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -140,6 +140,10 @@ def sync_mosdns_hosts(mihomo_config: Dict[str, Any], config_data: Dict[str, Any]
     内网域名映射需要同步写入 Mihomo 顶层 hosts，避免 Mihomo 自身
     （订阅更新、节点域名解析）经公网 NAT 回环访问内网服务。
 
+    注意：仅用于推送给局域网内 Agent 的配置（sync_lan_hosts=True）；
+    订阅/下载配置可能被漫游设备（手机在外）使用，注入内网 IP 会导致
+    这些域名在外网不可达，因此默认不注入。
+
     - 自定义配置中已显式写的同名 hosts 条目优先，不覆盖
     - hosts 参与解析需要 dns.use-hosts: true；用户显式配置过则不改动
     """
@@ -161,8 +165,15 @@ def sync_mosdns_hosts(mihomo_config: Dict[str, Any], config_data: Dict[str, Any]
         dns_config['use-hosts'] = True
 
 
-def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '') -> str:
-    """生成 Mihomo YAML 配置"""
+def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
+                           sync_lan_hosts: bool = False) -> str:
+    """生成 Mihomo YAML 配置
+
+    Args:
+        sync_lan_hosts: 是否把 MosDNS 自定义 Hosts（内网域名映射）注入
+            顶层 hosts。仅推送给局域网内 Agent 时为 True；订阅/下载
+            配置保持 False，避免漫游设备在外网解析到内网 IP。
+    """
 
     # 从合并数组中分离规则和规则集
     rules_list, rule_sets_list = split_rules_and_rulesets(config_data)
@@ -214,8 +225,9 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '') -> s
 
     normalize_find_process_mode(mihomo_config)
 
-    # 同步 MosDNS 自定义 Hosts（内网域名映射），Mihomo 自身解析同样内网直达
-    sync_mosdns_hosts(mihomo_config, config_data)
+    # 仅 Agent 推送场景同步 MosDNS 自定义 Hosts（内网域名映射）
+    if sync_lan_hosts:
+        sync_mosdns_hosts(mihomo_config, config_data)
 
     # 收集被策略组使用的节点ID、订阅ID和聚合ID
     used_node_ids = set()

--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -103,6 +103,64 @@ def normalize_find_process_mode(mihomo_config: Dict[str, Any]) -> None:
             mihomo_config['find-process-mode'] = normalized
 
 
+def parse_mosdns_custom_hosts(custom_hosts: str) -> Dict[str, str]:
+    """解析 MosDNS 自定义 Hosts 文本为 {域名: IP} 映射
+
+    与 MosDNS 转换器保持一致，支持两种格式：
+    1. 域名在前，IP 在后：example.com 192.168.1.1（推荐格式）
+    2. IP 在前，域名在后：192.168.1.1 example.com（传统 hosts 格式）
+    """
+    import re
+
+    hosts: Dict[str, str] = {}
+    if not custom_hosts or not custom_hosts.strip():
+        return hosts
+
+    for line in custom_hosts.strip().split('\n'):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        first, second = parts[0], parts[1]
+        if re.match(r'^[\d\.]+$', second):
+            domain, ip = first, second
+        else:
+            domain, ip = second, first
+        hosts[domain] = ip
+    return hosts
+
+
+def sync_mosdns_hosts(mihomo_config: Dict[str, Any], config_data: Dict[str, Any]) -> None:
+    """将 MosDNS 自定义 Hosts 同步注入 Mihomo 配置
+
+    MosDNS 的自定义 Hosts 只对查询 MosDNS 的客户端生效；Mihomo 自身
+    使用独立的 DNS 上游（不能指回 MosDNS，否则形成解析回环），因此
+    内网域名映射需要同步写入 Mihomo 顶层 hosts，避免 Mihomo 自身
+    （订阅更新、节点域名解析）经公网 NAT 回环访问内网服务。
+
+    - 自定义配置中已显式写的同名 hosts 条目优先，不覆盖
+    - hosts 参与解析需要 dns.use-hosts: true；用户显式配置过则不改动
+    """
+    synced = parse_mosdns_custom_hosts(
+        config_data.get('mosdns', {}).get('custom_hosts', '')
+    )
+    if not synced:
+        return
+
+    hosts = mihomo_config.get('hosts')
+    if not isinstance(hosts, dict):
+        hosts = {}
+    for domain, ip in synced.items():
+        hosts.setdefault(domain, ip)
+    mihomo_config['hosts'] = hosts
+
+    dns_config = mihomo_config.get('dns')
+    if isinstance(dns_config, dict) and 'use-hosts' not in dns_config:
+        dns_config['use-hosts'] = True
+
+
 def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '') -> str:
     """生成 Mihomo YAML 配置"""
 
@@ -155,6 +213,9 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '') -> s
         }
 
     normalize_find_process_mode(mihomo_config)
+
+    # 同步 MosDNS 自定义 Hosts（内网域名映射），Mihomo 自身解析同样内网直达
+    sync_mosdns_hosts(mihomo_config, config_data)
 
     # 收集被策略组使用的节点ID、订阅ID和聚合ID
     used_node_ids = set()

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -607,7 +607,10 @@ def push_config_to_agent(agent_id):
         try:
             if service_type == 'mihomo':
                 logger.info("生成 Mihomo 配置...")
-                config_content = generate_mihomo_config(config_data, base_url=base_url)
+                # Agent 在局域网内，注入 MosDNS 自定义 Hosts 让内网域名直达；
+                # 订阅/下载配置（可能被在外设备使用）不注入
+                config_content = generate_mihomo_config(config_data, base_url=base_url,
+                                                        sync_lan_hosts=True)
 
                 # 获取 provider 下载信息
                 provider_downloads = get_mihomo_provider_downloads(config_data, base_url=base_url)


### PR DESCRIPTION
## 背景
MosDNS 的自定义 Hosts 只对查询 MosDNS 的客户端生效；Mihomo 自身使用独立 DNS 上游（架构上不能指回 MosDNS，否则形成解析回环）。因此当自定义 Hosts 里配置了内网域名（如 `app.example.com 192.168.1.10`）时，局域网内 Mihomo 自身的流量（订阅 provider 更新、节点 server 域名解析）仍会通过公共 DNS 解析到公网 IP，经 NAT 回环访问内网服务——回环不通时订阅更新失败、以内网域名作为 server 的节点直接失活。

## 实现
生成 Mihomo 配置时把 MosDNS 自定义 Hosts 注入顶层 `hosts:` 段，**但仅限 Agent 推送路径**：
- `generate_mihomo_config` 新增 `sync_lan_hosts` 参数（默认 `False`）；只有推送给局域网内 Agent 时为 `True`
- **订阅/下载配置不注入**——这些配置可能被漫游设备（手机在外）使用，内网 IP 会导致域名在外网不可达
- 行解析逻辑与 MosDNS 转换器一致，两种格式均支持（`example.com 192.168.1.1` / `192.168.1.1 example.com`），忽略注释、空行与格式错误行
- 自定义配置中显式写的同名 hosts 条目优先，同步不覆盖
- 自动补 `dns.use-hosts: true`（仅注入时）；用户显式配置过 use-hosts 则不改动
- MosDNS 未配置 Hosts 时零影响

## 验证证据
- 示例数据断言：默认（订阅）路径不含 hosts 且不加 use-hosts；`sync_lan_hosts=True` 注入且 use-hosts 开启；显式条目优先；显式 `use-hosts: false` 不被改动；空 hosts 零影响
- 真实环境导出配置双路径验证：订阅配置无 hosts ✅，Agent 配置注入全部条目 + use-hosts ✅
- `python3 -m py_compile` 通过（converters/mihomo.py、routes/agents.py）