### PR TITLE
支持单独关闭 MosDNS 缓存持久化文件

### DIFF
--- a/backend/agents/go-agent/routes/config.go
+++ b/backend/agents/go-agent/routes/config.go
@@ -11,8 +11,10 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -65,11 +67,11 @@ type Config struct {
 	HeartbeatInterval  int    `json:"heartbeat_interval"`
 	AgentID            string `json:"agent_id,omitempty"`
 	Token              string `json:"token,omitempty"`
-	
+
 	// MosDNS 特殊功能字段
 	Directories       []string              `json:"directories,omitempty"`
 	RulesetDownloads  []RulesetDownloadItem `json:"ruleset_downloads,omitempty"`
-	
+
 	filePath string
 }
 
@@ -77,14 +79,14 @@ type Config struct {
 func ConfigUpdateHandler(cfg *Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Config update requested from %s", r.RemoteAddr)
-		
+
 		var req UpdateRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			log.Printf("Failed to decode request body: %v", err)
 			JsonResponse(w, http.StatusBadRequest, map[string]string{"success": "false", "message": "Invalid request body"})
 			return
 		}
-		
+
 		log.Printf("Request parsed. Config length: %d, Directories: %d, RulesetDownloads: %d, CustomFiles: %d",
 			len(req.Config), len(req.Directories), len(req.RulesetDownloads), len(req.CustomFiles))
 
@@ -102,25 +104,24 @@ func handleMosdnsFeatures(cfg *Config, req UpdateRequest) error {
 	// 获取实际的配置文件目录（从 ConfigPath 中提取）
 	configDir := filepath.Dir(cfg.ConfigPath)
 
-	// 1. 创建 cache.dump 文件（如果不存在）
-	cacheDumpPath := filepath.Join(configDir, "cache.dump")
-	if _, err := os.Stat(cacheDumpPath); os.IsNotExist(err) {
-		log.Printf("cache.dump not found, creating empty file: %s", cacheDumpPath)
-		// 创建空的 cache.dump 文件
-		file, err := os.Create(cacheDumpPath)
-		if err != nil {
-			log.Printf("Warning: failed to create cache.dump: %v", err)
-			// 不返回错误，只记录警告，因为这不是致命错误
+	// 1. 仅在配置启用缓存持久化时预创建 dump 文件
+	cacheDumpFile, err := mosdnsCacheDumpFile(req.Config)
+	if err != nil {
+		log.Printf("Warning: failed to inspect MosDNS cache settings: %v", err)
+	} else if cacheDumpFile != "" {
+		cacheDumpPath := cacheDumpFile
+		if !filepath.IsAbs(cacheDumpPath) {
+			cacheDumpPath = filepath.Join(configDir, cacheDumpPath)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(cacheDumpPath), 0755); err != nil {
+			log.Printf("Warning: failed to create cache dump directory: %v", err)
+		} else if file, err := os.OpenFile(cacheDumpPath, os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+			log.Printf("Warning: failed to create cache dump file: %v", err)
 		} else {
 			file.Close()
-			// 设置文件权限为 0644
-			if err := os.Chmod(cacheDumpPath, 0644); err != nil {
-				log.Printf("Warning: failed to set permissions for cache.dump: %v", err)
-			}
-			log.Printf("Successfully created empty cache.dump file")
+			log.Printf("Cache dump file ready: %s", cacheDumpPath)
 		}
-	} else {
-		log.Printf("cache.dump already exists: %s", cacheDumpPath)
 	}
 
 	// 2. 处理 MosDNS 目录创建
@@ -151,6 +152,29 @@ func handleMosdnsFeatures(cfg *Config, req UpdateRequest) error {
 	}
 
 	return nil
+}
+
+func mosdnsCacheDumpFile(configContent string) (string, error) {
+	var config struct {
+		Plugins []struct {
+			Type string `yaml:"type"`
+			Args struct {
+				DumpFile string `yaml:"dump_file"`
+			} `yaml:"args"`
+		} `yaml:"plugins"`
+	}
+
+	if err := yaml.Unmarshal([]byte(configContent), &config); err != nil {
+		return "", err
+	}
+
+	for _, plugin := range config.Plugins {
+		if plugin.Type == "cache" {
+			return strings.TrimSpace(plugin.Args.DumpFile), nil
+		}
+	}
+
+	return "", nil
 }
 
 // handleMihomoFeatures 处理Mihomo特殊功能
@@ -274,7 +298,7 @@ func downloadRuleset(configDir string, item RulesetDownloadItem) error {
 
 	// 否则从 URL 下载（向后兼容）
 	log.Printf("Downloading ruleset: %s from %s to %s (base: %s)", item.Name, item.URL, localPath, configDir)
-	
+
 	// 创建目标目录
 	dir := filepath.Dir(localPath)
 	log.Printf("Creating directory for ruleset: %s", dir)
@@ -681,12 +705,12 @@ func writeConfig(cfg *Config, configContent string, backupPath string) error {
 		// 获取当前用户ID和组ID
 		uid := os.Getuid()
 		gid := os.Getgid()
-		
+
 		log.Printf("Setting ownership for %s to uid=%d, gid=%d", configDir, uid, gid)
 		if err := os.Chown(configDir, uid, gid); err != nil {
 			log.Printf("Warning: failed to set ownership for %s: %v", configDir, err)
 		}
-		
+
 		// 递归设置目录中所有文件的权限
 		err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -709,7 +733,7 @@ func writeConfig(cfg *Config, configContent string, backupPath string) error {
 		}
 		return fmt.Errorf("failed to write new config: %w", err)
 	}
-	
+
 	return nil
 }
 

--- a/backend/agents/go-agent/routes/config_test.go
+++ b/backend/agents/go-agent/routes/config_test.go
@@ -1,0 +1,54 @@
+package routes
+
+import "testing"
+
+func TestMosdnsCacheDumpFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		expected string
+	}{
+		{
+			name: "persistence enabled",
+			config: `plugins:
+  - tag: lazy_cache
+    type: cache
+    args:
+      size: 10240
+      dump_file: ./cache.dump
+      dump_interval: 300
+`,
+			expected: "./cache.dump",
+		},
+		{
+			name: "persistence disabled",
+			config: `plugins:
+  - tag: lazy_cache
+    type: cache
+    args:
+      size: 10240
+`,
+			expected: "",
+		},
+		{
+			name: "cache disabled",
+			config: `plugins:
+  - tag: forward_local
+    type: forward
+`,
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := mosdnsCacheDumpFile(test.config)
+			if err != nil {
+				t.Fatalf("mosdnsCacheDumpFile returned an error: %v", err)
+			}
+			if actual != test.expected {
+				t.Fatalf("mosdnsCacheDumpFile() = %q, want %q", actual, test.expected)
+			}
+		})
+	}
+}

--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -53,7 +53,13 @@ def get_default_config() -> Dict[str, Any]:
             'custom_hosts': '',
             'custom_config': '',
             'custom_matches': [],
-            'custom_match_position': 'tail'
+            'custom_match_position': 'tail',
+            'cache_enabled': True,
+            'cache_size': 10240,
+            'cache_lazy_ttl': 21600,
+            'cache_dump_enabled': True,
+            'cache_dump_file': './cache.dump',
+            'cache_dump_interval': 300
         }
     }
 

--- a/backend/config_template.json
+++ b/backend/config_template.json
@@ -1187,6 +1187,7 @@
     "cache_enabled": true,
     "cache_size": 10240,
     "cache_lazy_ttl": 21600,
+    "cache_dump_enabled": true,
     "cache_dump_file": "./cache.dump",
     "cache_dump_interval": 300
   },

--- a/backend/converters/mosdns.py
+++ b/backend/converters/mosdns.py
@@ -676,19 +676,32 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
     cache_enabled = mosdns_config_data.get('cache_enabled', True)
     cache_size = mosdns_config_data.get('cache_size', 10240)
     cache_lazy_ttl = mosdns_config_data.get('cache_lazy_ttl', 21600)
+    cache_dump_enabled = mosdns_config_data.get('cache_dump_enabled', True)
     cache_dump_file = mosdns_config_data.get('cache_dump_file', './cache.dump')
     cache_dump_interval = mosdns_config_data.get('cache_dump_interval', 300)
 
     if cache_enabled:
+        cache_args = {
+            'size': int(cache_size) if cache_size is not None else 10240,
+            'lazy_cache_ttl': int(cache_lazy_ttl) if cache_lazy_ttl is not None else 21600,
+        }
+        if cache_dump_enabled:
+            try:
+                normalized_dump_interval = int(cache_dump_interval)
+            except (TypeError, ValueError):
+                normalized_dump_interval = 300
+            if normalized_dump_interval <= 0:
+                normalized_dump_interval = 300
+
+            cache_args.update({
+                'dump_file': str(cache_dump_file).strip() if cache_dump_file else './cache.dump',
+                'dump_interval': normalized_dump_interval
+            })
+
         plugins.append({
             'tag': 'lazy_cache',
             'type': 'cache',
-            'args': {
-                'size': int(cache_size) if cache_size is not None else 10240,
-                'lazy_cache_ttl': int(cache_lazy_ttl) if cache_lazy_ttl is not None else 21600,
-                'dump_file': str(cache_dump_file) if cache_dump_file else './cache.dump',
-                'dump_interval': int(cache_dump_interval) if cache_dump_interval is not None else 300
-            }
+            'args': cache_args
         })
 
     # 3. 转发插件 - 国内 DNS 服务器

--- a/backend/converters/test_mosdns.py
+++ b/backend/converters/test_mosdns.py
@@ -1,0 +1,41 @@
+import unittest
+
+import yaml
+
+from backend.converters.mosdns import generate_mosdns_config
+
+
+class MosdnsCacheConfigTest(unittest.TestCase):
+    @staticmethod
+    def _cache_plugin(mosdns_settings):
+        generated = generate_mosdns_config({'mosdns': mosdns_settings})
+        config = yaml.safe_load(generated)
+        return next(
+            (plugin for plugin in config['plugins'] if plugin.get('tag') == 'lazy_cache'),
+            None
+        )
+
+    def test_cache_persistence_can_be_disabled(self):
+        plugin = self._cache_plugin({
+            'cache_enabled': True,
+            'cache_dump_enabled': False,
+        })
+
+        self.assertIsNotNone(plugin)
+        self.assertNotIn('dump_file', plugin['args'])
+        self.assertNotIn('dump_interval', plugin['args'])
+
+    def test_cache_persistence_defaults_remain_compatible(self):
+        plugin = self._cache_plugin({'cache_enabled': True})
+
+        self.assertEqual(plugin['args']['dump_file'], './cache.dump')
+        self.assertEqual(plugin['args']['dump_interval'], 300)
+
+    def test_cache_plugin_can_still_be_disabled(self):
+        plugin = self._cache_plugin({'cache_enabled': False})
+
+        self.assertIsNone(plugin)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/routes/mosdns.py
+++ b/backend/routes/mosdns.py
@@ -301,6 +301,7 @@ def handle_mosdns_cache_settings():
             'cache_enabled': True,
             'cache_size': 10240,
             'cache_lazy_ttl': 21600,
+            'cache_dump_enabled': True,
             'cache_dump_file': './cache.dump',
             'cache_dump_interval': 300
         }
@@ -314,6 +315,8 @@ def handle_mosdns_cache_settings():
         mosdns_config['cache_size'] = 10240
     if 'cache_lazy_ttl' not in mosdns_config:
         mosdns_config['cache_lazy_ttl'] = 21600
+    if 'cache_dump_enabled' not in mosdns_config:
+        mosdns_config['cache_dump_enabled'] = True
     if 'cache_dump_file' not in mosdns_config:
         mosdns_config['cache_dump_file'] = './cache.dump'
     if 'cache_dump_interval' not in mosdns_config:
@@ -324,6 +327,7 @@ def handle_mosdns_cache_settings():
             'cache_enabled': mosdns_config.get('cache_enabled', True),
             'cache_size': mosdns_config.get('cache_size', 10240),
             'cache_lazy_ttl': mosdns_config.get('cache_lazy_ttl', 21600),
+            'cache_dump_enabled': mosdns_config.get('cache_dump_enabled', True),
             'cache_dump_file': mosdns_config.get('cache_dump_file', './cache.dump'),
             'cache_dump_interval': mosdns_config.get('cache_dump_interval', 300)
         })
@@ -333,6 +337,7 @@ def handle_mosdns_cache_settings():
             data = request.json or {}
 
             mosdns_config['cache_enabled'] = bool(data.get('cache_enabled', True))
+            mosdns_config['cache_dump_enabled'] = bool(data.get('cache_dump_enabled', True))
 
             # 数字字段做简单容错
             def _to_int(value, default: int) -> int:
@@ -343,7 +348,8 @@ def handle_mosdns_cache_settings():
 
             mosdns_config['cache_size'] = _to_int(data.get('cache_size', 10240), 10240)
             mosdns_config['cache_lazy_ttl'] = _to_int(data.get('cache_lazy_ttl', 21600), 21600)
-            mosdns_config['cache_dump_interval'] = _to_int(data.get('cache_dump_interval', 300), 300)
+            dump_interval = _to_int(data.get('cache_dump_interval', 300), 300)
+            mosdns_config['cache_dump_interval'] = dump_interval if dump_interval > 0 else 300
 
             dump_file = data.get('cache_dump_file', './cache.dump')
             mosdns_config['cache_dump_file'] = str(dump_file) if dump_file is not None else './cache.dump'

--- a/frontend/src/views/Generate.vue
+++ b/frontend/src/views/Generate.vue
@@ -657,7 +657,11 @@
               </div>
             </el-form-item>
 
-            <el-form-item label="dump_file" v-if="mosdnsCacheEnabled">
+            <el-form-item label="持久化缓存" v-if="mosdnsCacheEnabled">
+              <el-switch v-model="mosdnsCacheDumpEnabled" />
+            </el-form-item>
+
+            <el-form-item label="dump_file" v-if="mosdnsCacheEnabled && mosdnsCacheDumpEnabled">
               <el-input
                 v-model="mosdnsCacheDumpFile"
                 placeholder="./cache.dump"
@@ -667,16 +671,16 @@
               </div>
             </el-form-item>
 
-            <el-form-item label="dump_interval" v-if="mosdnsCacheEnabled">
+            <el-form-item label="dump_interval" v-if="mosdnsCacheEnabled && mosdnsCacheDumpEnabled">
               <el-input-number
                 v-model="mosdnsCacheDumpInterval"
-                :min="0"
+                :min="1"
                 :max="86400"
                 :step="10"
                 controls-position="right"
               />
               <div style="margin-top: 8px; color: #909399; font-size: 12px">
-                缓存保存间隔（秒），0 表示禁用定时保存
+                缓存保存间隔（秒）
               </div>
             </el-form-item>
           </el-form>
@@ -1582,6 +1586,7 @@ const mosdnsApiAddress = ref('0.0.0.0:8338')
 const mosdnsCacheEnabled = ref(true)
 const mosdnsCacheSize = ref(10240)
 const mosdnsCacheLazyTtl = ref(21600)
+const mosdnsCacheDumpEnabled = ref(true)
 const mosdnsCacheDumpFile = ref('./cache.dump')
 const mosdnsCacheDumpInterval = ref(300)
 const availableRuleSets = ref<RuleSet[]>([])
@@ -2416,7 +2421,8 @@ const showMosdnsSettingsDialog = async () => {
     mosdnsCacheEnabled.value = cacheResponse.data.cache_enabled !== undefined ? Boolean(cacheResponse.data.cache_enabled) : true
     mosdnsCacheSize.value = Number(cacheResponse.data.cache_size ?? 10240)
     mosdnsCacheLazyTtl.value = Number(cacheResponse.data.cache_lazy_ttl ?? 21600)
-    mosdnsCacheDumpFile.value = cacheResponse.data.cache_dump_file || './cache.dump'
+    mosdnsCacheDumpEnabled.value = cacheResponse.data.cache_dump_enabled !== undefined ? Boolean(cacheResponse.data.cache_dump_enabled) : true
+    mosdnsCacheDumpFile.value = cacheResponse.data.cache_dump_file ?? './cache.dump'
     mosdnsCacheDumpInterval.value = Number(cacheResponse.data.cache_dump_interval ?? 300)
 
     // 重置到第一个 tab
@@ -2497,6 +2503,7 @@ const saveMosdnsSettings = async () => {
       cache_enabled: mosdnsCacheEnabled.value,
       cache_size: mosdnsCacheSize.value,
       cache_lazy_ttl: mosdnsCacheLazyTtl.value,
+      cache_dump_enabled: mosdnsCacheDumpEnabled.value,
       cache_dump_file: mosdnsCacheDumpFile.value,
       cache_dump_interval: mosdnsCacheDumpInterval.value
     })


### PR DESCRIPTION
## 背景

当前 MosDNS 缓存启用后，生成配置会固定包含 `dump_file` 和 `dump_interval`，无法在保留内存缓存的同时关闭磁盘持久化。

## 修改内容

- 新增 `cache_dump_enabled` 配置项，默认开启，兼容现有配置
- 前端增加“持久化缓存”开关
- 关闭持久化后，生成配置不再包含 `dump_file` 和 `dump_interval`
- 保留 `size` 和 `lazy_cache_ttl`，内存缓存继续正常工作
- Agent 仅在配置包含 `dump_file` 时创建缓存文件
- 修正 `dump_interval: 0` 被误认为关闭持久化的问题

## 生成效果

关闭持久化后：

```yaml
- tag: lazy_cache
  type: cache
  args:
    size: 10240
    lazy_cache_ttl: 21600