### PR TITLE
feat: 规则页支持查找重复规则

### DIFF
--- a/backend/routes/rules.py
+++ b/backend/routes/rules.py
@@ -618,11 +618,19 @@ def find_duplicate_rules():
         rule_configs = config_data.get('rule_configs', [])
         rule_library = config_data.get('rule_library', [])
 
-        # key: (规则类型, 规则值) -> 出现位置列表
+        # key: (规则类型, 归一化规则值) -> {'value': 首次出现的原始值, 'items': 出现位置列表}
         occurrences = {}
         rules_checked = 0
         rulesets_checked = 0
         failed_rulesets = []
+
+        # 正则类规则值大小写敏感，不做小写归一
+        case_sensitive_types = {'REGEX', 'REGEXP'}
+
+        def add_occurrence(rule_type, rule_value, item):
+            normalized = rule_value if rule_type in case_sensitive_types else rule_value.lower()
+            entry = occurrences.setdefault((rule_type, normalized), {'value': rule_value, 'items': []})
+            entry['items'].append(item)
 
         for index, rule_item in enumerate(rule_configs, start=1):
             # 跳过禁用的规则（与生成配置、规则索引行为一致）
@@ -638,8 +646,7 @@ def find_duplicate_rules():
                     continue
 
                 rules_checked += 1
-                key = (rule_type, rule_value.lower())
-                occurrences.setdefault(key, []).append({
+                add_occurrence(rule_type, rule_value, {
                     'source_type': 'rule',
                     'source': '直接配置的规则',
                     'rule_id': rule_item.get('id', ''),
@@ -673,7 +680,7 @@ def find_duplicate_rules():
                     if not rule_value:
                         continue
 
-                    occurrences.setdefault((rule_type, rule_value.lower()), []).append({
+                    add_occurrence(rule_type, rule_value, {
                         'source_type': 'ruleset',
                         'source': rule_set_name,
                         'rule_id': rule_item.get('id', ''),
@@ -685,12 +692,13 @@ def find_duplicate_rules():
 
         # 同一规则集内部与跨来源的重复都算重复
         duplicates = []
-        for (rule_type, rule_value), items in occurrences.items():
+        for (rule_type, _), entry in occurrences.items():
+            items = entry['items']
             if len(items) < 2:
                 continue
             duplicates.append({
                 'rule_type': rule_type,
-                'value': rule_value,
+                'value': entry['value'],  # 首次出现的原始值，保留大小写用于展示
                 'count': len(items),
                 'policy_conflict': len({i['policy'] for i in items}) > 1,
                 'occurrences': items

--- a/backend/routes/rules.py
+++ b/backend/routes/rules.py
@@ -604,3 +604,114 @@ def match_test_rule():
     except Exception as e:
         logger.error(f'Rule match test failed: {e}')
         return jsonify({'success': False, 'message': f'查询失败: {str(e)}'}), 500
+
+
+@bp.route('/find-duplicates', methods=['POST'])
+@require_auth
+def find_duplicate_rules():
+    """查找重复规则 - 检查直接规则与规则集内容中的重复条目"""
+    import time
+
+    start_time = time.time()
+
+    try:
+        rule_configs = config_data.get('rule_configs', [])
+        rule_library = config_data.get('rule_library', [])
+
+        # key: (规则类型, 规则值) -> 出现位置列表
+        occurrences = {}
+        rules_checked = 0
+        rulesets_checked = 0
+        failed_rulesets = []
+
+        for index, rule_item in enumerate(rule_configs, start=1):
+            # 跳过禁用的规则（与生成配置、规则索引行为一致）
+            if not rule_item.get('enabled', True):
+                continue
+
+            item_type = rule_item.get('itemType', 'rule')
+
+            if item_type == 'rule':
+                rule_type = (rule_item.get('rule_type') or '').strip().upper()
+                rule_value = (rule_item.get('value') or '').strip()
+                if not rule_type or not rule_value:
+                    continue
+
+                rules_checked += 1
+                key = (rule_type, rule_value.lower())
+                occurrences.setdefault(key, []).append({
+                    'source_type': 'rule',
+                    'source': '直接配置的规则',
+                    'rule_id': rule_item.get('id', ''),
+                    'policy': rule_item.get('policy', 'DIRECT'),
+                    'priority': index,
+                    'line': f'{rule_type},{rule_value}'
+                })
+
+            elif item_type == 'ruleset':
+                rule_set_name = rule_item.get('name', '规则集')
+                policy = rule_item.get('policy', 'DIRECT')
+                library_rule_id = rule_item.get('library_rule_id', '')
+
+                library_rule = None
+                if library_rule_id:
+                    library_rule = next((r for r in rule_library if r.get('id') == library_rule_id), None)
+
+                rule_content = get_ruleset_content(rule_item, library_rule)
+                if not rule_content:
+                    logger.warning(f'Skipping ruleset "{rule_set_name}" in duplicate check: unable to fetch content')
+                    failed_rulesets.append(rule_set_name)
+                    continue
+
+                rulesets_checked += 1
+                for line_no, line in enumerate(rule_content.splitlines(), start=1):
+                    parsed = parse_rule_line(line)
+                    if not parsed:
+                        continue
+
+                    rule_type, rule_value = parsed
+                    if not rule_value:
+                        continue
+
+                    occurrences.setdefault((rule_type, rule_value.lower()), []).append({
+                        'source_type': 'ruleset',
+                        'source': rule_set_name,
+                        'rule_id': rule_item.get('id', ''),
+                        'policy': policy,
+                        'priority': index,
+                        'line': line.strip(),
+                        'line_no': line_no
+                    })
+
+        # 同一规则集内部与跨来源的重复都算重复
+        duplicates = []
+        for (rule_type, rule_value), items in occurrences.items():
+            if len(items) < 2:
+                continue
+            duplicates.append({
+                'rule_type': rule_type,
+                'value': rule_value,
+                'count': len(items),
+                'policy_conflict': len({i['policy'] for i in items}) > 1,
+                'occurrences': items
+            })
+
+        # 策略冲突的排前面，其余按出现次数降序、优先级升序
+        duplicates.sort(key=lambda d: (not d['policy_conflict'], -d['count'], d['occurrences'][0]['priority']))
+
+        elapsed_time = time.time() - start_time
+        return jsonify({
+            'success': True,
+            'duplicates': duplicates,
+            'stats': {
+                'rules_checked': rules_checked,
+                'rulesets_checked': rulesets_checked,
+                'failed_rulesets': failed_rulesets,
+                'duplicate_groups': len(duplicates)
+            },
+            'elapsed_time': round(elapsed_time * 1000, 2)  # 毫秒
+        })
+
+    except Exception as e:
+        logger.error(f'Find duplicate rules failed: {e}', exc_info=True)
+        return jsonify({'success': False, 'message': f'查重失败: {str(e)}'}), 500

--- a/backend/utils/rule_matcher.py
+++ b/backend/utils/rule_matcher.py
@@ -75,6 +75,9 @@ def parse_rule_line(line: str) -> Optional[Tuple[str, str]]:
         parts = line.split(',', 1)
         rule_type = parts[0].strip().upper()
         rule_value = parts[1].strip()
+        # 剥离尾部的 no-resolve 参数，它不属于规则值（否则 IP 匹配和查重都会失效）
+        if rule_value.lower().endswith(',no-resolve'):
+            rule_value = rule_value[:-len(',no-resolve')].strip()
         return (rule_type, rule_value)
 
     # 2. MosDNS 格式（domain: / full: / keyword: / regexp: / ip:）
@@ -82,6 +85,10 @@ def parse_rule_line(line: str) -> Optional[Tuple[str, str]]:
         prefix, value = line.split(':', 1)
         prefix = prefix.strip().lower()
         value = value.strip()
+
+        # YAML 规则集的 payload: 头行不是规则
+        if prefix == 'payload' and not value:
+            return None
 
         if prefix == 'domain':
             return ('DOMAIN-SUFFIX', value)

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -61,7 +61,8 @@ export const ruleApi = {
   create: (data: any) => api.post('/rules', data),
   update: (id: string, data: any) => api.put(`/rules/${id}`, data),
   delete: (id: string) => api.delete(`/rules/${id}`),
-  batchCreate: (data: any) => api.post('/rules/batch', data)
+  batchCreate: (data: any) => api.post('/rules/batch', data),
+  findDuplicates: () => api.post('/rules/find-duplicates', {}, { timeout: 120000 })
 }
 
 // 规则集相关

--- a/frontend/src/views/Rules.vue
+++ b/frontend/src/views/Rules.vue
@@ -1488,7 +1488,8 @@ const performDuplicateScan = async () => {
 }
 
 const deleteDuplicateRule = async (occ: any) => {
-  const rule = allRules.value.find(r => r.id === occ.rule_id && r.itemType === 'rule')
+  // 后端对缺失 itemType 的旧数据按 'rule' 兜底，这里保持同样口径
+  const rule = allRules.value.find(r => r.id === occ.rule_id && (r.itemType ?? 'rule') === 'rule')
   if (!rule) {
     ElMessage.error('未找到对应的规则，可能已被删除')
     return

--- a/frontend/src/views/Rules.vue
+++ b/frontend/src/views/Rules.vue
@@ -44,6 +44,14 @@
           <el-icon><Search /></el-icon>
           规则索引
         </el-button>
+        <el-button
+          type="primary"
+          class="action-btn action-secondary"
+          @click="showDuplicateDialog"
+        >
+          <el-icon><CopyDocument /></el-icon>
+          查找重复
+        </el-button>
       </div>
     </div>
 
@@ -551,13 +559,106 @@
         </div>
       </template>
     </el-dialog>
+
+    <!-- 查找重复规则对话框 -->
+    <el-dialog v-model="duplicateDialogVisible" title="查找重复规则" width="700px" class="rule-dialog">
+      <div class="dialog-card">
+        <el-alert
+          title="查找重复规则"
+          type="info"
+          :closable="false"
+          style="margin-bottom: 16px"
+        >
+          <div style="font-size: 13px; margin-top: 8px;">
+            检查已启用的直接规则与规则集内容，找出完全相同的规则条目（首次扫描需拉取规则集内容，可能较慢）
+          </div>
+        </el-alert>
+
+        <div v-if="duplicateLoading" class="dup-loading">
+          <el-icon class="is-loading"><Loading /></el-icon>
+          <span>正在扫描规则……</span>
+        </div>
+
+        <template v-else-if="duplicateResult">
+          <div class="dup-stats">
+            <span>已检查 {{ duplicateResult.stats.rules_checked }} 条规则、{{ duplicateResult.stats.rulesets_checked }} 个规则集</span>
+            <el-tag v-if="duplicateResult.duplicates.length" type="warning" size="small">
+              {{ duplicateResult.duplicates.length }} 组重复
+            </el-tag>
+            <el-tag v-else type="success" size="small">无重复</el-tag>
+            <el-tag v-if="duplicateResult.elapsed_time !== undefined" type="info" size="small">
+              {{ duplicateResult.elapsed_time }} ms
+            </el-tag>
+          </div>
+
+          <el-alert
+            v-if="duplicateResult.stats.failed_rulesets.length"
+            type="warning"
+            :closable="false"
+            style="margin-bottom: 12px"
+            :title="`以下规则集内容获取失败，未参与查重：${duplicateResult.stats.failed_rulesets.join('、')}`"
+          />
+
+          <el-result
+            v-if="!duplicateResult.duplicates.length"
+            icon="success"
+            title="未发现重复规则"
+            style="padding: 20px 0;"
+          />
+
+          <div v-else class="dup-list">
+            <div v-for="group in duplicateResult.duplicates" :key="`${group.rule_type},${group.value}`" class="dup-group">
+              <div class="dup-group-header">
+                <el-tag type="info" size="small" style="font-family: monospace;">
+                  {{ group.rule_type }},{{ group.value }}
+                </el-tag>
+                <el-tag type="warning" size="small">{{ group.count }} 处</el-tag>
+                <el-tag v-if="group.policy_conflict" type="danger" size="small">策略冲突</el-tag>
+              </div>
+              <div class="dup-occ" v-for="(occ, i) in group.occurrences" :key="i">
+                <el-tag :type="occ.source_type === 'rule' ? 'primary' : 'success'" size="small">
+                  {{ occ.source_type === 'rule' ? '直接规则' : '规则集' }}
+                </el-tag>
+                <span class="dup-occ-source" :title="occ.line">
+                  {{ occ.source_type === 'rule' ? occ.line : `${occ.source} · 第 ${occ.line_no} 行` }}
+                </span>
+                <span class="dup-occ-meta">优先级 #{{ occ.priority }}</span>
+                <el-tag
+                  :type="occ.policy === 'DIRECT' ? 'success' : occ.policy === 'REJECT' ? 'danger' : 'primary'"
+                  size="small"
+                >
+                  {{ occ.policy }}
+                </el-tag>
+                <el-button
+                  v-if="occ.source_type === 'rule'"
+                  class="list-btn danger"
+                  size="small"
+                  title="删除该条直接规则"
+                  @click="deleteDuplicateRule(occ)"
+                >
+                  <el-icon><Delete /></el-icon>
+                </el-button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+      <template #footer>
+        <div class="dialog-footer">
+          <el-button class="footer-btn ghost" @click="duplicateDialogVisible = false">关闭</el-button>
+          <el-button class="footer-btn primary" type="primary" @click="performDuplicateScan" :loading="duplicateLoading">
+            重新扫描
+          </el-button>
+        </div>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, onActivated, computed, nextTick, watch } from 'vue'
 import { ElMessage } from 'element-plus'
-import { DCaret, Edit, Delete, FolderOpened, ArrowUp, ArrowDown, Search, Plus, View, Hide, InfoFilled, List, Grid, ChatLineSquare } from '@element-plus/icons-vue'
+import { DCaret, Edit, Delete, FolderOpened, ArrowUp, ArrowDown, Search, Plus, View, Hide, InfoFilled, List, Grid, ChatLineSquare, CopyDocument, Loading } from '@element-plus/icons-vue'
 import { ruleApi, ruleSetApi, proxyGroupApi } from '@/api'
 import type { Rule, RuleSet, ProxyGroup } from '@/types'
 import Sortable from 'sortablejs'
@@ -585,6 +686,11 @@ const ruleIndexDialogVisible = ref(false)
 const ruleIndexQuery = ref('')
 const ruleIndexResult = ref<any>(null)
 const ruleIndexLoading = ref(false)
+
+// 查找重复规则相关
+const duplicateDialogVisible = ref(false)
+const duplicateResult = ref<any>(null)
+const duplicateLoading = ref(false)
 const isSavingOrder = ref(false) // 防止并发保存排序
 
 const ruleForm = ref<Partial<Rule>>({
@@ -1351,6 +1457,47 @@ const performRuleIndexQuery = async () => {
   }
 }
 
+// 查找重复规则相关方法
+const showDuplicateDialog = () => {
+  duplicateDialogVisible.value = true
+  performDuplicateScan()
+}
+
+const performDuplicateScan = async () => {
+  duplicateLoading.value = true
+  duplicateResult.value = null
+
+  try {
+    // 需要拉取并解析规则集内容，与规则索引一样使用较长超时
+    const { data } = await ruleApi.findDuplicates()
+    if (data.success) {
+      duplicateResult.value = data
+    } else {
+      ElMessage.error(data.message || '查重失败')
+    }
+  } catch (error: any) {
+    console.error('Find duplicates failed:', error)
+    if (error.code === 'ECONNABORTED') {
+      ElMessage.error('查重超时，请检查规则集配置是否正确')
+    } else {
+      ElMessage.error(error.response?.data?.message || '查重失败，请稍后重试')
+    }
+  } finally {
+    duplicateLoading.value = false
+  }
+}
+
+const deleteDuplicateRule = async (occ: any) => {
+  const rule = allRules.value.find(r => r.id === occ.rule_id && r.itemType === 'rule')
+  if (!rule) {
+    ElMessage.error('未找到对应的规则，可能已被删除')
+    return
+  }
+  await deleteRule(rule)
+  // 删除后刷新查重结果
+  performDuplicateScan()
+}
+
 // 监听视图模式切换，重新初始化拖拽
 watch(viewMode, () => {
   nextTick(() => {
@@ -1984,6 +2131,74 @@ onActivated(() => {
 
 .sortable-ghost {
   opacity: 0.4;
+}
+
+/* 查找重复规则对话框 */
+.dup-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 0;
+  color: #6c74a0;
+  font-size: 14px;
+}
+
+.dup-stats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: #6c74a0;
+}
+
+.dup-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.dup-group {
+  border: 1px solid rgba(107, 115, 255, 0.14);
+  border-radius: var(--rule-radius-md, 16px);
+  padding: 12px 16px;
+  background: rgba(107, 115, 255, 0.04);
+}
+
+.dup-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.dup-occ {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px dashed rgba(107, 115, 255, 0.12);
+  font-size: 13px;
+}
+
+.dup-occ-source {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #303133;
+  font-family: monospace;
+}
+
+.dup-occ-meta {
+  color: #909399;
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 /* 视图切换按钮样式 */


### PR DESCRIPTION
## 变更摘要

实现 #45 请求的「查找重复规则」功能：

**后端**（`backend/routes/rules.py`）
- 新增 `POST /api/rules/find-duplicates` 接口：遍历已启用的直接规则与规则集内容（复用 `get_ruleset_content` 缓存优先逻辑与 `parse_rule_line` 多格式解析），按「规则类型 + 规则值（大小写归一）」分组找出出现 2 次以上的条目
- 返回每组重复的出现位置（来源、策略、优先级、行号）、是否存在策略冲突，以及扫描统计（含内容获取失败的规则集列表，失败不中断扫描）
- 排序：策略冲突组优先，其余按重复次数降序

**前端**（`Rules.vue` / `api/index.ts`）
- 规则页头部新增「查找重复」按钮，打开对话框自动扫描
- 结果按组展示：重复条目、出现次数、策略冲突标记，每处显示来源（直接规则 / 规则集 + 行号）、优先级与策略
- 直接规则的重复项可在对话框内直接删除（复用现有删除逻辑，含 MosDNS 引用同步），删除后自动重新扫描
- 样式与页面现有浅色风格保持一致

issue 中另提到的「数字优先级」是独立改动，不在本 PR 范围。

## 验证证据
- 后端：Flask test client 脚本覆盖 6 个场景全部通过——直接规则跨策略重复（policy_conflict=true）、大小写归一（Google.COM ≡ google.com）、直接规则与规则集内容重复、同一规则集内部重复、禁用规则不参与查重、规则集拉取失败计入 failed_rulesets 且不中断
- 后端：`from backend.app import app` 完整加载通过，`/api/rules/find-duplicates` 路由注册确认
- 前端：`npm run build` 通过

Closes #45