### PR TITLE
fix: 推送配置后由 Agent 落盘完成再重启，消除服务启动失败的竞态

### DIFF
--- a/backend/agents/go-agent/client.go
+++ b/backend/agents/go-agent/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const AgentVersion = "1.0.9-go"
+const AgentVersion = "1.1.0-go"
 
 // 全局监控数据收集器
 var metricsCollector *MetricsCollector

--- a/backend/agents/go-agent/routes/config.go
+++ b/backend/agents/go-agent/routes/config.go
@@ -23,6 +23,10 @@ type UpdateRequest struct {
 	ProviderDownloads []ProviderDownloadItem `json:"provider_downloads,omitempty"`
 	RulesetDownloads  []RulesetDownloadItem  `json:"ruleset_downloads,omitempty"`
 	CustomFiles       []CustomFileItem       `json:"custom_files,omitempty"`
+	// RestartAfterUpdate 为真时，由 Agent 在配置与规则集全部落盘后自行重启服务。
+	// 配置更新是异步的（HTTP 200 仅表示任务已启动），服务端收到响应后立即重启
+	// 会撞上「旧配置已清理、新配置未写入」的窗口，导致服务起不来。
+	RestartAfterUpdate bool `json:"restart_after_update,omitempty"`
 }
 
 // ProviderDownloadItem 定义 provider 下载项的结构
@@ -812,6 +816,17 @@ func handleConfigUpdateAsync(cfg *Config, req UpdateRequest) {
 	}
 
 	log.Printf("Async config update completed successfully.")
+
+	// 配置与规则集全部落盘后再重启，避免服务端在异步任务进行中重启导致
+	// 服务读到不完整（甚至缺失）的配置而启动失败
+	if req.RestartAfterUpdate {
+		log.Printf("RestartAfterUpdate is set, restarting service...")
+		if output, err := RestartService(cfg); err != nil {
+			log.Printf("Restart after config update failed: %v\nOutput: %s", err, string(output))
+		} else {
+			log.Printf("Service restarted successfully after config update.")
+		}
+	}
 }
 
 // handleConfigUpdate 处理配置更新请求 (同步版本，保留用于兼容)

--- a/backend/agents/go-agent/routes/restart.go
+++ b/backend/agents/go-agent/routes/restart.go
@@ -9,6 +9,33 @@ import (
 	"io"
 )
 
+// RestartService 执行服务重启命令，返回命令输出。
+// supervisorctl 场景下补全配置文件路径；restart 失败时回退为 start。
+func RestartService(cfg *Config) ([]byte, error) {
+	restartCommand := cfg.RestartCommand
+	if strings.Contains(restartCommand, "supervisorctl") && !strings.Contains(restartCommand, "-c") {
+		restartCommand = strings.Replace(restartCommand, "supervisorctl", "supervisorctl -c /etc/supervisor/supervisord.conf", 1)
+		log.Printf("Modified supervisorctl command: %s", restartCommand)
+	}
+
+	log.Printf("Executing restart command: %s", restartCommand)
+	output, err := executeURLCommand(restartCommand)
+	if err == nil {
+		return output, nil
+	}
+
+	log.Printf("Restart command failed: %v\nOutput: %s", err, string(output))
+
+	// supervisorctl restart 失败时，服务可能未在运行，改用 start
+	if strings.Contains(restartCommand, "supervisorctl") && strings.Contains(restartCommand, "restart") {
+		startCommand := strings.Replace(restartCommand, "restart", "start", 1)
+		log.Printf("Attempting to start service instead: %s", startCommand)
+		return executeURLCommand(startCommand)
+	}
+
+	return output, err
+}
+
 // RestartHandler 处理服务重启请求
 func RestartHandler(cfg *Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/backend/agents/version.py
+++ b/backend/agents/version.py
@@ -1,7 +1,7 @@
 """Agent 版本管理"""
 
 # Agent 最新版本号
-LATEST_AGENT_VERSION = "1.0.9-go"
+LATEST_AGENT_VERSION = "1.1.0-go"
 
 # 版本更新日志（可选）
 VERSION_CHANGELOG = {

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -6,7 +6,12 @@ import os
 from flask import request, jsonify, send_file
 
 from backend.agents.config_generator import generate_agent_config
-from backend.agents.version import get_latest_version, has_update
+from backend.agents.version import (
+    LATEST_AGENT_VERSION,
+    compare_versions,
+    get_latest_version,
+    has_update,
+)
 from backend.converters.mihomo import generate_mihomo_config, get_mihomo_provider_downloads, get_mihomo_ruleset_downloads
 from backend.converters.mosdns import generate_mosdns_config, get_mosdns_ruleset_downloads, get_mosdns_custom_files
 from backend.converters.surge import generate_surge_config
@@ -18,6 +23,17 @@ from backend.common.utils import str_to_bool
 from backend.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# 支持「配置落盘后由 Agent 自行重启」的最低 Agent 版本。
+# 更早的版本不认识 restart_after_update 字段，只能由服务端触发重启。
+_SELF_RESTART_MIN_VERSION = "1.1.0-go"
+
+
+def _supports_self_restart(agent_version: str) -> bool:
+    """判断 Agent 是否支持配置落盘后自重启"""
+    if not agent_version:
+        return False
+    return compare_versions(agent_version, _SELF_RESTART_MIN_VERSION) >= 0
 
 
 @bp.route('/install-script', methods=['GET'])
@@ -658,14 +674,22 @@ def push_config_to_agent(agent_id):
         # 推送到 Agent
         logger.info(f"推送配置到 Agent: {agent.get('host')}:{agent.get('port')}")
 
+        # Agent 的配置更新是异步的：HTTP 200 只代表任务已启动，此时旧配置可能
+        # 已被清理而新配置尚未写入。因此重启交给 Agent 在落盘后自行执行，
+        # 服务端不再在收到响应后立即重启（那样会让服务读到不完整配置而启动失败）。
+        restart_requested = data.get('restart', True)
+        agent_version = agent.get('version') or ''
+        agent_supports_self_restart = _supports_self_restart(agent_version)
+
         # 准备额外数据
-        extra_data = None
+        extra_data = {}
+        if restart_requested and agent_supports_self_restart:
+            extra_data['restart_after_update'] = True
         if service_type == 'mihomo':
             # Mihomo 需要下载 providers 和 rulesets
             if provider_downloads or ruleset_downloads:
-                extra_data = {
-                    'directories': ['providers', 'ruleset']  # Agent 需要创建 providers 和 ruleset 目录
-                }
+                # Agent 需要创建 providers 和 ruleset 目录
+                extra_data['directories'] = ['providers', 'ruleset']
                 if provider_downloads:
                     extra_data['provider_downloads'] = provider_downloads
                 if ruleset_downloads:
@@ -681,9 +705,8 @@ def push_config_to_agent(agent_id):
                 logger.info(f"准备推送配置，包含 {', '.join(log_parts)}")
         elif service_type == 'mosdns':
             # MosDNS 需要下载 rulesets 和写入自定义文件
-            extra_data = {
-                'directories': ['rules']  # Agent 需要在配置文件同级目录创建 rules 文件夹
-            }
+            # Agent 需要在配置文件同级目录创建 rules 文件夹
+            extra_data['directories'] = ['rules']
             if ruleset_downloads:
                 extra_data['ruleset_downloads'] = ruleset_downloads
             if custom_files:
@@ -698,7 +721,7 @@ def push_config_to_agent(agent_id):
 
             logger.info(f"准备推送配置，包含 {', '.join(log_parts)}")
 
-        result = agent_manager.push_config_to_agent(agent_id, config_content, extra_data=extra_data)
+        result = agent_manager.push_config_to_agent(agent_id, config_content, extra_data=extra_data or None)
 
         # 处理推送结果
         if result['success']:
@@ -718,11 +741,14 @@ def push_config_to_agent(agent_id):
                     result['ruleset_downloads'] = ruleset_downloads
             save_config()
 
-            # 推送成功后自动重启服务加载新配置
-            # Agent 的 /api/config/update 只落盘文件，不重启进程；
-            # 不重启的话新配置不会生效。可通过请求体 {"restart": false} 关闭
-            if data.get('restart', True):
-                logger.info(f"配置推送成功，触发服务重启: {agent_id}")
+            # 重启由 Agent 在配置落盘后自行完成（见 restart_after_update）。
+            # 旧版 Agent 不认识该字段，只能退回服务端触发重启——那样存在竞态，
+            # 因此仅在旧版上保留，并提示升级。
+            if restart_requested and not agent_supports_self_restart:
+                logger.warning(
+                    f"Agent {agent.get('name')} 版本 {agent_version or '未知'} 不支持落盘后自重启，"
+                    f"退回服务端触发重启（存在与异步写入的竞态，建议升级 Agent 至 {LATEST_AGENT_VERSION}）"
+                )
                 restart_result = agent_manager.restart_agent_service(agent_id)
                 result['restart'] = restart_result
                 if not restart_result.get('success'):
@@ -730,6 +756,11 @@ def push_config_to_agent(agent_id):
                         f"配置已推送但服务重启失败: {restart_result.get('message')}，"
                         f"需手动重启服务后新配置才会生效"
                     )
+            elif restart_requested:
+                result['restart'] = {
+                    'success': True,
+                    'message': 'Restart delegated to agent after config is written',
+                }
         else:
             logger.error(f"配置推送失败: {result.get('message')}")
 


### PR DESCRIPTION
## 问题
PR #36 在推送配置成功后立即调用 `/api/restart`，但 Agent 的 `/api/config/update` 是**异步**的：

```go
go handleConfigUpdateAsync(cfg, req)   // 后台处理
JsonResponse(w, 200, {"message": "Config update task started"})  // 立即返回
```

后台任务的顺序是：

1. Step 1：**备份并清理旧配置**
2. Step 2：下载规则集 / provider、写入自定义文件（耗时）
3. Step 3：**写入新配置**

服务端收到 200 时才刚进入 Step 1，此时立刻重启会撞上「旧配置已清理、新配置未写入」的窗口，服务读到缺失或不完整的配置直接启动失败。用户实际遇到了服务挂掉。

## 修复
把重启的时机交给唯一知道"何时写完"的一方——Agent 自己：

- **go-agent**：`UpdateRequest` 新增 `restart_after_update`；`handleConfigUpdateAsync` 在 Step 3 完成后再执行重启。重启逻辑从 `RestartHandler` 抽出为 `RestartService(cfg)`，两处复用（含 supervisorctl 补全 `-c` 与 restart 失败回退 start 的原有行为）
- **后端**：推送时下发该标志，不再于响应后立即重启；响应中的 `restart` 字段标明已委托 Agent
- **兼容**：旧版 Agent 不认识该字段，按版本号回退为服务端触发重启（保持原行为不至于"完全不重启"），并记录告警提示升级
- Agent 版本 `1.0.9-go` → `1.1.0-go`

## 验证证据
断言脚本 **红 → 绿**：
- 旧代码：`ImportError: cannot import name '_supports_self_restart'`（修复不存在）
- 新代码：`PASS: 全部 5 组断言通过`

覆盖：
1. 版本判断 6 个用例（`1.1.0-go`/`1.2.0-go` 支持；`1.0.9-go`/`1.0.0-go`/空/None 不支持）
2. `LATEST_AGENT_VERSION` 必须满足自重启最低版本，避免新装 Agent 反走旧路径
3. Go 侧与 Python 侧版本号一致性
4. **Go 侧重启点位置**：断言 `Step 3 写配置` < `完成日志` < `触发重启` 的源码顺序，防止重启被误挪到写入之前
5. 后端确实按版本区分路径且下发了标志

`python3 -m py_compile` 通过；Go 编译由 CI 双架构验证。

## 升级说明
合并后需更新 Agent（ConfigFlow 中「更新 Agent」）才能走新路径；未升级的 Agent 仍按旧行为工作。