### PR TITLE
fix: 补齐旧配置缺失的配置节，修复升级后「加载订阅列表失败」

### DIFF
--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -87,9 +87,18 @@ def load_config():
                     return
                 loaded_data = json.loads(content)
 
+            # 与默认配置递归合并，补齐旧版本 config.json 中缺失的配置节。
+            # 代码中存在直接按键访问（config_data['subscriptions'] 等），缺键会抛
+            # KeyError 导致接口 500、页面报「加载订阅列表失败」。用户已有的值优先。
+            missing_keys = [k for k in get_default_config() if k not in loaded_data]
+            merged_data = _deep_merge(get_default_config(), loaded_data)
+
             # 这样所有持有 config_data 引用的对象（如 agent_manager）都能看到更新
             config_data.clear()
-            config_data.update(loaded_data)
+            config_data.update(merged_data)
+
+            if missing_keys:
+                logger.info(f"配置缺少顶层项，已补齐默认值: {', '.join(missing_keys)}")
 
             # 为没有 ID 的节点生成 ID
             nodes_updated = False
@@ -104,8 +113,8 @@ def load_config():
             # 清理策略组中对已删除/已禁用聚合的引用
             proxy_groups_cleaned = clean_invalid_proxy_group_aggregations()
 
-            # 如果节点被更新或聚合/策略组被清理，保存配置
-            if nodes_updated or aggregations_cleaned or proxy_groups_cleaned:
+            # 如果补齐了缺失项、节点被更新或聚合/策略组被清理，保存配置
+            if missing_keys or nodes_updated or aggregations_cleaned or proxy_groups_cleaned:
                 save_config()
 
         except (json.JSONDecodeError, ValueError) as e:


### PR DESCRIPTION
Closes #30

## 问题
issue #30 反馈「新版本用不了」，补充截图后确认现象是**一打开就提示「加载订阅列表失败」**。

根因在 `backend/common/config.py` 的 `load_config()`：

```python
config_data.clear()            # 清空默认配置
config_data.update(loaded_data)  # 完全以文件内容替换
```

默认配置被整体丢弃。旧版本升级上来的 `config.json` 若缺少后续版本新增的配置节，而代码中大量存在**直接按键访问**（`config_data['subscriptions']`、`config_data['mihomo']`、`config_data['mosdns']`、`config_data['nodes']` 等），加载订阅接口就会抛 `KeyError` 返回 500，前端 catch 后提示「加载订阅列表失败」。

本地复现（模拟老配置 `{nodes, proxy_groups, rule_configs}`）：

```
默认配置顶层键: [mihomo, mosdns, nodes, proxy_groups, rule_configs, rule_library,
              subscription_aggregations, subscriptions, system_config]
加载后实际键:   [agents, nodes, proxy_groups, rule_configs, system_config]
丢失的键:       [mihomo, mosdns, rule_library, subscription_aggregations, subscriptions]
❌ KeyError: 'subscriptions' → 接口 500 → 前端「加载订阅列表失败」
```

## 修复
加载时与默认配置**递归合并**，复用仓库既有的 `_deep_merge`（此前只用于配置导入）：

- 用户已有值优先，不覆盖
- 缺失的顶层节与嵌套子键都补默认值
- 用户的额外自定义键原样保留
- 补齐后写回磁盘，避免每次启动重复补
- 保持 `config_data` 对象标识不变（`agent_manager` 等持有引用）

## 验证证据
断言脚本 **红 → 绿**：

**旧代码**
```
FAIL:
 - 仍缺少顶层键: ['subscriptions', 'rule_library', 'subscription_aggregations', 'mihomo', 'mosdns']
 - 补齐后仍 KeyError: 'subscriptions'
 - 嵌套默认值未补齐: mosdns.default_forward
 - 补齐结果未持久化到 config.json
```

**新代码**：`PASS: 全部 4 组断言通过`

覆盖四组：
1. 旧配置缺失键被补齐，接口中的直接按键访问（含嵌套 `mihomo.custom_config`）不再 KeyError
2. 用户已有订阅与自定义配置不被默认值覆盖，同时嵌套缺失项（`mosdns.default_forward`）被补齐
3. 补齐结果持久化到 `config.json`
4. 用户额外的自定义键（`agents`、任意键）不丢失

`python3 -m py_compile` 通过。