### PR TITLE
fix: 认证改为完全可选，移除 SKIP_AUTH_CHECK 与生产环境强制校验

### DIFF
--- a/backend/common/auth.py
+++ b/backend/common/auth.py
@@ -1,12 +1,14 @@
 """认证相关工具模块"""
 import os
+import secrets
 import jwt
 from datetime import datetime, timedelta
 from functools import wraps
 from flask import request, jsonify
 
 # JWT 配置
-JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'your-secret-key-change-this-in-production')
+# 未显式配置时随机生成（进程级），避免使用可预测的硬编码默认密钥
+JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY') or secrets.token_urlsafe(48)
 JWT_ALGORITHM = 'HS256'
 JWT_EXPIRATION_HOURS = 24
 
@@ -112,86 +114,17 @@ def require_auth(f):
 
 
 def validate_required_env_vars():
-    """验证必需的环境变量是否已设置"""
-    # 开发环境检测：检查 DATA_DIR 环境变量
-    # 如果 DATA_DIR 未设置或设置为 /data 但目录不存在，则认为是开发环境
-    data_dir = os.environ.get('DATA_DIR', '/data')
-    is_dev_mode = not os.path.exists(data_dir) if data_dir == '/data' else False
-
-    # 也可以通过 SKIP_AUTH_CHECK 环境变量跳过验证（用于本地开发）
-    if os.environ.get('SKIP_AUTH_CHECK', '').lower() == 'true':
-        is_dev_mode = True
-
-    if is_dev_mode:
-        # 开发模式：如果没有设置认证信息，给出提示但不强制退出
-        if not ADMIN_USERNAME or not ADMIN_PASSWORD:
-            print('\n' + '=' * 80)
-            print('INFO: Running in DEVELOPMENT mode without authentication')
-            print('=' * 80)
-            print('⚠️  Authentication is DISABLED. Anyone can access the application.')
-            print('')
-            print('To enable authentication in development, set:')
-            print('  export ADMIN_USERNAME=admin')
-            print('  export ADMIN_PASSWORD=your-password')
-            print('  export JWT_SECRET_KEY=your-secret-key')
-            print('')
-            print('Production environments (Docker) REQUIRE authentication.')
-            print('=' * 80 + '\n')
+    """启动时提示认证状态（认证为可选功能，不做强制校验）"""
+    if is_auth_enabled():
         return
 
-    # 生产环境：强制要求配置
-    missing_vars = []
-    invalid_vars = []
-
-    # 检查 ADMIN_USERNAME
-    if not ADMIN_USERNAME or ADMIN_USERNAME.strip() == '':
-        missing_vars.append('ADMIN_USERNAME')
-
-    # 检查 ADMIN_PASSWORD
-    if not ADMIN_PASSWORD or ADMIN_PASSWORD.strip() == '':
-        missing_vars.append('ADMIN_PASSWORD')
-
-    # 检查 JWT_SECRET_KEY
-    if not JWT_SECRET_KEY or JWT_SECRET_KEY.strip() == '':
-        missing_vars.append('JWT_SECRET_KEY')
-    elif len(JWT_SECRET_KEY.strip()) < 32 or JWT_SECRET_KEY.strip() == 'your-secret-key-change-this-in-production':
-        invalid_vars.append('JWT_SECRET_KEY (must be at least 32 characters and not use default value)')
-
-    if missing_vars or invalid_vars:
-        error_msg = '\n' + '=' * 80 + '\n'
-        error_msg += '❌ ERROR: Authentication configuration is REQUIRED in production!\n'
-        error_msg += '=' * 80 + '\n\n'
-
-        if missing_vars:
-            error_msg += '❌ Missing required environment variables:\n'
-            for var in missing_vars:
-                error_msg += f'  - {var}\n'
-            error_msg += '\n'
-
-        if invalid_vars:
-            error_msg += '❌ Invalid environment variables:\n'
-            for var in invalid_vars:
-                error_msg += f'  - {var}\n'
-            error_msg += '\n'
-
-        error_msg += 'Please set the following environment variables:\n'
-        error_msg += '  - ADMIN_USERNAME: Admin username for login (e.g., admin)\n'
-        error_msg += '  - ADMIN_PASSWORD: Admin password for login (e.g., admin123)\n'
-        error_msg += '  - JWT_SECRET_KEY: Secret key for JWT token (must be unique and secure)\n'
-        error_msg += '\n📝 Example (docker-compose.yml):\n'
-        error_msg += '  environment:\n'
-        error_msg += '    - ADMIN_USERNAME=admin\n'
-        error_msg += '    - ADMIN_PASSWORD=your-secure-password\n'
-        error_msg += '    - JWT_SECRET_KEY=your-unique-secret-key-here\n'
-        error_msg += '\n📝 Example (Docker run):\n'
-        error_msg += '  docker run -e ADMIN_USERNAME=admin \\\n'
-        error_msg += '             -e ADMIN_PASSWORD=your-secure-password \\\n'
-        error_msg += '             -e JWT_SECRET_KEY=your-unique-secret-key-here \\\n'
-        error_msg += '             ...\n'
-        error_msg += '\n💡 For local development without auth:\n'
-        error_msg += '  export SKIP_AUTH_CHECK=true\n'
-        error_msg += '=' * 80 + '\n'
-
-        print(error_msg, flush=True)
-        import sys
-        sys.exit(1)
+    print('\n' + '=' * 80)
+    print('INFO: Running WITHOUT authentication')
+    print('=' * 80)
+    print('⚠️  Authentication is DISABLED. Anyone can access the application.')
+    print('')
+    print('To enable authentication, set:')
+    print('  ADMIN_USERNAME=admin')
+    print('  ADMIN_PASSWORD=your-password')
+    print('  JWT_SECRET_KEY=your-secret-key')
+    print('=' * 80 + '\n', flush=True)

--- a/doc/README.md
+++ b/doc/README.md
@@ -166,7 +166,7 @@ services:
 
 启动：`docker-compose up -d`，访问 `http://localhost` 即可使用。
 
-> 请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值，生产环境务必更新凭据。
+> 认证是可选的：不设置 `ADMIN_USERNAME` / `ADMIN_PASSWORD` 即无需登录直接使用；设置后才开启登录，此时请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值。
 > Sub-Store 用于订阅解析和节点格式转换，也可在「配置生成」页面配置已有的 Sub-Store 地址。
 
 [查看完整部署指南 →](module/deployment.md)

--- a/doc/install_guide.md
+++ b/doc/install_guide.md
@@ -44,7 +44,7 @@ services:
 - 访问 `http://localhost`，出现登录页说明部署成功。
 - `./data` 保存 ConfigFlow 数据，`./sub-store-data` 保存 Sub-Store 数据，方便以后迁移或备份。
 
-> 请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值，生产环境务必更新凭据。
+> 认证是可选的：不设置 `ADMIN_USERNAME` / `ADMIN_PASSWORD` 即无需登录直接使用；设置后才开启登录，此时请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值。
 > Sub-Store 用于订阅解析和节点格式转换。如果已有 Sub-Store 服务，可移除 `sub-store` 部分，在「配置生成」页面配置已有的 Sub-Store URL。
 
 ---

--- a/doc/module/deployment.md
+++ b/doc/module/deployment.md
@@ -25,7 +25,7 @@ docker run -d \
 
 访问 `http://localhost` 即可使用。
 
-> 请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值，生产环境务必更新凭据。
+> 认证是可选的：不设置 `ADMIN_USERNAME` / `ADMIN_PASSWORD` 即无需登录直接使用；设置后才开启登录，此时请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值。
 
 ### 参数说明
 
@@ -129,7 +129,7 @@ docker-compose up -d
 
 访问 `http://localhost` 即可使用。
 
-> 请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值，生产环境务必更新凭据。
+> 认证是可选的：不设置 `ADMIN_USERNAME` / `ADMIN_PASSWORD` 即无需登录直接使用；设置后才开启登录，此时请把 `ADMIN_PASSWORD` 和 `JWT_SECRET_KEY` 替换为更安全的值。
 > 如果已有 Sub-Store 服务，可移除 `sub-store` 部分，在「配置生成」页面配置已有的 Sub-Store URL。
 
 ### 配置说明

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,12 +21,11 @@ services:
     environment:
       - DATA_DIR=/data
       - SUB_STORE_URL=http://sub-store:3001
-      # 登录认证配置（生产环境必需，请修改默认密码和密钥）
-      # 本地开发可以设置 SKIP_AUTH_CHECK=true 跳过认证
-      - ADMIN_USERNAME=admin
-      - ADMIN_PASSWORD=admin123
-      - JWT_SECRET_KEY=your-secret-key-please-change-in-production  # 必须修改为唯一的密钥
-      # - SKIP_AUTH_CHECK=true  # 取消注释以禁用认证（仅用于开发测试）
+      # 登录认证配置（可选：不设置则不需要登录，设置后才开启认证）
+      # 需要登录时取消下面三行注释，并改成自己的用户名/密码/密钥
+      # - ADMIN_USERNAME=admin
+      # - ADMIN_PASSWORD=your-secure-password
+      # - JWT_SECRET_KEY=your-unique-secret-key-at-least-32-chars
 
   sub-store:
     image: xream/sub-store:latest


### PR DESCRIPTION
## 背景
1.0 用户升级到 1.2 时，如果没有设置 \`ADMIN_USERNAME\` / \`ADMIN_PASSWORD\` / \`JWT_SECRET_KEY\`，`validate_required_env_vars()` 会在生产环境直接 `sys.exit(1)`，容器起不来。需求：**不需要任何授权也能正常使用**。

## 变更
- `backend/common/auth.py`
  - 删除生产环境强制校验 + 硬退出逻辑，`validate_required_env_vars()` 只在未开启认证时打印一次提示
  - 移除 `SKIP_AUTH_CHECK` 环境变量（强制校验没了，跳过开关也就没有存在意义）
  - `JWT_SECRET_KEY` 未配置时改为 `secrets.token_urlsafe(48)` 随机生成，避免沿用可预测的硬编码默认密钥
- `docker/docker-compose.yml`：三个认证变量改为注释掉的可选项
- `doc/README.md` / `doc/install_guide.md` / `doc/module/deployment.md`：说明认证为可选

认证行为本身没变：`is_auth_enabled()` 依旧以「是否同时设置用户名和密码」为开关，设置了就要求登录，没设置就直接放行。

## 验证
本地跑真实模块（venv + PyJWT/Flask），两个场景：

场景 1 — 清空所有认证变量、`DATA_DIR=/data`（即老用户升级场景，旧代码在此会 exit 1）：
```
INFO: Running WITHOUT authentication
⚠️  Authentication is DISABLED. Anyone can access the application.
auth_enabled = False
secret 非硬编码默认值 = True 长度 64
```
进程正常返回，未退出。

场景 2 — 设置 `ADMIN_USERNAME/ADMIN_PASSWORD/JWT_SECRET_KEY`：
```
auth_enabled = True
token verify = admin
```
登录签发/校验链路正常。

其他：`python3 -m py_compile backend/common/auth.py` 通过；`yaml.safe_load(docker-compose.yml)` 解析通过，env 只剩 `DATA_DIR` 与 `SUB_STORE_URL`。

## 风险
默认部署将**无需登录即可访问**，这是本次需求的明确目标。需要认证的用户按 compose/文档取消注释三个变量即可。