### PR TITLE
fix: Alpine 镜像源不可用时自动回退官方源

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -43,7 +43,11 @@ COPY backend/agents/go-agent/supervisord.conf /etc/supervisor/supervisord.conf
 COPY backend/agents/go-agent/supervisor/ /etc/supervisor/conf.d/
 COPY docker/docker-agent-entrypoint-service.sh /entrypoint.sh
 
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && \
+# 优先使用国内镜像源加速；镜像源不可用时（DNS 抖动、临时故障）
+# 自动回退官方源，避免 CI 因单一镜像源随机失败
+RUN { sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && apk update; } || \
+    { echo "镜像源不可用，回退官方源" && \
+      sed -i 's/mirrors.tuna.tsinghua.edu.cn/dl-cdn.alpinelinux.org/g' /etc/apk/repositories && apk update; } && \
     apk add --no-cache ca-certificates su-exec supervisor python3-dev py3-pip bash && \
     pip3 install --break-system-packages "setuptools<81" && \
     mkdir -p /etc/mihomo /etc/mosdns /etc/supervisor/conf.d /var/log/supervisor /run && \


### PR DESCRIPTION
## 问题
Agent 镜像构建将 Alpine 源固定替换为清华镜像（`docker/Dockerfile.agent:46`）。镜像源 DNS 抖动时 `apk add` 直接失败，整个构建中断：

```
WARNING: fetching https://mirrors.tuna.tsinghua.edu.cn/alpine/v3.24/main/aarch64/APKINDEX.tar.gz: DNS: transient error (try again later)
ERROR: unable to select packages
process "/bin/sh -c sed -i ... && apk add ..." did not complete successfully: exit code: 6
```

这是**反复出现的基础设施故障**，与代码无关：
- 2026-08-02（run 30752150525）：arm64 失败、amd64 同时成功，重跑即通过
- 2026-02-07：同一位置失败过一次

单一镜像源是个单点故障，每次都要人工重跑。

## 修复
镜像源优先 + `apk update` 探测可用性，不可用时自动回退官方源：

```dockerfile
RUN { sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && apk update; } || \
    { echo "镜像源不可用，回退官方源" && \
      sed -i 's/mirrors.tuna.tsinghua.edu.cn/dl-cdn.alpinelinux.org/g' /etc/apk/repositories && apk update; } && \
    apk add --no-cache ...
```

正常情况仍走国内镜像（保持加速效果），仅在镜像源故障时回退官方源——慢一些但构建能完成。

## 验证证据
本机无 Docker，以等价 shell 逻辑覆盖两条路径：
- **镜像源正常** → 最终源 `mirrors.tuna.tsinghua.edu.cn`，退出码 0
- **镜像源故障** → 输出「镜像源不可用，回退官方源」，最终源 `dl-cdn.alpinelinux.org`，退出码 0

真实镜像构建由本 PR 的 CI 验证（Docker Agent Build 工作流覆盖 amd64 + arm64 双架构）。

## 附：本次失败已单独重跑恢复
run 30752150525 重跑后 success（1m49s），当前 main 的 Agent 镜像可用；本 PR 用于防止复发。