### PR TITLE
perf: Provider 懒惰健康检查、剔除 mosdns 无效规则、Agent 日志降噪

### DIFF
--- a/backend/agents/go-agent/client.go
+++ b/backend/agents/go-agent/client.go
@@ -197,7 +197,7 @@ func (c *Config) createHeartbeatRequest() ([]byte, error) {
 // sendHeartbeatRequest 发送心跳请求到服务器
 func (c *Config) sendHeartbeatRequest(jsonData []byte) error {
 	heartbeatURL := fmt.Sprintf("%s/api/agents/%s/heartbeat", c.ServerURL, c.AgentID)
-	log.Printf("Sending heartbeat to: %s", heartbeatURL)
+	logDebugf("Sending heartbeat to: %s", heartbeatURL)
 	
 	req, err := http.NewRequest("POST", heartbeatURL, bytes.NewBuffer(jsonData))
 	if err != nil {
@@ -218,7 +218,13 @@ func (c *Config) sendHeartbeatRequest(jsonData []byte) error {
 
 	if resp.StatusCode == http.StatusOK {
 		status := getServiceStatus(c.ServiceName)
-		log.Printf("Heartbeat sent successfully (service status: %s)", status)
+		// 心跳成功是常态，仅在服务状态发生变化时记录，避免日志无限累积
+		if status != lastReportedStatus {
+			log.Printf("Heartbeat sent successfully (service status: %s -> %s)", lastReportedStatus, status)
+			lastReportedStatus = status
+		} else {
+			logDebugf("Heartbeat sent successfully (service status: %s)", status)
+		}
 	} else {
 		// 读取响应体以便记录错误信息
 		respBody := make([]byte, 1024)

--- a/backend/agents/go-agent/logging.go
+++ b/backend/agents/go-agent/logging.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+// debugEnabled 控制例行日志（心跳、服务状态探测）是否输出。
+// 这些日志每个心跳周期都会产生，长期运行会累积到数十万行、占满小容量磁盘，
+// 默认关闭；排查问题时设置环境变量 CONFIGFLOW_AGENT_DEBUG=1 打开。
+var debugEnabled = func() bool {
+	v := os.Getenv("CONFIGFLOW_AGENT_DEBUG")
+	if v == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	return err == nil && enabled
+}()
+
+// logDebugf 输出例行调试日志，仅在 debugEnabled 为真时生效
+func logDebugf(format string, v ...interface{}) {
+	if debugEnabled {
+		log.Printf(format, v...)
+	}
+}
+
+// lastReportedStatus 记录上一次心跳观察到的服务状态，
+// 用于只在状态发生变化时输出日志（初始值为空，首次心跳必然记录一次）
+var lastReportedStatus string

--- a/backend/agents/go-agent/system.go
+++ b/backend/agents/go-agent/system.go
@@ -40,7 +40,7 @@ func checkServiceWithSystemctl(serviceName string) (string, bool) {
 
 	cmd := exec.Command("systemctl", "is-active", "--quiet", serviceName)
 	if err := cmd.Run(); err == nil {
-		log.Printf("Service %s is active (systemctl)", serviceName)
+		logDebugf("Service %s is active (systemctl)", serviceName)
 		return "active", true
 	}
 	return "", false
@@ -58,11 +58,11 @@ func checkServiceWithOpenRC(serviceName string) (string, bool) {
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	log.Printf("rc-service output for %s: %s", serviceName, outputStr)
+	logDebugf("rc-service output for %s: %s", serviceName, outputStr)
 
 	// 检查服务状态
 	if err == nil && (strings.Contains(outputStr, "started") || strings.Contains(outputStr, "running")) {
-		log.Printf("Service %s is active (rc-service)", serviceName)
+		logDebugf("Service %s is active (rc-service)", serviceName)
 		return "active", true
 	} else if strings.Contains(outputStr, "stopped") || strings.Contains(outputStr, "crashed") {
 		log.Printf("Service %s is inactive (rc-service)", serviceName)
@@ -91,7 +91,7 @@ func checkServiceWithSupervisorctl(serviceName string) (string, bool) {
 	if strings.Contains(outputStr, serviceName) {
 		// 检查输出中是否包含 RUNNING
 		if strings.Contains(outputStr, "RUNNING") {
-			log.Printf("Service %s is active (supervisorctl)", serviceName)
+			logDebugf("Service %s is active (supervisorctl)", serviceName)
 			return "active", true
 		} else if strings.Contains(outputStr, "FATAL") {
 			log.Printf("Service %s is in FATAL state (supervisorctl) - reporting as inactive", serviceName)
@@ -130,7 +130,7 @@ func checkServiceWithProcess(serviceName string) (string, bool) {
 
 // getServiceStatus 检查服务状态（支持多种 init 系统）
 func getServiceStatus(serviceName string) string {
-	log.Printf("Checking service status for: %s", serviceName)
+	logDebugf("Checking service status for: %s", serviceName)
 
 	// 首先尝试使用 systemctl (systemd)
 	if status, found := checkServiceWithSystemctl(serviceName); found {

--- a/backend/agents/go_install_script.py
+++ b/backend/agents/go_install_script.py
@@ -225,6 +225,15 @@ depend() {{
 start_pre() {{
     checkpath --directory --mode 0755 /var/log
     checkpath --file --mode 0644 --owner root:root /var/log/configflow-agent.log
+    # 日志超过 10MB 时保留一份备份后截断，防止长期运行占满小容量磁盘
+    if [ -f /var/log/configflow-agent.log ]; then
+        log_size=$(wc -c < /var/log/configflow-agent.log 2>/dev/null || echo 0)
+        if [ "$log_size" -gt 10485760 ]; then
+            mv -f /var/log/configflow-agent.log /var/log/configflow-agent.log.1
+            : > /var/log/configflow-agent.log
+            chmod 0644 /var/log/configflow-agent.log
+        fi
+    fi
 }}
 INITEOF
 

--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -408,7 +408,10 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
                 'health-check': {
                     'enable': True,
                     'url': 'http://www.gstatic.com/generate_204',
-                    'interval': 300
+                    'interval': 300,
+                    # 懒惰检测：仅当 Provider 被策略组实际使用时才探测，
+                    # 避免闲置节点持续占用 CPU（低配设备上尤其明显）
+                    'lazy': True
                 }
             }
 
@@ -432,7 +435,10 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
                 'health-check': {
                     'enable': True,
                     'url': 'http://www.gstatic.com/generate_204',
-                    'interval': 300
+                    'interval': 300,
+                    # 懒惰检测：仅当 Provider 被策略组实际使用时才探测，
+                    # 避免闲置节点持续占用 CPU（低配设备上尤其明显）
+                    'lazy': True
                 }
             }
 

--- a/backend/converters/mosdns.py
+++ b/backend/converters/mosdns.py
@@ -1046,9 +1046,11 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
                 (rule_set.get('name') or _normalize_ruleset_id(item_id))
             )
             if behavior == 'ipcidr':
-                match_expr = f"resp_ip ${tag}"
-            else:
-                match_expr = f"qname ${tag}"
+                # IP 类规则集在主序列中无效：此处尚未向上游查询，
+                # 没有响应可供 resp_ip 匹配，规则永远不会命中。
+                # IP 维度的分流由 Mihomo 的 IP 规则负责，此处跳过。
+                continue
+            match_expr = f"qname ${tag}"
 
             if item_id in direct_ruleset_ids:
                 # 直连规则集，使用国内 DNS
@@ -1079,13 +1081,14 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
             # 标记为已添加
             added_merged_tags.add(rule_tag)
 
-            # 根据tag类型决定使用 qname 还是 resp_ip
+            # IP 类规则在主序列中无效：此处尚未向上游查询，
+            # 没有响应可供 resp_ip 匹配，规则永远不会命中。
+            # IP 维度的分流由 Mihomo 的 IP 规则负责，此处跳过。
             if 'ip_rules' in rule_tag:
-                # IP规则使用 resp_ip
-                match_expr = f"resp_ip ${rule_tag}"
-            else:
-                # 域名规则使用 qname
-                match_expr = f"qname ${rule_tag}"
+                continue
+
+            # 域名规则使用 qname
+            match_expr = f"qname ${rule_tag}"
 
             if item_id in direct_rule_ids:
                 # 直连规则，使用国内 DNS


### PR DESCRIPTION
网络体检收尾的三项优化（第四项无需改代码，见文末）。

## ① Provider 懒惰健康检查
生成的 proxy-provider 健康检查写死 `interval: 300` 且未设 `lazy`，闲置 Provider 的全部节点每 5 分钟被探测一次。加 `lazy: true` 后仅在策略组实际使用时探测——低配设备（单核路由盒）上 CPU 开销明显下降。代价：久未使用的节点首次选中时可能多等一次检测。

## ② 剔除 mosdns 主序列中的无效 IP 规则
IP 类规则集/单条 IP 规则会生成 `resp_ip $xxx` 条目写入主序列，但主序列的匹配发生在向上游转发**之前**——此时没有响应可供 `resp_ip` 匹配，这些条目永远不会命中。IP 维度的分流本就由 mihomo 的 IP 规则负责，因此跳过写入。

`ip_set` 插件定义与规则文件**保留**：用户自定义 match 可能在转发之后的位置引用它们，删除会破坏这类配置。

## ③ Agent 日志降噪 + 轮转
每个心跳周期固定产生 5 行例行日志（Sending heartbeat / Checking service status / rc-service output / is active / sent successfully），且无轮转。实测单台设备 162 天累积 **108 万行 / 70MB**，占满 427MB 系统盘的 16%。

- 例行日志改为 debug 级，默认关闭；排查时 `CONFIGFLOW_AGENT_DEBUG=1` 打开
- 心跳成功仅在服务状态**变化**时记录（异常路径日志保持不变，不影响排障）
- 安装脚本 `start_pre` 增加大小保护：超过 10MB 轮转一份并截断（Alpine 无 logrotate 依赖）

## 验证证据
- 断言脚本通过：两处 Provider 均含 `lazy: true` 且 interval/enable 未被改动；mosdns 主序列无 resp_ip 条目、域名规则完整保留、`ip_set` 插件仍在
- 真实环境导出配置回归：mihomo 48 规则 / 34 策略组 / 4 Provider（全部 lazy）/ 8 hosts 无变化；mosdns 主序列剔除 1 条死规则后 goto proxy_dns_seq ×13、goto china_dns ×9、tcp_server 均正常
- `python3 -m py_compile` 通过（converters ×2、go_install_script）
- Go 改动为日志调用替换 + 新增 logging.go，本机无 Go 工具链，编译由 CI 验证

## 未包含：mosdns API 可观测性
原计划的第四项经核查**无需改代码**——生成器已支持 `api_enabled` / `api_address`（默认 `0.0.0.0:8338`），当前实例是设置里关掉了，在 ConfigFlow 的 MosDNS 设置中开启即可。