### PR TITLE
fix: 逻辑规则的 no-resolve 写入子条件，避免生成 Mihomo 无法加载的配置

### DIFF
--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -1,4 +1,5 @@
 """Mihomo (Clash Meta) 配置生成器"""
+import re
 import yaml
 from typing import Dict, Any, List, Optional
 from backend.utils.logger import get_logger
@@ -85,6 +86,33 @@ def split_rules_and_rulesets(config_data: Dict[str, Any]) -> tuple:
         rule_sets = config_data.get('rule_sets', [])
 
     return rules, rule_sets
+
+
+# 逻辑规则类型：no-resolve 不能作为第四个字段追加，Mihomo 会把它当成策略名
+LOGIC_RULE_TYPES = ('AND', 'OR', 'NOT')
+
+# 会触发域名解析的目标 IP 类规则（SRC-IP-CIDR 匹配来源 IP，不触发解析）
+_RESOLVE_TRIGGER_RULE_TYPES = ('IP-CIDR', 'IP-CIDR6', 'IP-SUFFIX', 'GEOIP', 'IP-ASN')
+
+
+def apply_no_resolve_to_logic_rule(value: str) -> str:
+    """为逻辑规则内部的目标 IP 类子条件补上 no-resolve
+
+    Mihomo 的逻辑规则（AND/OR/NOT）不接受尾部的 no-resolve 参数，会报
+    `proxy [no-resolve] not found` 导致配置加载失败；正确写法是写在子条件内：
+
+        AND,((SRC-IP-CIDR,10.0.0.0/24),(IP-CIDR,10.0.0.0/24,no-resolve)),DIRECT
+    """
+    def _inject(match: 're.Match') -> str:
+        inner = match.group(1)
+        parts = [p.strip() for p in inner.split(',')]
+        if not parts or parts[0].upper() not in _RESOLVE_TRIGGER_RULE_TYPES:
+            return match.group(0)
+        if any(p.lower() == 'no-resolve' for p in parts):
+            return match.group(0)
+        return f"({inner},no-resolve)"
+
+    return re.sub(r'\(([^()]*)\)', _inject, value)
 
 
 def normalize_find_process_mode(mihomo_config: Dict[str, Any]) -> None:
@@ -916,6 +944,12 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
                 rules.append(f"MATCH,{policy}")
             elif rule_type == 'RULE-SET':
                 rules.append(f"RULE-SET,{value},{policy}")
+            elif rule_type in LOGIC_RULE_TYPES:
+                # 逻辑规则的 no-resolve 必须写在子条件内部，追加为第四个字段
+                # 会被 Mihomo 当作策略名，导致配置加载失败
+                if item.get('no_resolve', False):
+                    value = apply_no_resolve_to_logic_rule(value)
+                rules.append(f"{rule_type},{value},{policy}")
             else:
                 # 其他规则有三个字段：RULE_TYPE,VALUE,POLICY
                 # 根据配置决定是否添加 no-resolve 参数

--- a/frontend/src/views/Rules.vue
+++ b/frontend/src/views/Rules.vue
@@ -329,7 +329,7 @@
           <el-form-item label="no-resolve" v-if="isIpRuleType">
             <div class="switch-with-tip">
               <el-switch v-model="ruleForm.no_resolve" />
-              <span class="form-tip">IP 类规则建议开启</span>
+              <span class="form-tip">IP 类规则建议开启；逻辑规则会写入其 IP 子条件</span>
             </div>
           </el-form-item>
           <el-form-item label="状态">
@@ -615,8 +615,13 @@ const availablePolicies = computed(() => {
 })
 
 // 判断当前规则类型是否为 IP 类型（需要 no-resolve）
+// 逻辑规则内部可包含 IP 类条件，同样需要 no-resolve（生成时会写入子条件内）
+const LOGIC_RULE_TYPES = ['AND', 'OR', 'NOT']
+const IP_RULE_TYPES = ['IP-CIDR', 'IP-CIDR6', 'IP-SUFFIX', 'GEOIP']
+
 const isIpRuleType = computed(() => {
-  return ['IP-CIDR', 'IP-CIDR6', 'IP-SUFFIX', 'GEOIP'].includes(ruleForm.value.rule_type || '')
+  const type = ruleForm.value.rule_type || ''
+  return IP_RULE_TYPES.includes(type) || LOGIC_RULE_TYPES.includes(type)
 })
 
 // 展开的组ID集合
@@ -847,8 +852,7 @@ const editRule = (row: Rule) => {
   ruleForm.value = { ...row }
   // 如果没有 no_resolve 字段，根据规则类型设置默认值
   if (ruleForm.value.no_resolve === undefined || ruleForm.value.no_resolve === null) {
-    const isIpType = ['IP-CIDR', 'IP-CIDR6', 'IP-SUFFIX', 'GEOIP'].includes(ruleForm.value.rule_type || '')
-    ruleForm.value.no_resolve = isIpType
+    ruleForm.value.no_resolve = IP_RULE_TYPES.includes(ruleForm.value.rule_type || '')
   }
   ruleDialogVisible.value = true
 }


### PR DESCRIPTION
## 问题
给逻辑规则（AND/OR/NOT）开启 no-resolve 后，转换器会把它追加为第四个字段：

```yaml
- AND,((SRC-IP-CIDR,10.0.0.0/24),(IP-CIDR,10.0.0.0/24)),🎯 全球直连,no-resolve
```

Mihomo 把第四个字段当成策略名，直接拒绝加载：

```
level=error msg="rules[12] [AND,((SRC-IP-CIDR,10.0.0.0/24),(IP-CIDR,10.0.0.0/24)),🎯 全球直连,no-resolve] error: proxy [no-resolve] not found"
configuration file test failed
```

结果是**推送后服务起不来**。前端此前不显示逻辑规则的 no-resolve 开关（`isIpRuleType` 只含 IP-CIDR/IP-CIDR6/IP-SUFFIX/GEOIP），但通过 API 设置即可触发，属于能产出坏配置的路径。

反过来，逻辑规则内含目标 IP 条件却**没有** no-resolve 时，Mihomo 为了判断 IP 会对每个域名先做真实解析——本可由 fake-ip 完全避免的解析因此暴露给国内递归（DNS 泄露）。所以这个开关是需要的，只是语法得对。

## 修复
Mihomo 对逻辑规则的正确写法是把 no-resolve 写在子条件内：

```yaml
- AND,((SRC-IP-CIDR,10.0.0.0/24),(IP-CIDR,10.0.0.0/24,no-resolve)),🎯 全球直连
```

- **转换器**：逻辑规则改为把 no-resolve 注入其目标 IP 类子条件（`IP-CIDR`/`IP-CIDR6`/`IP-SUFFIX`/`GEOIP`/`IP-ASN`）
  - `SRC-IP-CIDR` 匹配来源 IP、不触发解析，**跳过**（且不会因子串匹配被误伤）
  - 子条件已有 no-resolve 时不重复添加
  - 非 IP 子条件、以及普通规则的既有语法均不变
- **前端**：逻辑规则的编辑框补上 no-resolve 开关，并说明「逻辑规则会写入其 IP 子条件」

## 验证证据
断言脚本 **红 → 绿**（旧代码 `ImportError`，新代码 `PASS: 全部 4 组断言通过`），覆盖：

1. 注入函数 5 个用例：仅目标 IP 子条件添加、`SRC-IP-CIDR` 不添加、`GEOIP` 添加、已有不重复、无 IP 条件原样返回、多个 IP 子条件都添加
2. 逻辑规则**不再**把 no-resolve 追加为第四字段，且生成结果精确匹配期望
3. 未开启 no_resolve 时逻辑规则保持原样
4. 普通 IP 规则仍用尾部参数（回归）

**真实 Mihomo 二进制校验**（v1.19.28）：

```
AND,((SRC-IP-CIDR,10.0.0.0/24),(IP-CIDR,10.0.0.0/24,no-resolve)),DIRECT
IP-CIDR,1.1.1.1/32,DIRECT,no-resolve
→ configuration file test is successful
```

同一套配置在修复前会 `test failed`。`python3 -m py_compile` 通过。