### PR TITLE
feat: 订阅与聚合支持自定义健康检查地址

### DIFF
--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -88,6 +88,28 @@ def split_rules_and_rulesets(config_data: Dict[str, Any]) -> tuple:
     return rules, rule_sets
 
 
+# Provider 健康检查默认地址
+DEFAULT_HEALTH_CHECK_URL = 'http://www.gstatic.com/generate_204'
+
+
+def build_provider_health_check(source: Dict[str, Any]) -> Dict[str, Any]:
+    """构建 Provider 的健康检查配置
+
+    默认使用境外地址探测。回家/内网类订阅从国内网络出网，用境外地址
+    检查必然超时而被误判为失活，客户端因此不会选用这些节点，故允许每个
+    订阅/聚合单独指定检查地址（如 http://www.baidu.com）。
+    """
+    url = str(source.get('health_check_url') or '').strip() or DEFAULT_HEALTH_CHECK_URL
+    return {
+        'enable': True,
+        'url': url,
+        'interval': 300,
+        # 懒惰检测：仅当 Provider 被策略组实际使用时才探测，
+        # 避免闲置节点持续占用 CPU（低配设备上尤其明显）
+        'lazy': True
+    }
+
+
 # 逻辑规则类型：no-resolve 不能作为第四个字段追加，Mihomo 会把它当成策略名
 LOGIC_RULE_TYPES = ('AND', 'OR', 'NOT')
 
@@ -433,14 +455,7 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
                 'url': sub_url,
                 'path': f"./providers/{sub['name']}.yaml",
                 'interval': 3600,
-                'health-check': {
-                    'enable': True,
-                    'url': 'http://www.gstatic.com/generate_204',
-                    'interval': 300,
-                    # 懒惰检测：仅当 Provider 被策略组实际使用时才探测，
-                    # 避免闲置节点持续占用 CPU（低配设备上尤其明显）
-                    'lazy': True
-                }
+                'health-check': build_provider_health_check(sub)
             }
 
     # 添加聚合提供者 - 只添加被策略组使用且启用的聚合
@@ -460,14 +475,7 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
                 'url': agg_url,
                 'path': f"./providers/{agg['name']}.yaml",
                 'interval': 3600,
-                'health-check': {
-                    'enable': True,
-                    'url': 'http://www.gstatic.com/generate_204',
-                    'interval': 300,
-                    # 懒惰检测：仅当 Provider 被策略组实际使用时才探测，
-                    # 避免闲置节点持续占用 CPU（低配设备上尤其明显）
-                    'lazy': True
-                }
+                'health-check': build_provider_health_check(agg)
             }
 
     if proxy_providers:

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,6 +5,8 @@ export interface Subscription {
   type: string
   enabled: boolean
   interval?: number
+  /** 健康检查地址，留空用默认（境外）；回家/内网订阅建议填国内地址 */
+  health_check_url?: string
   cached_node_count?: number | null
   cached_updated_at?: string | null
 }

--- a/frontend/src/views/SubscriptionAggregation.vue
+++ b/frontend/src/views/SubscriptionAggregation.vue
@@ -210,6 +210,14 @@
             />
           </el-form-item>
 
+          <el-form-item label="健康检查">
+            <el-input
+              v-model="form.health_check_url"
+              placeholder="留空使用默认（http://www.gstatic.com/generate_204）"
+            />
+            <div class="form-tip">回家 / 内网聚合从国内出网，境外地址会被误判为失活，建议填 http://www.baidu.com</div>
+          </el-form-item>
+
           <el-form-item label="描述">
             <el-input
               v-model="form.description"
@@ -368,6 +376,8 @@ interface Aggregation {
   description?: string
   enabled?: boolean
   regex_filter?: string
+  /** 健康检查地址，留空用默认（境外）；回家/内网聚合建议填国内地址 */
+  health_check_url?: string
   created_at?: string
   updated_at?: string
   node_count?: number
@@ -401,7 +411,8 @@ const form = ref<Aggregation>({
   nodes: [],
   description: '',
   enabled: true,
-  regex_filter: ''
+  regex_filter: '',
+  health_check_url: ''
 })
 
 const loadAggregationNodeCount = async (aggregation: Aggregation) => {

--- a/frontend/src/views/Subscriptions.vue
+++ b/frontend/src/views/Subscriptions.vue
@@ -172,6 +172,13 @@
                 <span class="interval-hint">秒（建议 86400 = 1 天）</span>
               </div>
             </el-form-item>
+            <el-form-item label="健康检查" class="form-item">
+              <el-input
+                v-model="form.health_check_url"
+                placeholder="留空使用默认（http://www.gstatic.com/generate_204）"
+              />
+              <div class="form-tip">回家 / 内网订阅从国内出网，境外地址会被误判为失活，建议填 http://www.baidu.com</div>
+            </el-form-item>
             <el-form-item label="启用状态" class="form-item status-item">
               <div class="status-toggle-row">
                 <el-switch v-model="form.enabled" />
@@ -260,7 +267,8 @@ const form = ref<Partial<Subscription>>({
   url: '',
   type: 'universal',
   enabled: true,
-  interval: 86400
+  interval: 86400,
+  health_check_url: ''
 })
 
 // 节点预览相关


### PR DESCRIPTION
## 问题
生成器对**所有** Provider 写死同一个健康检查地址：

```yaml
health-check:
  url: http://www.gstatic.com/generate_204   # 境外，国内不可达
```

回家 / 内网类订阅（WireGuard、SS 等指向自己家宽带的节点）是**从国内网络出网**的，访问这个地址必然超时 → 节点被判定为失活 → 客户端不会选用它们。表现出来就是**回家代理连不上**，但实际链路完全正常。

实测同一组回家节点，只换检查地址：

| 检查地址 | 存活 |
|---|---|
| `http://www.gstatic.com/generate_204` | ❌ **0/2** |
| `http://www.baidu.com` | ✅ **2/2**（78ms / 98ms）|

同时确认公网端口转发、DDNS、服务端进程均正常——问题只在"体检标准"用错了地方。

## 实现
订阅与聚合各自新增 `health_check_url`：

- 后端抽出 `build_provider_health_check()`，读取该字段，**留空 / 缺失 / 纯空白**时沿用原默认地址；两端空白会被裁剪
- `enable` / `interval` / `lazy` 保持原值不变
- 前端在订阅和聚合的编辑框各加一个输入项，占位符写明默认值，并提示「回家 / 内网订阅建议填 http://www.baidu.com」
- `Subscription` / `Aggregation` 类型补上该字段

**未配置时行为与此前完全一致**，属于纯增量。

## 验证证据
断言脚本 **红 → 绿**（旧代码 `ImportError`，新代码 `PASS: 全部 4 组断言通过`）：

1. 构建函数 6 个用例：未设置 / 空串 / 纯空白 / `None` 均回落默认；自定义地址生效；两端空白被裁剪；且 `enable`/`interval`/`lazy` 不被改动
2. **默认行为回归**：不配置时两个 Provider 的地址仍是原默认值
3. 订阅与聚合可各自独立设置不同地址
4. 只配订阅时聚合仍用默认，互不污染

**真实 Mihomo 二进制校验**（v1.19.28）：

```
home-sub: {'enable': True, 'url': 'http://www.baidu.com', 'interval': 300, 'lazy': True}
→ configuration file test is successful
```

`python3 -m py_compile` 通过。