### PR TITLE
feat: add multi-profile configuration management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,31 +23,37 @@ dist/
 *.swo
 .claude/
 
-# Config
-config.json
-backend/*.yaml
-backend/*.conf
+# Runtime configuration and generated data only
+/config.json
+/backend/config.json
+/system.json
+/system.json.lock
+/profiles/
+/cache/
+/generated/
+/backup/
+/backend/rules/
+/backend/statics/
+/backend/providers/
+/backend/subscribes/
+/data/
+/backend/data/metrics/
+
+!*.example.json
+!*.sample.json
+!*.example.yaml
+!*.sample.yaml
 
 # Logs
 *.log
-backend/config.json
-frontend/node_modules/
-frontend/dist/
 
 # License keys (IMPORTANT: Never commit private keys!)
 keys/
 private_key.pem
 *.pem.private
-/backend/rules/
-/backend/statics/
-/backend/providers/
-/backend/subscribes/
+
 /frontend/dist.zip
-backup/
-/data/
 /backend/agents/go-agent/agent-test
-/backend/data/metrics/agent_1762946067748_metrics.json
-/backend/agents/go-agent/config.example.json
 /backend/agents/go-agent/config.test.json
 /backend/agents/go-agent/test_local.sh
 /backend/agents/go-agent/test_metrics.go

--- a/backend/agents/go-agent/client.go
+++ b/backend/agents/go-agent/client.go
@@ -47,25 +47,31 @@ func (c *Config) sendRegisterRequest(reqBody RegisterRequest) (*RegisterResponse
 		log.Printf("Failed to marshal register request: %v", err)
 		return nil, fmt.Errorf("failed to marshal register request: %w", err)
 	}
-	
-	log.Printf("Register request body: %s", string(jsonData))
+
+	log.Printf("Register request prepared (body length: %d)", len(jsonData))
 
 	registerURL := fmt.Sprintf("%s/api/agents/register", c.ServerURL)
 	log.Printf("Sending register request to: %s", registerURL)
-	resp, err := http.Post(registerURL, "application/json", bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest(http.MethodPost, registerURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Printf("Failed to create register request: %v", err)
+		return nil, fmt.Errorf("failed to create register request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Printf("Failed to send register request: %v", err)
 		return nil, fmt.Errorf("failed to send register request: %w", err)
 	}
 	defer resp.Body.Close()
-	
+
 	log.Printf("Register request response status: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
-		// 读取响应体以便记录错误信息
-		respBody := make([]byte, 1024)
-		n, _ := resp.Body.Read(respBody)
-		log.Printf("Register request failed with status code: %d, response: %s", resp.StatusCode, string(respBody[:n]))
+		log.Printf("Register request failed with status code: %d", resp.StatusCode)
 		return nil, fmt.Errorf("register request failed with status code: %d", resp.StatusCode)
 	}
 
@@ -74,7 +80,7 @@ func (c *Config) sendRegisterRequest(reqBody RegisterRequest) (*RegisterResponse
 		log.Printf("Failed to decode register response: %v", err)
 		return nil, fmt.Errorf("failed to decode register response: %w", err)
 	}
-	
+
 	log.Printf("Register response: success=%t, id=%s", regResp.Success, regResp.ID)
 	return &regResp, nil
 }
@@ -88,14 +94,16 @@ func (c *Config) handleRegisterResponse(regResp *RegisterResponse) error {
 
 	log.Printf("Registration successful! Agent ID: %s", regResp.ID)
 	c.AgentID = regResp.ID
-	c.Token = regResp.Token
+	if regResp.Token != "" {
+		c.Token = regResp.Token
+	}
 
 	log.Printf("Saving configuration...")
 	if err := c.Save(); err != nil {
 		log.Printf("Failed to save configuration: %v", err)
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
-	
+
 	log.Printf("Configuration saved successfully")
 	return nil
 }
@@ -115,8 +123,8 @@ func (c *Config) RegisterAgent() error {
 	if hostIP == "" {
 		hostIP = localIP
 	}
-	
-	log.Printf("Registering agent with name: %s, host: %s, port: %d, service_type: %s", 
+
+	log.Printf("Registering agent with name: %s, host: %s, port: %d, service_type: %s",
 		c.AgentName, hostIP, c.AgentPort, c.ServiceType)
 
 	reqBody := RegisterRequest{
@@ -198,7 +206,7 @@ func (c *Config) createHeartbeatRequest() ([]byte, error) {
 func (c *Config) sendHeartbeatRequest(jsonData []byte) error {
 	heartbeatURL := fmt.Sprintf("%s/api/agents/%s/heartbeat", c.ServerURL, c.AgentID)
 	logDebugf("Sending heartbeat to: %s", heartbeatURL)
-	
+
 	req, err := http.NewRequest("POST", heartbeatURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		log.Printf("Error: Failed to create heartbeat request: %v", err)
@@ -226,19 +234,16 @@ func (c *Config) sendHeartbeatRequest(jsonData []byte) error {
 			logDebugf("Heartbeat sent successfully (service status: %s)", status)
 		}
 	} else {
-		// 读取响应体以便记录错误信息
-		respBody := make([]byte, 1024)
-		n, _ := resp.Body.Read(respBody)
-		log.Printf("Error: Heartbeat failed with status code: %d, response: %s", resp.StatusCode, string(respBody[:n]))
+		log.Printf("Error: Heartbeat failed with status code: %d", resp.StatusCode)
 	}
-	
+
 	return nil
 }
 
 // SendHeartbeat 发送心跳
 func (c *Config) SendHeartbeat() {
 	log.Printf("Sending heartbeat...")
-	
+
 	if c.AgentID == "" || c.Token == "" {
 		log.Println("Skipping heartbeat: agent_id or token is empty.")
 		return

--- a/backend/agents/go-agent/client_test.go
+++ b/backend/agents/go-agent/client_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSendRegisterRequestAddsExistingBearerToken(t *testing.T) {
+	const token = "existing-go-token"
+	var gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"id":"agent-1"}`))
+	}))
+	defer server.Close()
+
+	config := &Config{ServerURL: server.URL, Token: token}
+	response, err := config.sendRegisterRequest(RegisterRequest{Name: "probe", Host: "10.0.0.8"})
+
+	if err != nil {
+		t.Fatalf("sendRegisterRequest returned error: %v", err)
+	}
+	if response.ID != "agent-1" {
+		t.Fatalf("unexpected response ID: %q", response.ID)
+	}
+	if gotAuthorization != "Bearer "+token {
+		t.Fatalf("Authorization = %q, want configured bearer", gotAuthorization)
+	}
+}
+
+func TestSendRegisterRequestWithoutTokenDoesNotAddAuthorization(t *testing.T) {
+	var gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"id":"agent-new","token":"new-token"}`))
+	}))
+	defer server.Close()
+
+	config := &Config{ServerURL: server.URL}
+	_, err := config.sendRegisterRequest(RegisterRequest{Name: "new", Host: "10.0.0.9"})
+
+	if err != nil {
+		t.Fatalf("sendRegisterRequest returned error: %v", err)
+	}
+	if gotAuthorization != "" {
+		t.Fatalf("Authorization = %q, want empty", gotAuthorization)
+	}
+}
+
+func TestHandleRegisterResponsePreservesExistingTokenWhenResponseOmitsToken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	config := &Config{AgentID: "agent-1", Token: "keep-token", filePath: path}
+
+	if err := config.handleRegisterResponse(&RegisterResponse{Success: true, ID: "agent-1"}); err != nil {
+		t.Fatalf("handleRegisterResponse returned error: %v", err)
+	}
+	if config.Token != "keep-token" {
+		t.Fatalf("Token = %q, want existing token", config.Token)
+	}
+	assertSavedToken(t, path, "keep-token")
+}
+
+func TestHandleRegisterResponseStoresTokenForFirstRegistration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	config := &Config{filePath: path}
+
+	if err := config.handleRegisterResponse(&RegisterResponse{
+		Success: true,
+		ID:      "agent-new",
+		Token:   "issued-token",
+	}); err != nil {
+		t.Fatalf("handleRegisterResponse returned error: %v", err)
+	}
+	if config.AgentID != "agent-new" || config.Token != "issued-token" {
+		t.Fatalf("unexpected registration state: id=%q token=%q", config.AgentID, config.Token)
+	}
+	assertSavedToken(t, path, "issued-token")
+}
+
+func assertSavedToken(t *testing.T, path, expected string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	var saved Config
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("decode saved config: %v", err)
+	}
+	if saved.Token != expected {
+		t.Fatalf("saved token = %q, want %q", saved.Token, expected)
+	}
+}

--- a/backend/agents/go-agent/install-script.txt
+++ b/backend/agents/go-agent/install-script.txt
@@ -443,7 +443,7 @@ register_to_server() {
 
     log "注册数据: $json_data"
 
-    # 发送注册请求
+    # 发送注册请求；响应可能包含令牌，禁止写入日志
     local response=$(curl -s -w "\n%{http_code}" -X POST "$register_url" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
@@ -453,7 +453,7 @@ register_to_server() {
     local body=$(echo "$response" | sed '$d')
 
     log "注册响应状态码: $http_code"
-    log "注册响应内容: $body"
+
 
     if [ "$http_code" = "200" ]; then
         # 解析 JSON 响应
@@ -514,9 +514,8 @@ send_heartbeat() {
 
     local json_data="{\"version\":\"$AGENT_VERSION\",\"service_status\":\"$service_status\"}"
 
-    # 打印心跳命令（方便调试）
-    local token_prefix=$(echo "$TOKEN" | cut -c1-10)
-    log "发送心跳: curl -X POST '$heartbeat_url' -H 'Authorization: Bearer ${token_prefix}...' -H 'Content-Type: application/json' -d '$json_data'"
+    # 打印脱敏后的心跳命令（不得泄露任何令牌片段）
+    log "发送心跳: curl -X POST '$heartbeat_url' -H 'Authorization: Bearer ***' -H 'Content-Type: application/json' -d '$json_data'"
 
     # 发送心跳并记录详细结果
     local response=$(curl -s -w "\n%{http_code}" --connect-timeout 5 --max-time 10 -X POST "$heartbeat_url" \
@@ -532,12 +531,12 @@ send_heartbeat() {
 
     if [ $exit_code -ne 0 ]; then
         log_error "心跳发送失败: curl 退出码 $exit_code"
-        log_error "完整响应: $response"
+        log_error "心跳请求未完成（响应长度: ${#response}）"
     elif [ "$http_code" = "200" ]; then
         log "心跳发送成功 (服务状态: $service_status)"
     else
         log_error "心跳发送失败，HTTP状态码: $http_code"
-        log_error "响应内容: $body"
+        log_error "响应内容未记录（响应长度: ${#body}）"
     fi
 }
 
@@ -567,7 +566,7 @@ restart_service() {
         local http_code=$(echo "$response" | tail -n1)
         local body=$(echo "$response" | sed '$d')
 
-        log "重启请求响应: HTTP状态码=$http_code, 响应内容=$body"
+        log "重启请求响应: HTTP状态码=$http_code, 响应长度=${#body}"
 
         if [ "$http_code" = "200" ] || [ "$http_code" = "204" ]; then
             log "服务重启成功 (URL方式)"

--- a/backend/agents/go-agent/routes/auth.go
+++ b/backend/agents/go-agent/routes/auth.go
@@ -1,32 +1,40 @@
 package routes
 
 import (
-	"net/http"
+	"crypto/subtle"
 	"log"
-	"fmt"
+	"net/http"
 )
+
+const (
+	bearerPrefix         = "Bearer "
+	maxBearerTokenLength = 4096
+)
+
+func parseBearerToken(authHeader string) ([]byte, bool) {
+	if len(authHeader) <= len(bearerPrefix) || len(authHeader) > len(bearerPrefix)+maxBearerTokenLength {
+		return nil, false
+	}
+	if authHeader[:len(bearerPrefix)] != bearerPrefix {
+		return nil, false
+	}
+
+	token := []byte(authHeader[len(bearerPrefix):])
+	for _, char := range token {
+		if char < 0x21 || char > 0x7e {
+			return nil, false
+		}
+	}
+	return token, true
+}
 
 // AuthMiddleware 验证请求的 Bearer Token
 func AuthMiddleware(cfg *Config, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			log.Printf("Authorization header missing")
+		token, valid := parseBearerToken(r.Header.Get("Authorization"))
+		if !valid || subtle.ConstantTimeCompare(token, []byte(cfg.Token)) != 1 {
+			log.Printf("Authorization rejected")
 			JsonResponse(w, http.StatusUnauthorized, map[string]string{"success": "false", "message": "Unauthorized"})
-			return
-		}
-
-		token := ""
-		n, err := fmt.Sscanf(authHeader, "Bearer %s", &token)
-		if err != nil || n != 1 {
-			log.Printf("Failed to parse authorization header: %v, parsed tokens: %d", err, n)
-			JsonResponse(w, http.StatusUnauthorized, map[string]string{"success": "false", "message": "Invalid authorization header format"})
-			return
-		}
-
-		if token != cfg.Token {
-			log.Printf("Invalid token provided. Expected: %s, Got: %s", cfg.Token, token)
-			JsonResponse(w, http.StatusUnauthorized, map[string]string{"success": "false", "message": "Invalid token"})
 			return
 		}
 		next(w, r)

--- a/backend/agents/go-agent/routes/auth_test.go
+++ b/backend/agents/go-agent/routes/auth_test.go
@@ -1,0 +1,118 @@
+package routes
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAuthMiddlewareStrictAuthorizationGrammar(t *testing.T) {
+	const token = "valid-auth-token-7f3c"
+	longToken := strings.Repeat("a", 4097)
+	tests := []struct {
+		name        string
+		header      string
+		configToken string
+		wantStatus  int
+	}{
+		{name: "valid", header: "Bearer " + token, configToken: token, wantStatus: http.StatusNoContent},
+		{name: "missing", configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "empty token", header: "Bearer ", configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "lowercase scheme", header: "bearer " + token, configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "tab separator", header: "Bearer\t" + token, configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "two spaces", header: "Bearer  " + token, configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "trailing field", header: "Bearer " + token + " extra", configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "trailing tab", header: "Bearer " + token + "\textra", configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "unicode token", header: "Bearer 令牌", configToken: "令牌", wantStatus: http.StatusUnauthorized},
+		{name: "unicode scheme", header: "Beáer " + token, configToken: token, wantStatus: http.StatusUnauthorized},
+		{name: "overlong token", header: "Bearer " + longToken, configToken: longToken, wantStatus: http.StatusUnauthorized},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			if test.header != "" {
+				request.Header.Set("Authorization", test.header)
+			}
+			response := httptest.NewRecorder()
+			called := false
+			handler := AuthMiddleware(&Config{Token: test.configToken}, func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			handler(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", response.Code, test.wantStatus)
+			}
+			if called != (test.wantStatus == http.StatusNoContent) {
+				t.Fatalf("protected handler called = %v", called)
+			}
+		})
+	}
+}
+
+func TestParseBearerTokenFuzzLikeByteCases(t *testing.T) {
+	for value := 0; value <= 255; value++ {
+		candidate := "left" + string([]byte{byte(value)}) + "right"
+		parsed, valid := parseBearerToken("Bearer " + candidate)
+		wantValid := value >= 0x21 && value <= 0x7e
+		if valid != wantValid {
+			t.Fatalf("byte 0x%02x validity = %v, want %v", value, valid, wantValid)
+		}
+		if valid && string(parsed) != candidate {
+			t.Fatalf("byte 0x%02x parsed token = %q, want %q", value, parsed, candidate)
+		}
+	}
+
+	validBoundary := strings.Repeat("z", maxBearerTokenLength)
+	if _, valid := parseBearerToken("Bearer " + validBoundary); !valid {
+		t.Fatal("maximum-length ASCII token was rejected")
+	}
+	if _, valid := parseBearerToken("Bearer " + validBoundary + "z"); valid {
+		t.Fatal("overlong token was accepted")
+	}
+
+	for index := range bearerPrefix {
+		mutated := []byte(bearerPrefix + "token")
+		mutated[index] ^= 1
+		if _, valid := parseBearerToken(string(mutated)); valid {
+			t.Fatalf("mutated prefix at byte %d was accepted", index)
+		}
+	}
+}
+
+func TestAuthMiddlewareRejectsInvalidTokenWithoutLoggingOrEchoingSecrets(t *testing.T) {
+	const expectedToken = "expected-auth-token-7f3c"
+	const providedToken = "provided-auth-token-a91e"
+
+	var logs bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(originalWriter)
+
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	request.Header.Set("Authorization", "Bearer "+providedToken)
+	response := httptest.NewRecorder()
+	handler := AuthMiddleware(&Config{Token: expectedToken}, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("invalid token reached protected handler")
+	})
+
+	handler(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+	}
+	body := response.Body.String()
+	if strings.Contains(body, expectedToken) || strings.Contains(body, providedToken) {
+		t.Fatalf("response echoed an authentication token: %q", body)
+	}
+	output := logs.String()
+	if strings.Contains(output, expectedToken) || strings.Contains(output, providedToken) {
+		t.Fatalf("authentication failure log leaked a token: %q", output)
+	}
+}

--- a/backend/agents/go-agent/routes/restart.go
+++ b/backend/agents/go-agent/routes/restart.go
@@ -2,11 +2,11 @@ package routes
 
 import (
 	"fmt"
-	"net/http"
+	"io"
 	"log"
+	"net/http"
 	"os/exec"
 	"strings"
-	"io"
 )
 
 // RestartService 执行服务重启命令，返回命令输出。
@@ -63,10 +63,10 @@ func RestartHandler(cfg *Config) http.HandlerFunc {
 				if startErr != nil {
 					log.Printf("Start command also failed: %v\nOutput: %s", startErr, string(startOutput))
 					JsonResponse(w, http.StatusInternalServerError, map[string]interface{}{
-						"success": false,
-						"message": "Restart and start both failed",
+						"success":        false,
+						"message":        "Restart and start both failed",
 						"restart_output": string(output),
-						"start_output": string(startOutput),
+						"start_output":   string(startOutput),
 					})
 					return
 				}
@@ -88,7 +88,7 @@ func RestartHandler(cfg *Config) http.HandlerFunc {
 // executeURLCommand 执行URL格式的命令
 func executeURLCommand(command string) ([]byte, error) {
 	log.Printf("Executing command: %s", command)
-	
+
 	// 检查是否为URL格式的命令
 	if strings.HasPrefix(command, "http://") || strings.HasPrefix(command, "https://") {
 		log.Printf("Executing URL command: %s", command)
@@ -99,32 +99,32 @@ func executeURLCommand(command string) ([]byte, error) {
 			return nil, fmt.Errorf("failed to execute URL command: %w", err)
 		}
 		defer resp.Body.Close()
-		
+
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response: %v", err)
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
-		
+
 		if resp.StatusCode >= 400 {
-			log.Printf("URL command failed with status %d: %s", resp.StatusCode, string(body))
-			return body, fmt.Errorf("URL command failed with status %d: %s", resp.StatusCode, string(body))
+			log.Printf("URL command failed with status %d", resp.StatusCode)
+			return body, fmt.Errorf("URL command failed with status %d", resp.StatusCode)
 		}
-		
+
 		log.Printf("URL command executed successfully")
 		return body, nil
 	}
-	
+
 	// 否则执行普通的shell命令
 	log.Printf("Executing shell command: %s", command)
-	
+
 	// 特殊处理 supervisorctl 命令，确保使用正确的配置文件路径
 	if strings.Contains(command, "supervisorctl") && !strings.Contains(command, "-c") {
 		// 在命令中添加配置文件路径
 		command = strings.Replace(command, "supervisorctl", "supervisorctl -c /etc/supervisor/supervisord.conf", 1)
 		log.Printf("Modified supervisorctl command: %s", command)
 	}
-	
+
 	cmd := exec.Command("sh", "-c", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/backend/agents/go-agent/routes/utils.go
+++ b/backend/agents/go-agent/routes/utils.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"encoding/json"
-	"net/http"
 	"log"
+	"net/http"
 )
 
 // JsonResponse 是一个辅助函数，用于统一返回JSON响应
@@ -13,7 +13,7 @@ func JsonResponse(w http.ResponseWriter, statusCode int, data interface{}) {
 	if data != nil {
 		// 添加错误日志记录
 		if statusCode >= 400 {
-			log.Printf("Returning error response: %d, data: %v", statusCode, data)
+			log.Printf("Returning error response: %d", statusCode)
 		}
 		json.NewEncoder(w).Encode(data)
 	}

--- a/backend/agents/manager.py
+++ b/backend/agents/manager.py
@@ -10,20 +10,31 @@ from .metrics_history import MetricsHistory
 class AgentManager:
     """Agent 管理器，负责 Agent 的注册、心跳、状态管理等"""
 
-    def __init__(self, config_data: Dict[str, Any]):
+    def __init__(self, repository):
         """
         初始化 Agent 管理器
 
         Args:
-            config_data: 全局配置数据字典
+            repository: system/profile 配置仓库
         """
-        self.config_data = config_data
-        # 确保 agents 字段存在
-        if 'agents' not in self.config_data:
-            self.config_data['agents'] = []
+        self.repository = repository
 
         # 初始化监控历史管理器
         self.metrics_history = MetricsHistory()
+
+    def _agents(self) -> List[Dict[str, Any]]:
+        return self.repository.get_system().get('agents', [])
+
+    def _update_agents(self, updater, profile_id=None):
+        result = {}
+
+        def update(system):
+            if profile_id:
+                self.repository._profile_metadata(profile_id, system)
+            result['value'] = updater(system.setdefault('agents', []))
+
+        self.repository.update_system_transaction(update)
+        return result.get('value')
 
     def register_agent(self, agent_data: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -40,58 +51,41 @@ class AgentManager:
         """
         agent_name = agent_data.get('name', 'Unnamed Agent')
         agent_host = agent_data.get('host', '')
+        requested_profile_id = agent_data.get('profile_id')
+        if requested_profile_id:
+            from backend.common.config import get_repository
+            get_repository().validate_profile_id(requested_profile_id)
 
-        # 查找是否已存在相同名称和地址的 Agent
-        agents = self.config_data.get('agents', [])
-        existing_agent = None
-        existing_index = -1
+        def register(agents):
+            existing_agent = next(
+                (agent for agent in agents if agent.get('name') == agent_name and agent.get('host') == agent_host),
+                None,
+            )
+            if existing_agent:
+                agent_id = existing_agent['id']
+                token = existing_agent['token']
+                updated_agent = {
+                    'id': agent_id,
+                    'name': agent_name,
+                    'host': agent_host,
+                    'port': agent_data.get('port', 8080),
+                    'token': token,
+                    'service_type': agent_data.get('service_type', 'mihomo'),
+                    'profile_id': requested_profile_id or existing_agent.get('profile_id', 'default'),
+                    'deployment_method': agent_data.get('deployment_method', existing_agent.get('deployment_method', 'unknown')),
+                    'status': 'online',
+                    'last_heartbeat': datetime.now().isoformat(),
+                    'version': agent_data.get('version', '1.0.0'),
+                    'config_version': existing_agent.get('config_version', '0'),
+                    'enabled': True,
+                    'created_at': existing_agent.get('created_at', datetime.now().isoformat()),
+                    'updated_at': datetime.now().isoformat(),
+                }
+                agents[agents.index(existing_agent)] = updated_agent
+                return {'id': agent_id, 'token': token, 'agent': updated_agent}
 
-        for i, agent in enumerate(agents):
-            if agent.get('name') == agent_name and agent.get('host') == agent_host:
-                existing_agent = agent
-                existing_index = i
-                break
-
-        if existing_agent:
-            # 已存在，更新记录（保留 ID 和 token）
-            agent_id = existing_agent['id']
-            token = existing_agent['token']
-
-            # 更新 Agent 信息
-            updated_agent = {
-                'id': agent_id,
-                'name': agent_name,
-                'host': agent_host,
-                'port': agent_data.get('port', 8080),
-                'token': token,
-                'service_type': agent_data.get('service_type', 'mihomo'),
-                'deployment_method': agent_data.get('deployment_method', existing_agent.get('deployment_method', 'unknown')),
-                'status': 'online',
-                'last_heartbeat': datetime.now().isoformat(),
-                'version': agent_data.get('version', '1.0.0'),
-                'config_version': existing_agent.get('config_version', '0'),
-                'enabled': True,
-                'created_at': existing_agent.get('created_at', datetime.now().isoformat()),
-                'updated_at': datetime.now().isoformat()
-            }
-
-            # 更新列表中的记录
-            self.config_data['agents'][existing_index] = updated_agent
-
-            return {
-                'id': agent_id,
-                'token': token,
-                'agent': updated_agent
-            }
-        else:
-            # 不存在，创建新记录
-            # 生成唯一 ID
-            agent_id = f"agent_{int(datetime.now().timestamp() * 1000)}"
-
-            # 生成随机 token（32 字符）
+            agent_id = f"agent_{int(datetime.now().timestamp() * 1000)}_{secrets.token_hex(3)}"
             token = secrets.token_urlsafe(24)
-
-            # 构建 Agent 完整信息
             agent = {
                 'id': agent_id,
                 'name': agent_name,
@@ -99,27 +93,23 @@ class AgentManager:
                 'port': agent_data.get('port', 8080),
                 'token': token,
                 'service_type': agent_data.get('service_type', 'mihomo'),
+                'profile_id': requested_profile_id or 'default',
                 'deployment_method': agent_data.get('deployment_method', 'unknown'),
                 'status': 'online',
                 'last_heartbeat': datetime.now().isoformat(),
                 'version': agent_data.get('version', '1.0.0'),
-                'config_version': '0',  # 初始配置版本
+                'config_version': '0',
                 'enabled': True,
-                'created_at': datetime.now().isoformat()
+                'created_at': datetime.now().isoformat(),
             }
+            agents.append(agent)
+            return {'id': agent_id, 'token': token, 'agent': agent}
 
-            # 添加到列表
-            self.config_data['agents'].append(agent)
-
-            return {
-                'id': agent_id,
-                'token': token,
-                'agent': agent
-            }
+        return self._update_agents(register, requested_profile_id)
 
     def get_all_agents(self) -> List[Dict[str, Any]]:
         """获取所有 Agent 列表"""
-        agents = self.config_data.get('agents', [])
+        agents = self._agents()
 
         # 更新在线状态（超过 2 分钟未心跳视为离线）
         now = datetime.now()
@@ -135,12 +125,12 @@ class AgentManager:
 
     def get_agent_by_id(self, agent_id: str) -> Optional[Dict[str, Any]]:
         """根据 ID 获取 Agent"""
-        agents = self.config_data.get('agents', [])
+        agents = self._agents()
         return next((a for a in agents if a['id'] == agent_id), None)
 
     def get_agent_by_token(self, token: str) -> Optional[Dict[str, Any]]:
         """根据 token 获取 Agent（用于认证）"""
-        agents = self.config_data.get('agents', [])
+        agents = self._agents()
         return next((a for a in agents if a.get('token') == token), None)
 
     def update_agent(self, agent_id: str, updates: Dict[str, Any]) -> bool:
@@ -154,27 +144,33 @@ class AgentManager:
         Returns:
             bool: 是否更新成功
         """
-        agents = self.config_data.get('agents', [])
-        for i, agent in enumerate(agents):
-            if agent['id'] == agent_id:
+        if 'profile_id' in updates:
+            self.repository.validate_profile_id(updates['profile_id'])
+
+        def update(agents):
+            for agent in agents:
+                if agent['id'] != agent_id:
+                    continue
                 # 更新允许的字段
-                allowed_fields = ['name', 'host', 'port', 'enabled', 'service_type']
+                allowed_fields = ['name', 'host', 'port', 'enabled', 'service_type', 'profile_id']
                 for field in allowed_fields:
                     if field in updates:
                         agent[field] = updates[field]
 
                 agent['updated_at'] = datetime.now().isoformat()
-                self.config_data['agents'][i] = agent
                 return True
+            return False
 
-        return False
+        return self._update_agents(update, updates.get('profile_id'))
 
     def delete_agent(self, agent_id: str) -> bool:
         """删除 Agent"""
-        agents = self.config_data.get('agents', [])
-        initial_len = len(agents)
-        self.config_data['agents'] = [a for a in agents if a['id'] != agent_id]
-        return len(self.config_data['agents']) < initial_len
+        def delete(agents):
+            initial_len = len(agents)
+            agents[:] = [agent for agent in agents if agent['id'] != agent_id]
+            return len(agents) < initial_len
+
+        return self._update_agents(delete)
 
     def update_heartbeat(self, agent_id: str, heartbeat_data: Dict[str, Any] = None) -> bool:
         """
@@ -187,9 +183,10 @@ class AgentManager:
         Returns:
             bool: 是否更新成功
         """
-        agents = self.config_data.get('agents', [])
-        for i, agent in enumerate(agents):
-            if agent['id'] == agent_id:
+        def update(agents):
+            for agent in agents:
+                if agent['id'] != agent_id:
+                    continue
                 agent['last_heartbeat'] = datetime.now().isoformat()
                 agent['status'] = 'online'  # Agent 在线状态
 
@@ -229,10 +226,10 @@ class AgentManager:
                     elif 'memory' in heartbeat_data:
                         agent['memory'] = heartbeat_data['memory']
 
-                self.config_data['agents'][i] = agent
                 return True
+            return False
 
-        return False
+        return self._update_agents(update)
 
     def push_config_to_agent(self, agent_id: str, config_content: str, extra_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
@@ -287,7 +284,14 @@ class AgentManager:
                 result = response.json()
                 # 更新配置版本
                 if result.get('success'):
-                    agent['config_version'] = config_md5[:8]
+                    def update_version(agents):
+                        for item in agents:
+                            if item['id'] == agent_id:
+                                item['config_version'] = config_md5[:8]
+                                return True
+                        return False
+
+                    self._update_agents(update_version)
                     return {'success': True, 'message': 'Config pushed successfully'}
                 else:
                     return {'success': False, 'message': result.get('message', 'Unknown error')}
@@ -621,14 +625,14 @@ class AgentManager:
                 result = response.json()
                 # 更新本地配置记录
                 if result.get('success'):
-                    agents = self.config_data.get('agents', [])
-                    for i, a in enumerate(agents):
-                        if a['id'] == agent_id:
-                            if 'logging_config' not in a:
-                                a['logging_config'] = {}
-                            a['logging_config']['enabled'] = enabled
-                            self.config_data['agents'][i] = a
-                            break
+                    def update_logging(agents):
+                        for item in agents:
+                            if item['id'] == agent_id:
+                                item.setdefault('logging_config', {})['enabled'] = enabled
+                                return True
+                        return False
+
+                    self._update_agents(update_logging)
                 return result
             else:
                 return {'success': False, 'message': f'HTTP {response.status_code}'}

--- a/backend/agents/manager.py
+++ b/backend/agents/manager.py
@@ -1,10 +1,21 @@
 """Agent 管理器"""
 import secrets
 import hashlib
+import hmac
 from datetime import datetime, timedelta
 from typing import Dict, Any, List, Optional
 import requests
 from .metrics_history import MetricsHistory
+
+
+def _constant_time_ascii_equal(provided: Any, expected: Any) -> bool:
+    """Compare credentials without timing leaks; non-ASCII is simply invalid."""
+    if not isinstance(provided, str) or not isinstance(expected, str):
+        return False
+    try:
+        return hmac.compare_digest(provided.encode('ascii'), expected.encode('ascii'))
+    except UnicodeEncodeError:
+        return False
 
 
 class AgentManager:
@@ -36,7 +47,11 @@ class AgentManager:
         self.repository.update_system_transaction(update)
         return result.get('value')
 
-    def register_agent(self, agent_data: Dict[str, Any]) -> Dict[str, Any]:
+    def register_agent(
+        self,
+        agent_data: Dict[str, Any],
+        existing_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         注册新的 Agent
 
@@ -47,7 +62,7 @@ class AgentManager:
             agent_data: Agent 信息，包含 name, host, port, service_type
 
         Returns:
-            Dict: 包含 id 和 token 的注册信息
+            Dict: 新 Agent 包含一次性返回的 token；已有 Agent 只返回非敏感状态
         """
         agent_name = agent_data.get('name', 'Unnamed Agent')
         agent_host = agent_data.get('host', '')
@@ -62,6 +77,8 @@ class AgentManager:
                 None,
             )
             if existing_agent:
+                if not _constant_time_ascii_equal(existing_token, existing_agent.get('token')):
+                    raise PermissionError('Unauthorized')
                 agent_id = existing_agent['id']
                 token = existing_agent['token']
                 updated_agent = {
@@ -82,7 +99,7 @@ class AgentManager:
                     'updated_at': datetime.now().isoformat(),
                 }
                 agents[agents.index(existing_agent)] = updated_agent
-                return {'id': agent_id, 'token': token, 'agent': updated_agent}
+                return {'id': agent_id, 'status': 'online', 'is_new': False}
 
             agent_id = f"agent_{int(datetime.now().timestamp() * 1000)}_{secrets.token_hex(3)}"
             token = secrets.token_urlsafe(24)
@@ -103,7 +120,12 @@ class AgentManager:
                 'created_at': datetime.now().isoformat(),
             }
             agents.append(agent)
-            return {'id': agent_id, 'token': token, 'agent': agent}
+            return {
+                'id': agent_id,
+                'status': 'online',
+                'is_new': True,
+                'token': token,
+            }
 
         return self._update_agents(register, requested_profile_id)
 

--- a/backend/agents/scripts/agent.sh
+++ b/backend/agents/scripts/agent.sh
@@ -133,6 +133,34 @@ get_local_ip() {
     fi
 }
 
+# 从 JSON 响应读取顶层字符串字段。优先使用 jq/python，最后用唯一字段回退。
+json_string_field() {
+    local json="$1"
+    local key="$2"
+    if command -v jq >/dev/null 2>&1; then
+        local value=$(printf '%s' "$json" | jq -r --arg key "$key" '.[$key] // empty' 2>/dev/null)
+        if [ -n "$value" ]; then
+            printf '%s' "$value"
+            return
+        fi
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        local value=$(printf '%s' "$json" | python3 -c 'import json,sys; d=json.load(sys.stdin); v=d.get(sys.argv[1], ""); print(v if isinstance(v,str) else "")' "$key" 2>/dev/null)
+        if [ -n "$value" ]; then
+            printf '%s' "$value"
+            return
+        fi
+    fi
+    if command -v python >/dev/null 2>&1; then
+        local value=$(printf '%s' "$json" | python -c 'import json,sys; d=json.load(sys.stdin); v=d.get(sys.argv[1], ""); print(v if isinstance(v,str) else "")' "$key" 2>/dev/null)
+        if [ -n "$value" ]; then
+            printf '%s' "$value"
+            return
+        fi
+    fi
+    printf '%s\n' "$json" | sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p"
+}
+
 # 注册到服务器
 register_to_server() {
     log "正在向主服务器注册..."
@@ -155,24 +183,40 @@ register_to_server() {
 
     log "注册数据: $json_data"
 
-    # 发送注册请求
-    local response=$(curl -s -w "\n%{http_code}" -X POST "$register_url" \
-        -H "Content-Type: application/json" \
-        -H "Accept: application/json" \
-        -d "$json_data" 2>&1)
+    # 已有令牌时进行真实 Bearer 认证，但日志只记录脱敏占位符。
+    local response=""
+    if [ -n "$TOKEN" ]; then
+        log "注册请求认证: Authorization: Bearer ***"
+        AUTH_HEADER="Authorization: Bearer $TOKEN"
+        response=$(curl -s -w "\n%{http_code}" -X POST "$register_url" \
+            -H "$AUTH_HEADER" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d "$json_data" 2>&1)
+    else
+        response=$(curl -s -w "\n%{http_code}" -X POST "$register_url" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d "$json_data" 2>&1)
+    fi
 
     local http_code=$(echo "$response" | tail -n1)
     local body=$(echo "$response" | sed '$d')
 
     log "注册响应状态码: $http_code"
-    log "注册响应内容: $body"
+    # 响应可能包含首次注册令牌，禁止写入日志。
 
     if [ "$http_code" = "200" ]; then
         # 解析 JSON 响应
         local success=$(echo "$body" | grep -o '"success"[[:space:]]*:[[:space:]]*true')
         if [ -n "$success" ]; then
-            local agent_id=$(echo "$body" | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
-            local token=$(echo "$body" | grep -o '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+            local agent_id=$(json_string_field "$body" "id")
+            local token=$(json_string_field "$body" "token")
+
+            # 合法重注册不会再次返回 token；此时必须保留本地现有令牌。
+            if [ -z "$token" ]; then
+                token="$TOKEN"
+            fi
 
             save_config "$agent_id" "$token"
             AGENT_ID="$agent_id"
@@ -226,13 +270,13 @@ send_heartbeat() {
 
     local json_data="{\"version\":\"$AGENT_VERSION\",\"service_status\":\"$service_status\"}"
 
-    # 打印心跳命令（方便调试）
-    local token_prefix=$(echo "$TOKEN" | cut -c1-10)
-    log "发送心跳: curl -X POST '$heartbeat_url' -H 'Authorization: Bearer ${token_prefix}...' -H 'Content-Type: application/json' -d '$json_data'"
+    # 打印脱敏后的心跳命令（不得泄露任何令牌片段）
+    log "发送心跳: curl -X POST '$heartbeat_url' -H 'Authorization: Bearer ***' -H 'Content-Type: application/json' -d '$json_data'"
 
-    # 发送心跳并记录详细结果
+    # 发送心跳并只记录非敏感结果
+    local heartbeat_auth_header="Authorization: Bearer $TOKEN"
     local response=$(curl -s -w "\n%{http_code}" --connect-timeout 5 --max-time 10 -X POST "$heartbeat_url" \
-        -H "Authorization: Bearer $TOKEN" \
+        -H "$heartbeat_auth_header" \
         -H "Content-Type: application/json" \
         -d "$json_data" 2>&1)
 
@@ -244,12 +288,12 @@ send_heartbeat() {
 
     if [ $exit_code -ne 0 ]; then
         log_error "心跳发送失败: curl 退出码 $exit_code"
-        log_error "完整响应: $response"
+        log_error "心跳请求未完成（响应长度: ${#response}）"
     elif [ "$http_code" = "200" ]; then
         log "心跳发送成功 (服务状态: $service_status)"
     else
         log_error "心跳发送失败，HTTP状态码: $http_code"
-        log_error "响应内容: $body"
+        log_error "响应内容未记录（响应长度: ${#body}）"
     fi
 }
 
@@ -279,7 +323,7 @@ restart_service() {
         local http_code=$(echo "$response" | tail -n1)
         local body=$(echo "$response" | sed '$d')
 
-        log "重启请求响应: HTTP状态码=$http_code, 响应内容=$body"
+        log "重启请求响应: HTTP状态码=$http_code, 响应长度=${#body}"
 
         if [ "$http_code" = "200" ] || [ "$http_code" = "204" ]; then
             log "服务重启成功 (URL方式)"
@@ -368,7 +412,7 @@ handle_http_request() {
     log "收到HTTP请求: $method $path"
 
     # 跳过 HTTP 头（改用更兼容的方式）
-    local auth_token=""
+    local auth_token=""""
     local content_length=""
     local line_count=0
     while IFS= read -r header; do
@@ -384,7 +428,7 @@ handle_http_request() {
 
         # 检查 Authorization 头
         if echo "$header" | grep -qi "^Authorization:"; then
-            auth_token=$(echo "$header" | sed 's/Authorization: *Bearer *//i')
+            auth_token=""$(echo "$header" | sed 's/Authorization: *Bearer *//i')
         fi
 
         # 检查 Content-Length
@@ -517,7 +561,7 @@ handle_http_request() {
                             # 如果数量为0，输出调试信息
                             if [ "$count" -eq 0 ]; then
                                 log_error "未能从 ruleset_downloads 中提取到规则集信息"
-                                log "检查 body 前 500 字符: $(echo "$body" | head -c 500)"
+                                log "请求体解析失败（长度: ${#body}）"
                             fi
 
                             # 逐行读取并下载

--- a/backend/common/agent_manager.py
+++ b/backend/common/agent_manager.py
@@ -1,6 +1,6 @@
 """Agent Manager 单例模块"""
 from backend.agents.manager import AgentManager
-from backend.common.config import config_data
+from backend.common.config import get_repository
 
 # 全局 agent_manager 实例
 _agent_manager = None
@@ -9,13 +9,14 @@ _agent_manager = None
 def get_agent_manager() -> AgentManager:
     """获取全局 AgentManager 实例"""
     global _agent_manager
-    if _agent_manager is None:
-        _agent_manager = AgentManager(config_data)
+    repository = get_repository()
+    if _agent_manager is None or _agent_manager.repository is not repository:
+        _agent_manager = AgentManager(repository)
     return _agent_manager
 
 
 def init_agent_manager():
     """初始化 AgentManager（在应用启动时调用）"""
     global _agent_manager
-    _agent_manager = AgentManager(config_data)
+    _agent_manager = AgentManager(get_repository())
     return _agent_manager

--- a/backend/common/auth.py
+++ b/backend/common/auth.py
@@ -46,7 +46,7 @@ def verify_token(token):
         return {'error': 'invalid', 'detail': str(e)}
 
 
-def validate_token_or_jwt(request_obj):
+def validate_token_or_jwt(request_obj, config=None):
     """验证 JWT token（前端）或 URL query token（外部客户端）
 
     Args:
@@ -60,8 +60,10 @@ def validate_token_or_jwt(request_obj):
         return {'valid': True}
 
     # 2. 检查 URL query token（用于外部客户端）
-    from backend.common.config import config_data
-    config_token = config_data.get('system_config', {}).get('config_token', '')
+    if config is None:
+        from backend.common.config import config_data
+        config = config_data
+    config_token = config.get('system_config', {}).get('config_token', '')
 
     # 如果没有启用认证，直接通过
     if not is_auth_enabled() and not config_token:
@@ -75,10 +77,6 @@ def validate_token_or_jwt(request_obj):
         # 如果 payload 不为 None 且不包含 error 键，说明验证成功
         if payload and not (isinstance(payload, dict) and 'error' in payload):
             return {'valid': True}
-
-    # 如果没有配置 config_token，允许无 token 访问（外部客户端）
-    if not config_token:
-        return {'valid': True}
 
     # 如果配置了 config_token，检查 URL query 参数中的 token
     url_token = request_obj.args.get('token', '')

--- a/backend/common/auth.py
+++ b/backend/common/auth.py
@@ -13,10 +13,28 @@ from backend.common.internal_call import is_internal_call
 JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY') or secrets.token_urlsafe(48)
 JWT_ALGORITHM = 'HS256'
 JWT_EXPIRATION_HOURS = 24
+MAX_AUTH_TOKEN_LENGTH = 8192
 
 # 登录配置（从环境变量读取）
 ADMIN_USERNAME = os.environ.get('ADMIN_USERNAME', '')  # 默认为空表示不需要登录
 ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD', '')
+
+
+def parse_bearer_token(auth_header):
+    """Return a strictly formatted ASCII Bearer token, or ``None``."""
+    if not isinstance(auth_header, str) or not auth_header.startswith('Bearer '):
+        return None
+    token = auth_header[len('Bearer '):]
+    if not token or len(token) > MAX_AUTH_TOKEN_LENGTH:
+        return None
+    if any(ord(char) < 0x21 or ord(char) > 0x7E for char in token):
+        return None
+    return token
+
+
+def is_token_within_length(token):
+    """Return whether a non-Bearer credential is a bounded non-empty string."""
+    return isinstance(token, str) and 0 < len(token) <= MAX_AUTH_TOKEN_LENGTH
 
 
 def is_auth_enabled():
@@ -63,23 +81,39 @@ def validate_token_or_jwt(request_obj, config=None):
     if config is None:
         from backend.common.config import config_data
         config = config_data
-    config_token = config.get('system_config', {}).get('config_token', '')
+    system_config = config.get('system_config', {}) or {}
+    config_token = system_config.get('config_token', '')
+    rule_proxy_token = system_config.get('rule_proxy_token', '')
+    retired_rule_proxy_tokens = system_config.get('retired_rule_proxy_tokens', [])
+    if not isinstance(retired_rule_proxy_tokens, list):
+        retired_rule_proxy_tokens = []
+    auth_header = request_obj.headers.get('Authorization', '')
+    bearer = parse_bearer_token(auth_header)
+    url_token = request_obj.args.get('token', '')
+    if not is_token_within_length(url_token):
+        url_token = ''
+
+    # The internal rule-proxy capability must never authenticate public APIs,
+    # even if persisted legacy state accidentally made both tokens equal.
+    internal_tokens = {
+        token for token in [rule_proxy_token, *retired_rule_proxy_tokens]
+        if isinstance(token, str) and token
+    }
+    if bearer in internal_tokens or url_token in internal_tokens:
+        return {'valid': False, 'message': 'Invalid or missing authentication'}
 
     # 如果没有启用认证，直接通过
     if not is_auth_enabled() and not config_token:
         return {'valid': True}
 
     # 1. 先检查 Authorization header (JWT token)
-    auth_header = request_obj.headers.get('Authorization')
-    if auth_header and auth_header.startswith('Bearer '):
-        token = auth_header.split(' ')[1]
-        payload = verify_token(token)
+    if bearer is not None:
+        payload = verify_token(bearer)
         # 如果 payload 不为 None 且不包含 error 键，说明验证成功
         if payload and not (isinstance(payload, dict) and 'error' in payload):
             return {'valid': True}
 
     # 如果配置了 config_token，检查 URL query 参数中的 token
-    url_token = request_obj.args.get('token', '')
     if url_token and url_token == config_token:
         return {'valid': True}
 
@@ -99,11 +133,10 @@ def require_auth(f):
             return f(*args, **kwargs)
 
         # 认证已启用，检查 token
-        auth_header = request.headers.get('Authorization')
-        if not auth_header or not auth_header.startswith('Bearer '):
+        token = parse_bearer_token(request.headers.get('Authorization'))
+        if token is None:
             return jsonify({'success': False, 'message': 'Unauthorized: Missing or invalid Authorization header'}), 401
 
-        token = auth_header.split(' ')[1]
         payload = verify_token(token)
 
         # 检查验证结果

--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -1,10 +1,14 @@
 """配置管理模块"""
 import os
 import json
-from typing import Dict, Any
+import copy
+from contextvars import ContextVar
+from collections.abc import MutableMapping, Iterator
+from typing import Callable, Dict, Any, Optional
 
 from backend.common.utils import get_local_ip
 from backend.common.resource import get_backend_resource
+from backend.common.config_repository import ProfileRepository
 from backend.utils.logger import get_logger
 
 # 获取当前模块的日志记录器
@@ -13,14 +17,11 @@ logger = get_logger(__name__)
 # 配置存储文件
 # 优先使用环境变量指定的路径，否则使用默认路径
 DATA_DIR = os.environ.get('DATA_DIR', '/data')
-if not os.path.exists(DATA_DIR):
+if not os.path.exists(DATA_DIR) and 'DATA_DIR' not in os.environ:
     DATA_DIR = '.'  # 开发模式，使用当前目录
 CONFIG_FILE = os.path.join(DATA_DIR, 'config.json')
 AGGREGATION_PROVIDERS_DIR = os.path.join(DATA_DIR, 'providers')
 
-# 确保聚合 providers 目录存在
-if not os.path.exists(AGGREGATION_PROVIDERS_DIR):
-    os.makedirs(AGGREGATION_PROVIDERS_DIR)
 
 # 全局配置初始化函数
 def get_default_config() -> Dict[str, Any]:
@@ -35,7 +36,7 @@ def get_default_config() -> Dict[str, Any]:
         'rule_library': [],  # 规则仓库
         'system_config': {  # 系统配置
             'server_domain': '',
-            'github_proxy_domain': {},
+            'github_proxy_domain': '',
         },
         'subscription_aggregations': [],
         'mihomo': {  # Mihomo 配置
@@ -65,127 +66,188 @@ def get_default_config() -> Dict[str, Any]:
 
     return config
 
-# 全局配置
-config_data: Dict[str, Any] = get_default_config()
 
-def get_config():
-    """获取全局配置"""
-    return config_data
+def _get_initial_config() -> Dict[str, Any]:
+    """Keep the existing first-start template separate from migration defaults."""
+    config = get_default_config()
+    template_file = get_backend_resource('config_template.json')
+    try:
+        with open(template_file, 'r', encoding='utf-8') as handle:
+            template = json.load(handle)
+        if isinstance(template, dict):
+            config = _deep_merge(config, template)
+    except (OSError, json.JSONDecodeError):
+        pass
+    return config
 
 
-def load_config():
-    """加载配置"""
-    global config_data, agent_manager
+_repository: Optional[ProfileRepository] = None
+_CONFIG_CACHE: ContextVar[Optional[Dict[str, Dict[str, Any]]]] = ContextVar(
+    'configflow_profile_cache', default=None
+)
+_CONFIG_BASELINES: ContextVar[Optional[Dict[str, Dict[str, Any]]]] = ContextVar(
+    'configflow_profile_baselines', default=None
+)
+
+
+def get_repository() -> ProfileRepository:
+    global _repository
+    if _repository is None:
+        _repository = ProfileRepository(
+            DATA_DIR,
+            default_config_factory=get_default_config,
+            initial_config_factory=_get_initial_config,
+        )
+    return _repository
+
+
+def set_repository(repository: ProfileRepository) -> None:
+    """Replace the repository for tests and embedded deployments."""
+    global _repository
+    _repository = repository
+    _CONFIG_CACHE.set({})
+    _CONFIG_BASELINES.set({})
+
+
+def _cache() -> Dict[str, Dict[str, Any]]:
+    cache = _CONFIG_CACHE.get()
+    if cache is None:
+        cache = {}
+        _CONFIG_CACHE.set(cache)
+    return cache
+
+
+def reset_config_context() -> None:
+    """Discard compatibility snapshots at request/task boundaries."""
+    _CONFIG_CACHE.set(None)
+    _CONFIG_BASELINES.set(None)
+
+
+class ProfileConfigProxy(MutableMapping[str, Any]):
+    """Compatibility mapping resolved to the current request profile."""
+
+    def _data(self) -> Dict[str, Any]:
+        return get_config()
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data()[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._data()[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._data()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data())
+
+    def __len__(self) -> int:
+        return len(self._data())
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> Dict[str, Any]:
+        return copy.deepcopy(self._data(), memo)
+
+
+config_data = ProfileConfigProxy()
+
+
+def get_config(profile_id: Optional[str] = None) -> Dict[str, Any]:
+    """Get a request-scoped compatibility view of a profile."""
+    from backend.common.profile_context import resolve_profile_id
+
+    resolved_id = resolve_profile_id(profile_id)
+    cache = _cache()
+    if resolved_id not in cache:
+        cache[resolved_id] = get_repository().get_compat_config(resolved_id)
+        baselines = _CONFIG_BASELINES.get()
+        if baselines is None:
+            baselines = {}
+            _CONFIG_BASELINES.set(baselines)
+        baselines[resolved_id] = copy.deepcopy(cache[resolved_id])
+    return cache[resolved_id]
+
+
+def load_config() -> Dict[str, Any]:
+    """Initialize storage and normalize the active profile."""
     import uuid
+    from backend.common.profile_context import resolve_profile_id
 
-    # 如果 config.json 是目录（Docker 挂载时可能发生），删除它
-    if os.path.isdir(CONFIG_FILE):
-        import shutil
-        shutil.rmtree(CONFIG_FILE)
+    repository = get_repository()
+    _CONFIG_CACHE.set({})
+    active_id = resolve_profile_id()
+    data = get_config(active_id)
+    changed = False
+    for node in data.get('nodes', []):
+        if 'id' not in node:
+            node['id'] = f"node_{uuid.uuid4().hex[:8]}"
+            changed = True
+    if clean_invalid_aggregation_references():
+        changed = True
+    if clean_invalid_proxy_group_aggregations():
+        changed = True
+    if not data.get('system_config', {}).get('server_domain', '').strip():
+        data.setdefault('system_config', {})['server_domain'] = f"http://{get_local_ip()}:5001"
+        changed = True
+    if changed:
+        save_config(data, active_id)
 
-    if os.path.exists(CONFIG_FILE) and os.path.isfile(CONFIG_FILE):
-        try:
-            with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
-                content = f.read().strip()
-                # 如果文件为空，使用默认配置
-                if not content:
-                    save_config()
-                    return
-                loaded_data = json.loads(content)
-
-            # 与默认配置递归合并，补齐旧版本 config.json 中缺失的配置节。
-            # 代码中存在直接按键访问（config_data['subscriptions'] 等），缺键会抛
-            # KeyError 导致接口 500、页面报「加载订阅列表失败」。用户已有的值优先。
-            missing_keys = [k for k in get_default_config() if k not in loaded_data]
-            merged_data = _deep_merge(get_default_config(), loaded_data)
-
-            # 这样所有持有 config_data 引用的对象（如 agent_manager）都能看到更新
-            config_data.clear()
-            config_data.update(merged_data)
-
-            if missing_keys:
-                logger.info(f"配置缺少顶层项，已补齐默认值: {', '.join(missing_keys)}")
-
-            # 为没有 ID 的节点生成 ID
-            nodes_updated = False
-            for node in config_data.get('nodes', []):
-                if 'id' not in node:
-                    node['id'] = f"node_{uuid.uuid4().hex[:8]}"
-                    nodes_updated = True
-
-            # 清理聚合中的无效引用
-            aggregations_cleaned = clean_invalid_aggregation_references()
-
-            # 清理策略组中对已删除/已禁用聚合的引用
-            proxy_groups_cleaned = clean_invalid_proxy_group_aggregations()
-
-            # 如果补齐了缺失项、节点被更新或聚合/策略组被清理，保存配置
-            if missing_keys or nodes_updated or aggregations_cleaned or proxy_groups_cleaned:
-                save_config()
-
-        except (json.JSONDecodeError, ValueError) as e:
-            # JSON 解析失败，使用默认配置
-            print(f"配置文件解析失败，使用默认配置: {e}")
-            save_config()
-    else:
-        # 配置文件不存在，尝试从模板初始化
-        # 使用 resource helper 获取模板文件路径（兼容开发环境和 PyInstaller 打包后的环境）
-        template_file = get_backend_resource('config_template.json')
-        if os.path.exists(template_file) and os.path.isfile(template_file):
-            try:
-                # 从模板加载配置
-                import shutil
-                shutil.copy(template_file, CONFIG_FILE)
-                print(f'已从模板初始化配置文件: {template_file} -> {CONFIG_FILE}')
-
-                # 读取模板配置并加载到 config_data
-                with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
-                    loaded_template = json.loads(f.read())
-
-                # 更新 config_data（不要重新赋值，而是清空并更新）
-                config_data.clear()
-                config_data.update(loaded_template)
-            except Exception as e:
-                print(f'从模板初始化配置失败，使用空配置: {e}')
-                save_config()
-        else:
-            # 模板文件不存在，创建默认空配置
-            save_config()
-
-
-    # 如果 server_domain 未配置，自动设置为 http://本机IP:5001
-    server_domain_updated = False
-    if not config_data.get('system_config', {}).get('server_domain', '').strip():
-        local_ip = get_local_ip()
-        if 'system_config' not in config_data:
-            config_data['system_config'] = {}
-        config_data['system_config']['server_domain'] = f"http://{local_ip}:5001"
-        server_domain_updated = True
-        logger.info(f"Server domain not configured, auto-detected and set to: {config_data['system_config']['server_domain']}")
-
-    # 如果 server_domain 被自动设置，保存配置
-    if server_domain_updated:
-        save_config()
-
-    # 初始化 Agent 管理器单例
-    # 注意：由于我们使用 config_data.clear() + update() 而不是重新赋值
-    # agent_manager 持有的 config_data 引用始终有效
-    # 这里重新初始化是为了确保 agent_manager 正确初始化
     from backend.common.agent_manager import init_agent_manager
     init_agent_manager()
+    return data
 
 
-def save_config():
-    """保存配置到文件"""
-    try:
-        # 创建要保存的配置副本
-        config_to_save = {**config_data}
-        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
-            json.dump(config_to_save, f, ensure_ascii=False, indent=2)
-        return True
-    except Exception as e:
-        print(f"Error saving config: {e}")
-        return False
+def save_config(config: Optional[Dict[str, Any]] = None, profile_id: Optional[str] = None) -> bool:
+    """Persist a profile while retaining the legacy call signature."""
+    from backend.common.profile_context import resolve_profile_id
+
+    resolved_id = resolve_profile_id(profile_id)
+    if config is None:
+        config = get_config(resolved_id)
+    repository = get_repository()
+    baseline = (_CONFIG_BASELINES.get() or {}).get(resolved_id, {})
+    profile_changes = {
+        key: value for key, value in config.items()
+        if key in repository.PROFILE_FIELDS and baseline.get(key) != value
+    }
+    if profile_changes:
+        repository.update_profile_fields(
+            resolved_id,
+            profile_changes,
+            baseline={key: baseline.get(key) for key in profile_changes},
+        )
+    system_changes = {
+        key: config[key] for key in ("system_config", "backup")
+        if key in config and baseline.get(key) != config[key]
+    }
+    if system_changes:
+        def update_system(system):
+            for key, value in system_changes.items():
+                if isinstance(system.get(key), dict) and isinstance(value, dict):
+                    system[key] = _deep_merge(system[key], value)
+                else:
+                    system[key] = copy.deepcopy(value)
+        repository.update_system_transaction(update_system)
+    _cache()[resolved_id] = copy.deepcopy(config)
+    baselines = _CONFIG_BASELINES.get()
+    if baselines is not None:
+        baselines[resolved_id] = copy.deepcopy(config)
+    return True
+
+
+def update_config_transaction(
+    updater: Callable[[Dict[str, Any]], Optional[Dict[str, Any]]],
+    profile_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Apply an incremental resource update to freshly locked profile data."""
+    from backend.common.profile_context import resolve_profile_id
+
+    resolved_id = resolve_profile_id(profile_id)
+    result = get_repository().update_profile_transaction(resolved_id, updater)
+    _cache().pop(resolved_id, None)
+    baselines = _CONFIG_BASELINES.get()
+    if baselines is not None:
+        baselines.pop(resolved_id, None)
+    return result
 
 
 def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
@@ -205,13 +267,15 @@ def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any
     return result
 
 
-def safe_import_config(new_data: Dict[str, Any]) -> None:
-    """安全导入配置：与默认配置递归合并，避免丢失字段。"""
-    default = get_default_config()
-    merged = _deep_merge(default, new_data)
-    config_data.clear()
-    config_data.update(merged)
-    save_config()
+def safe_import_config(new_data: Dict[str, Any], profile_id: Optional[str] = None) -> None:
+    """Safely import a legacy/full configuration into one profile."""
+    repository = get_repository()
+    profile_data = {
+        key: value for key, value in new_data.items()
+        if key not in repository.SYSTEM_FIELDS
+    }
+    merged = _deep_merge(get_config(profile_id), profile_data)
+    save_config(merged, profile_id)
 
 
 def clean_invalid_aggregation_references():

--- a/backend/common/config_export.py
+++ b/backend/common/config_export.py
@@ -1,0 +1,172 @@
+"""Safe copies of configuration data for external responses and exports."""
+
+import urllib.parse
+from collections import deque
+from typing import Any, Dict, Iterable, Optional
+
+
+SENSITIVE_SYSTEM_CONFIG_FIELDS = frozenset(
+    {"rule_proxy_token", "retired_rule_proxy_tokens"}
+)
+_DESENSITIZED = "***已脱敏***"
+_REDACTED = "[REDACTED]"
+
+
+def _repository_rule_proxy_tokens() -> Iterable[str]:
+    """Read capability tokens from the authoritative repository, not a response."""
+    from backend.common.config import get_repository
+
+    yield from get_repository().rule_proxy_tokens_for_sanitization()
+
+
+def _repository_agent_tokens() -> Iterable[str]:
+    """Collect persisted Agent credentials without exposing manager return values."""
+    from backend.common.config import get_repository
+
+    for agent in get_repository().get_system().get("agents", []):
+        if isinstance(agent, dict):
+            token = agent.get("token")
+            if isinstance(token, str) and token:
+                yield token
+
+
+def _contains_encoded_secret(value: str, secrets: set[str]) -> bool:
+    """Inspect bounded URL-decoding paths without enumerating encoding depth."""
+    pending = deque([value])
+    seen = {value}
+    max_states = max(1, 2 * len(value) + 1)
+    max_steps = 2 * max_states
+    states = 0
+    steps = 0
+
+    while pending and states < max_states and steps < max_steps:
+        current = pending.popleft()
+        states += 1
+        if any(secret in current for secret in secrets):
+            return True
+        for decoder in (urllib.parse.unquote, urllib.parse.unquote_plus):
+            if steps >= max_steps:
+                break
+            steps += 1
+            decoded = decoder(current)
+            if len(decoded) <= len(current) and decoded not in seen:
+                seen.add(decoded)
+                pending.append(decoded)
+    return False
+
+
+def contains_internal_rule_proxy_token(value: str) -> bool:
+    """Detect current/retired internal rule tokens through arbitrary URL encoding."""
+    if not isinstance(value, str):
+        return False
+    secrets = {token for token in _repository_rule_proxy_tokens() if token}
+    return _contains_encoded_secret(value, secrets)
+
+
+def sanitize_external_payload(
+    payload: Any, system_config: Optional[Dict[str, Any]] = None
+) -> Any:
+    """Remove the repository's internal token from arbitrary external payloads."""
+    secrets = set(_repository_rule_proxy_tokens())
+    secrets.update(_repository_agent_tokens())
+    if isinstance(system_config, dict):
+        secrets.update(
+            system_config.get(field)
+            for field in SENSITIVE_SYSTEM_CONFIG_FIELDS
+            if isinstance(system_config.get(field), str) and system_config[field]
+        )
+    secrets = {secret for secret in secrets if isinstance(secret, str) and secret}
+
+    # A response sanitizer is an availability boundary: it must not inherit
+    # Python's recursion limit or follow hostile object cycles.  Depth counts
+    # the root as zero; a container at the limit is replaced as one subtree.
+    max_depth = 128
+    root = [None]
+    active_container_ids: set[int] = set()
+    stack = [("visit", payload, 0, root, 0)]
+
+    while stack:
+        operation, *arguments = stack.pop()
+        if operation == "leave":
+            active_container_ids.remove(arguments[0])
+            continue
+        if operation == "finish_tuple":
+            items, target, target_key = arguments
+            target[target_key] = tuple(items)
+            continue
+        if operation == "finish_dict_item":
+            output, item = arguments
+            output[item[0]] = item[1]
+            continue
+
+        value, depth, target, target_key = arguments
+        is_container = isinstance(value, (dict, list, tuple))
+        if is_container and (
+            depth >= max_depth or id(value) in active_container_ids
+        ):
+            target[target_key] = _REDACTED
+            continue
+
+        if isinstance(value, dict):
+            output: Dict[Any, Any] = {}
+            target[target_key] = output
+            container_id = id(value)
+            active_container_ids.add(container_id)
+            stack.append(("leave", container_id))
+            for key, item_value in reversed(tuple(value.items())):
+                if key in SENSITIVE_SYSTEM_CONFIG_FIELDS:
+                    continue
+                item = [None, None]
+                stack.append(("finish_dict_item", output, item))
+                stack.append(("visit", item_value, depth + 1, item, 1))
+                stack.append(("visit", key, depth + 1, item, 0))
+            continue
+
+        if isinstance(value, list):
+            output_list = [None] * len(value)
+            target[target_key] = output_list
+            container_id = id(value)
+            active_container_ids.add(container_id)
+            stack.append(("leave", container_id))
+            for index in range(len(value) - 1, -1, -1):
+                stack.append(("visit", value[index], depth + 1, output_list, index))
+            continue
+
+        if isinstance(value, tuple):
+            output_items = [None] * len(value)
+            container_id = id(value)
+            active_container_ids.add(container_id)
+            stack.append(("leave", container_id))
+            stack.append(("finish_tuple", output_items, target, target_key))
+            for index in range(len(value) - 1, -1, -1):
+                stack.append(("visit", value[index], depth + 1, output_items, index))
+            continue
+
+        if isinstance(value, str) and _contains_encoded_secret(value, secrets):
+            target[target_key] = _REDACTED
+        else:
+            target[target_key] = value
+
+    return root[0]
+
+
+def sanitize_config_for_output(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return an external-safe copy while leaving internal configuration untouched."""
+    system_config = config.get("system_config")
+    return sanitize_external_payload(
+        config, system_config if isinstance(system_config, dict) else None
+    )
+
+
+def prepare_config_export(config: Dict[str, Any], *, desensitize: bool = False) -> Dict[str, Any]:
+    """Build a safe full or credential-desensitized configuration export."""
+    output = sanitize_config_for_output(config)
+    output.pop("profile_id", None)
+    if desensitize:
+        for subscription in output.get("subscriptions", []):
+            if isinstance(subscription, dict) and "url" in subscription:
+                subscription["url"] = _DESENSITIZED
+        for node in output.get("nodes", []):
+            if isinstance(node, dict) and "proxy_string" in node:
+                node["proxy_string"] = _DESENSITIZED
+    return output

--- a/backend/common/config_repository.py
+++ b/backend/common/config_repository.py
@@ -1,0 +1,820 @@
+"""Durable, profile-scoped configuration storage."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import shutil
+import tempfile
+import threading
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+
+class ProfileRepositoryError(Exception):
+    """Base error for profile storage operations."""
+
+
+class ProfileValidationError(ProfileRepositoryError, ValueError):
+    """Raised when a profile identifier is unsafe or malformed."""
+
+
+class ProfileNotFound(ProfileRepositoryError, KeyError):
+    """Raised when a profile does not exist."""
+
+
+class ProfileExists(ProfileRepositoryError, ValueError):
+    """Raised when a profile identifier is already in use."""
+
+
+class ProfileInUse(ProfileRepositoryError, ValueError):
+    """Raised when an agent still references a profile."""
+
+
+_PROFILE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+_THREAD_LOCKS: Dict[str, threading.RLock] = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    result: Dict[str, Any] = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+_MISSING = object()
+
+
+def _list_item_key(value: Any) -> Any:
+    if isinstance(value, dict) and isinstance(value.get("id"), (str, int)):
+        return ("id", value["id"])
+    try:
+        return ("value", json.dumps(value, sort_keys=True, ensure_ascii=False))
+    except (TypeError, ValueError):
+        return ("repr", repr(value))
+
+
+def _three_way_merge(current: Any, baseline: Any, proposed: Any) -> Any:
+    """Apply the caller's baseline-to-proposed delta to freshly read data."""
+    if proposed == baseline:
+        return copy.deepcopy(current)
+    if isinstance(current, dict) and isinstance(baseline, dict) and isinstance(proposed, dict):
+        result = copy.deepcopy(current)
+        for key in baseline.keys() - proposed.keys():
+            if result.get(key, _MISSING) == baseline[key]:
+                result.pop(key, None)
+        for key, value in proposed.items():
+            old_value = baseline.get(key, _MISSING)
+            if old_value is _MISSING:
+                if key not in result:
+                    result[key] = copy.deepcopy(value)
+                elif isinstance(result[key], dict) and isinstance(value, dict):
+                    result[key] = _deep_merge(result[key], value)
+            elif value != old_value:
+                result[key] = _three_way_merge(result.get(key), old_value, value)
+        return result
+    if isinstance(current, list) and isinstance(baseline, list) and isinstance(proposed, list):
+        baseline_by_key = {_list_item_key(item): item for item in baseline}
+        proposed_by_key = {_list_item_key(item): item for item in proposed}
+        proposed_keys = [_list_item_key(item) for item in proposed]
+        removed = baseline_by_key.keys() - proposed_by_key.keys()
+        result = [copy.deepcopy(item) for item in current if _list_item_key(item) not in removed]
+        result_positions = {_list_item_key(item): index for index, item in enumerate(result)}
+        for key in proposed_keys:
+            proposed_item = proposed_by_key[key]
+            if key not in baseline_by_key:
+                if key not in result_positions:
+                    result.append(copy.deepcopy(proposed_item))
+                    result_positions[key] = len(result) - 1
+            elif proposed_item != baseline_by_key[key] and key in result_positions:
+                index = result_positions[key]
+                result[index] = _three_way_merge(result[index], baseline_by_key[key], proposed_item)
+
+        baseline_order = [_list_item_key(item) for item in baseline]
+        retained_proposed_order = [key for key in proposed_keys if key in baseline_by_key]
+        retained_baseline_order = [key for key in baseline_order if key in proposed_by_key]
+        if retained_proposed_order != retained_baseline_order:
+            result_by_key = {_list_item_key(item): item for item in result}
+            ordered_keys = [key for key in proposed_keys if key in result_by_key]
+            ordered_keys.extend(key for key in result_by_key if key not in ordered_keys)
+            result = [result_by_key[key] for key in ordered_keys]
+        return result
+    return copy.deepcopy(proposed)
+
+
+def _default_profile_config() -> Dict[str, Any]:
+    return {
+        "subscriptions": [],
+        "nodes": [],
+        "subscription_aggregations": [],
+        "rule_configs": [],
+        "rule_library": [],
+        "proxy_groups": [],
+        "mihomo": {"custom_config": ""},
+        "mosdns": {
+            "direct_rulesets": [],
+            "proxy_rulesets": [],
+            "direct_rules": [],
+            "proxy_rules": [],
+            "local_dns": "",
+            "remote_dns": "",
+            "fallback_dns": "",
+            "default_forward": "forward_remote",
+            "custom_hosts": "",
+            "custom_config": "",
+            "custom_matches": [],
+            "custom_match_position": "tail",
+            "cache_enabled": True,
+            "cache_size": 10240,
+            "cache_lazy_ttl": 21600,
+            "cache_dump_enabled": True,
+            "cache_dump_file": "./cache.dump",
+            "cache_dump_interval": 300,
+        },
+        "surge": {"custom_config": "", "smart_groups": []},
+    }
+
+
+class ProfileRepository:
+    """Stores system metadata and isolated profile data under ``DATA_DIR``."""
+
+    DEFAULT_PROFILE_ID = "default"
+    SCHEMA_VERSION = 2
+    SYSTEM_FILE_NAME = "system.json"
+    LEGACY_FILE_NAME = "config.json"
+    PROFILE_FIELDS = frozenset(
+        {
+            "subscriptions",
+            "nodes",
+            "subscription_aggregations",
+            "rule_configs",
+            "rule_library",
+            "proxy_groups",
+            "mihomo",
+            "mosdns",
+            "surge",
+        }
+    )
+    SYSTEM_FIELDS = frozenset({"schema_version", "active_profile_id", "profiles", "agents", "system_config", "backup", "profile_id"})
+    DERIVED_DIRS = ("subscribes", "providers", "rules", "generated")
+
+    def __init__(
+        self,
+        data_dir: os.PathLike[str] | str,
+        default_config_factory: Optional[Callable[[], Dict[str, Any]]] = None,
+        initial_config_factory: Optional[Callable[[], Dict[str, Any]]] = None,
+    ) -> None:
+        self.data_dir = Path(data_dir).expanduser().resolve()
+        self.profiles_dir = self.data_dir / "profiles"
+        self.system_file = self.data_dir / self.SYSTEM_FILE_NAME
+        self.legacy_file = self.data_dir / self.LEGACY_FILE_NAME
+        self.migrations_dir = self.data_dir / "migrations"
+        self._default_config_factory = default_config_factory
+        self._initial_config_factory = initial_config_factory
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.profiles_dir.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _profile_defaults(self) -> Dict[str, Any]:
+        defaults = _default_profile_config()
+        if self._default_config_factory:
+            factory_data = self._default_config_factory() or {}
+            defaults = _deep_merge(defaults, {k: v for k, v in factory_data.items() if k not in self.SYSTEM_FIELDS})
+        return defaults
+
+    def _new_system(self) -> Dict[str, Any]:
+        timestamp = _now()
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "active_profile_id": self.DEFAULT_PROFILE_ID,
+            "profiles": [
+                {
+                    "id": self.DEFAULT_PROFILE_ID,
+                    "name": "Default",
+                    "description": "Default configuration profile",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                }
+            ],
+            "agents": [],
+            "system_config": {"server_domain": "", "github_proxy_domain": ""},
+            "backup": {},
+        }
+
+    def _initialize(self) -> None:
+        if self.system_file.exists():
+            system = self._read_json(self.system_file)
+            self._normalize_system(system)
+            self._ensure_profile_files(system)
+            return
+
+        if self.legacy_file.exists():
+            self._migrate_legacy()
+            return
+
+        system = self._new_system()
+        self._ensure_profile_layout(self.DEFAULT_PROFILE_ID)
+        initial_config = (
+            self._initial_config_factory()
+            if self._initial_config_factory
+            else self._profile_defaults()
+        )
+        if not isinstance(initial_config, dict):
+            initial_config = self._profile_defaults()
+        for key in ("agents", "system_config", "backup"):
+            if key not in initial_config:
+                continue
+            value = copy.deepcopy(initial_config[key])
+            if isinstance(system.get(key), dict) and isinstance(value, dict):
+                system[key] = _deep_merge(system[key], value)
+            else:
+                system[key] = value
+        for agent in system.get("agents", []):
+            if isinstance(agent, dict):
+                agent.setdefault("profile_id", self.DEFAULT_PROFILE_ID)
+        initial_config = {
+            key: copy.deepcopy(value)
+            for key, value in initial_config.items()
+            if key not in self.SYSTEM_FIELDS
+        }
+        self._write_profile_file(self.DEFAULT_PROFILE_ID, initial_config)
+        self._write_system(system)
+
+    def _read_json(self, path: Path) -> Dict[str, Any]:
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                value = json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise ProfileRepositoryError(f"Invalid JSON in {path}: {exc}") from exc
+        if not isinstance(value, dict):
+            raise ProfileRepositoryError(f"JSON object expected in {path}")
+        return value
+
+    def _normalize_system(self, system: Dict[str, Any], persist: bool = True) -> Dict[str, Any]:
+        changed = False
+        defaults = self._new_system()
+        for key, value in defaults.items():
+            if key not in system:
+                system[key] = copy.deepcopy(value)
+                changed = True
+        if system.get("schema_version") != self.SCHEMA_VERSION:
+            system["schema_version"] = self.SCHEMA_VERSION
+            changed = True
+        profiles = system.get("profiles")
+        if not isinstance(profiles, list):
+            profiles = []
+            system["profiles"] = profiles
+            changed = True
+        seen = set()
+        valid_profiles = []
+        for profile in profiles:
+            if not isinstance(profile, dict) or "id" not in profile:
+                changed = True
+                continue
+            self.validate_profile_id(profile["id"])
+            if profile["id"] in seen:
+                changed = True
+                continue
+            seen.add(profile["id"])
+            valid_profiles.append(profile)
+        if not valid_profiles:
+            valid_profiles = copy.deepcopy(defaults["profiles"])
+            changed = True
+        if not any(profile["id"] == self.DEFAULT_PROFILE_ID for profile in valid_profiles):
+            valid_profiles.insert(0, copy.deepcopy(defaults["profiles"][0]))
+            changed = True
+        if valid_profiles != profiles:
+            system["profiles"] = valid_profiles
+            changed = True
+        active = system.get("active_profile_id")
+        if not isinstance(active, str) or active not in {p["id"] for p in valid_profiles}:
+            system["active_profile_id"] = self.DEFAULT_PROFILE_ID
+            changed = True
+        if not isinstance(system.get("agents"), list):
+            system["agents"] = []
+            changed = True
+        if not isinstance(system.get("system_config"), dict):
+            system["system_config"] = {}
+            changed = True
+        if not isinstance(system.get("backup"), dict):
+            system["backup"] = {}
+            changed = True
+        for agent in system["agents"]:
+            if isinstance(agent, dict) and not agent.get("profile_id"):
+                agent["profile_id"] = self.DEFAULT_PROFILE_ID
+                changed = True
+        if changed and persist:
+            self._write_system(system)
+        return system
+
+    def _ensure_profile_layout(self, profile_id: str) -> Path:
+        profile_dir = self.profile_dir(profile_id)
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        for dirname in self.DERIVED_DIRS:
+            (profile_dir / dirname).mkdir(parents=True, exist_ok=True)
+        return profile_dir
+
+    def _ensure_profile_files(self, system: Dict[str, Any]) -> None:
+        for profile in system["profiles"]:
+            profile_id = profile["id"]
+            self._ensure_profile_layout(profile_id)
+            path = self._profile_path(profile_id)
+            if not path.exists():
+                self._write_profile_file(profile_id, self._profile_defaults())
+
+    def _migrate_legacy(self) -> None:
+        legacy_data = self._read_json(self.legacy_file)
+        migration_dir = self.migrations_dir / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        while migration_dir.exists():
+            migration_dir = self.migrations_dir / f"{migration_dir.name}-{uuid.uuid4().hex[:8]}"
+        migration_dir.mkdir(parents=True, exist_ok=False)
+        shutil.copy2(self.legacy_file, migration_dir / self.LEGACY_FILE_NAME)
+
+        profile_data = {
+            key: copy.deepcopy(value)
+            for key, value in legacy_data.items()
+            if key not in self.SYSTEM_FIELDS
+        }
+        profile_data = _deep_merge(self._profile_defaults(), profile_data)
+        system = self._new_system()
+        for key in ("agents", "system_config", "backup"):
+            if key in legacy_data:
+                system[key] = copy.deepcopy(legacy_data[key])
+        for agent in system.get("agents", []):
+            if isinstance(agent, dict):
+                agent.setdefault("profile_id", self.DEFAULT_PROFILE_ID)
+
+        self._ensure_profile_layout(self.DEFAULT_PROFILE_ID)
+        self._write_profile_file(self.DEFAULT_PROFILE_ID, profile_data)
+        self._copy_legacy_derived_data()
+        # system.json is the migration commit marker. Legacy files remain recoverable.
+        self._write_system(system)
+
+    def _copy_legacy_derived_data(self) -> None:
+        profile_dir = self.profile_dir(self.DEFAULT_PROFILE_ID)
+        for dirname in self.DERIVED_DIRS[:-1]:
+            source = self.data_dir / dirname
+            if source.is_dir():
+                shutil.copytree(source, profile_dir / dirname, dirs_exist_ok=True)
+        generated = profile_dir / "generated"
+        for filename in ("config.yaml", "config.conf"):
+            source = self.data_dir / filename
+            if source.is_file():
+                shutil.copy2(source, generated / filename)
+
+    @staticmethod
+    def validate_profile_id(profile_id: str) -> str:
+        if not isinstance(profile_id, str) or not _PROFILE_ID.fullmatch(profile_id):
+            raise ProfileValidationError("Invalid profile id")
+        return profile_id
+
+    def profile_dir(self, profile_id: str) -> Path:
+        self.validate_profile_id(profile_id)
+        root = self.profiles_dir.resolve()
+        candidate = (root / profile_id).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as exc:  # defensive check if validation changes later
+            raise ProfileValidationError("Profile path escapes profile directory") from exc
+        return candidate
+
+    def profile_path(self, profile_id: str, relative_path: str) -> Path:
+        if not isinstance(relative_path, str) or not relative_path or "\x00" in relative_path:
+            raise ProfileValidationError("Invalid profile relative path")
+        profile_root = self.profile_dir(profile_id)
+        candidate = (profile_root / relative_path).resolve()
+        try:
+            candidate.relative_to(profile_root)
+        except ValueError as exc:
+            raise ProfileValidationError("Profile path escapes profile directory") from exc
+        return candidate
+
+    def cache_dir(self, profile_id: str) -> Path:
+        return self.profile_dir(profile_id) / "subscribes"
+
+    def providers_dir(self, profile_id: str) -> Path:
+        return self.profile_dir(profile_id) / "providers"
+
+    def rules_dir(self, profile_id: str) -> Path:
+        return self.profile_dir(profile_id) / "rules"
+
+    def generated_dir(self, profile_id: str) -> Path:
+        return self.profile_dir(profile_id) / "generated"
+
+    def _profile_path(self, profile_id: str) -> Path:
+        return self.profile_dir(profile_id) / "config.json"
+
+    def _profile_operation_lock_path(self, profile_id: str) -> Path:
+        self.validate_profile_id(profile_id)
+        return self.profiles_dir / f".{profile_id}.operation.lock"
+
+    def _thread_lock(self, path: Path) -> threading.RLock:
+        key = str(path.resolve())
+        with _THREAD_LOCKS_GUARD:
+            return _THREAD_LOCKS.setdefault(key, threading.RLock())
+
+    @contextmanager
+    def _lock(self, path: Path) -> Iterator[None]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        thread_lock = self._thread_lock(path)
+        with thread_lock:
+            with path.open("a+b") as handle:
+                if handle.seek(0, os.SEEK_END) == 0:
+                    handle.write(b"0")
+                    handle.flush()
+                handle.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    if os.name == "nt":
+                        import msvcrt
+
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _write_atomic(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path: Optional[Path] = None
+        try:
+            fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+            temp_path = Path(temp_name)
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            if path.exists():
+                shutil.copy2(path, path.with_name(f"{path.name}.bak"))
+            os.replace(temp_path, path)
+            if os.name != "nt":
+                dir_fd = os.open(path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+        finally:
+            if temp_path and temp_path.exists():
+                temp_path.unlink()
+
+    def _write_json(self, path: Path, data: Dict[str, Any]) -> None:
+        self._write_atomic(path, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+    def _write_system(self, system: Dict[str, Any]) -> None:
+        with self._lock(self.system_file.with_name(f"{self.system_file.name}.lock")):
+            self._write_json(self.system_file, system)
+
+    @contextmanager
+    def _system_transaction(self) -> Iterator[Dict[str, Any]]:
+        lock_path = self.system_file.with_name(f"{self.system_file.name}.lock")
+        with self._lock(lock_path):
+            previous = self.system_file.read_bytes()
+            try:
+                system = self._read_json(self.system_file)
+                self._normalize_system(system, persist=False)
+                yield system
+                self._write_json(self.system_file, system)
+            except Exception:
+                self.system_file.write_bytes(previous)
+                raise
+
+    def _write_profile_file(self, profile_id: str, data: Dict[str, Any]) -> None:
+        self._ensure_profile_layout(profile_id)
+        path = self._profile_path(profile_id)
+        with self._lock(path.with_name(f"{path.name}.lock")):
+            self._write_json(path, data)
+
+    def _profile_metadata(self, profile_id: str, system: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        self.validate_profile_id(profile_id)
+        system = system or self.get_system()
+        profile = next((p for p in system["profiles"] if p["id"] == profile_id), None)
+        if profile is None:
+            raise ProfileNotFound(profile_id)
+        return copy.deepcopy(profile)
+
+    def get_system(self) -> Dict[str, Any]:
+        if not self.system_file.exists():
+            self._initialize()
+        lock_path = self.system_file.with_name(f"{self.system_file.name}.lock")
+        with self._lock(lock_path):
+            system = self._read_json(self.system_file)
+            original = copy.deepcopy(system)
+            self._normalize_system(system, persist=False)
+            if system != original:
+                self._write_json(self.system_file, system)
+            return system
+
+    def update_system_transaction(
+        self,
+        updater: Callable[[Dict[str, Any]], Optional[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        """Read, mutate, and atomically write system data under its lock."""
+        if not callable(updater):
+            raise ProfileRepositoryError("System updater must be callable")
+        with self._system_transaction() as system:
+            replacement = updater(system)
+            if replacement is not None:
+                if not isinstance(replacement, dict):
+                    raise ProfileRepositoryError("System updater must return an object or None")
+                system.clear()
+                system.update(copy.deepcopy(replacement))
+                self._normalize_system(system, persist=False)
+            result = copy.deepcopy(system)
+        return result
+
+    def list_profiles(self) -> List[Dict[str, Any]]:
+        return [copy.deepcopy(profile) for profile in self.get_system()["profiles"]]
+
+    def active_profile_id(self) -> str:
+        return self.get_system()["active_profile_id"]
+
+    def get_profile(self, profile_id: str) -> Dict[str, Any]:
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            self._profile_metadata(profile_id)
+            path = self._profile_path(profile_id)
+            if not path.exists():
+                self._write_profile_file(profile_id, self._profile_defaults())
+            data = self._read_json(path)
+        return _deep_merge(self._profile_defaults(), data)
+
+    def get_compat_config(self, profile_id: str) -> Dict[str, Any]:
+        result = self.get_profile(profile_id)
+        system = self.get_system()
+        result["profile_id"] = profile_id
+        result["system_config"] = copy.deepcopy(system.get("system_config", {}))
+        result["agents"] = copy.deepcopy(system.get("agents", []))
+        result["backup"] = copy.deepcopy(system.get("backup", {}))
+        return result
+
+    def update_profile_transaction(
+        self,
+        profile_id: str,
+        updater: Callable[[Dict[str, Any]], Optional[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        """Read, mutate, and atomically write one profile under its file lock."""
+        if not callable(updater):
+            raise ProfileRepositoryError("Profile updater must be callable")
+
+        path = self._profile_path(profile_id)
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            self._profile_metadata(profile_id)
+            with self._lock(path.with_name(f"{path.name}.lock")):
+                previous = path.read_bytes() if path.exists() else None
+                current = self._profile_defaults()
+                if path.exists():
+                    current = _deep_merge(current, self._read_json(path))
+                replacement = updater(current)
+                updated = current if replacement is None else replacement
+                if not isinstance(updated, dict):
+                    raise ProfileRepositoryError("Profile updater must return an object or None")
+                profile_data = {
+                    key: copy.deepcopy(value)
+                    for key, value in updated.items()
+                    if key not in self.SYSTEM_FIELDS
+                }
+                profile_data = _deep_merge(self._profile_defaults(), profile_data)
+                try:
+                    self._write_json(path, profile_data)
+                    with self._system_transaction() as system:
+                        metadata = next((item for item in system["profiles"] if item["id"] == profile_id), None)
+                        if metadata is None:
+                            raise ProfileNotFound(profile_id)
+                        metadata["updated_at"] = _now()
+                except Exception:
+                    if previous is None:
+                        if path.exists():
+                            path.unlink()
+                    else:
+                        path.write_bytes(previous)
+                    raise
+        return copy.deepcopy(profile_data)
+
+    def update_profile_fields(
+        self,
+        profile_id: str,
+        fields: Dict[str, Any],
+        baseline: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Merge fields into fresh locked data, optionally using a stale baseline."""
+        if not isinstance(fields, dict):
+            raise ProfileRepositoryError("Profile fields must be an object")
+        if baseline is not None and not isinstance(baseline, dict):
+            raise ProfileRepositoryError("Profile baseline must be an object")
+
+        def merge_fields(profile: Dict[str, Any]) -> None:
+            for key, value in fields.items():
+                if baseline is not None and key in baseline:
+                    profile[key] = _three_way_merge(profile.get(key), baseline[key], value)
+                else:
+                    profile[key] = copy.deepcopy(value)
+
+        return self.update_profile_transaction(profile_id, merge_fields)
+
+    def save_profile(self, profile_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise ProfileRepositoryError("Profile data must be an object")
+        profile_data = {
+            key: copy.deepcopy(value)
+            for key, value in data.items()
+            if key not in self.SYSTEM_FIELDS
+        }
+        profile_data = _deep_merge(self._profile_defaults(), profile_data)
+        path = self._profile_path(profile_id)
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            self._profile_metadata(profile_id)
+            previous = path.read_bytes() if path.exists() else None
+            try:
+                self._write_profile_file(profile_id, profile_data)
+
+                # Never replace system-owned agents from a profile compatibility snapshot.
+                system_updates = {key: data[key] for key in ("system_config", "backup") if key in data}
+                with self._system_transaction() as system:
+                    metadata = next(profile for profile in system["profiles"] if profile["id"] == profile_id)
+                    metadata["updated_at"] = _now()
+                    if system_updates:
+                        for key, value in system_updates.items():
+                            if isinstance(system.get(key), dict) and isinstance(value, dict):
+                                system[key] = _deep_merge(system[key], value)
+                            else:
+                                system[key] = copy.deepcopy(value)
+            except Exception:
+                if previous is None:
+                    if path.exists():
+                        path.unlink()
+                else:
+                    path.write_bytes(previous)
+                raise
+        return copy.deepcopy(profile_data)
+
+    def create_profile(self, metadata: Dict[str, Any], clone_from: Optional[str] = None) -> Dict[str, Any]:
+        if not isinstance(metadata, dict):
+            raise ProfileRepositoryError("Profile metadata must be an object")
+        profile_id = metadata.get("id") or f"profile_{uuid.uuid4().hex[:12]}"
+        self.validate_profile_id(profile_id)
+        source = self.get_profile(clone_from) if clone_from else self._profile_defaults()
+        timestamp = _now()
+        profile = {
+            "id": profile_id,
+            "name": str(metadata.get("name") or profile_id),
+            "description": str(metadata.get("description") or ""),
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        }
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            profile_dir = self.profile_dir(profile_id)
+            staging_dir = self.profiles_dir / f".{profile_id}.staging-{uuid.uuid4().hex}"
+            backup_dir: Optional[Path] = None
+            try:
+                with self._system_transaction() as system:
+                    if any(item["id"] == profile_id for item in system["profiles"]):
+                        raise ProfileExists(profile_id)
+                    if profile_dir.exists():
+                        backup_dir = self.profiles_dir / f".{profile_id}.orphan-backup-{uuid.uuid4().hex}"
+                        os.replace(profile_dir, backup_dir)
+
+                    staging_dir.mkdir(parents=False, exist_ok=False)
+                    for dirname in self.DERIVED_DIRS:
+                        (staging_dir / dirname).mkdir()
+                    self._write_json(staging_dir / "config.json", source)
+                    os.replace(staging_dir, profile_dir)
+                    system["profiles"].append(profile)
+            except Exception:
+                if profile_dir.exists():
+                    os.replace(profile_dir, staging_dir)
+                if backup_dir is not None and backup_dir.exists():
+                    os.replace(backup_dir, profile_dir)
+                if staging_dir.exists():
+                    try:
+                        shutil.rmtree(staging_dir)
+                    except OSError:
+                        pass
+                raise
+
+            # An unregistered pre-existing directory is recoverable until the
+            # system index commit succeeds, then becomes best-effort cleanup.
+            if backup_dir is not None and backup_dir.exists():
+                try:
+                    shutil.rmtree(backup_dir)
+                except OSError:
+                    pass
+        return copy.deepcopy(profile)
+
+    def clone_profile(self, source_id: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        return self.create_profile(metadata, clone_from=source_id)
+
+    def update_profile(self, profile_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+        self.validate_profile_id(profile_id)
+        if not isinstance(updates, dict):
+            raise ProfileRepositoryError("Profile metadata must be an object")
+        with self._system_transaction() as system:
+            profile = next((p for p in system["profiles"] if p["id"] == profile_id), None)
+            if profile is None:
+                raise ProfileNotFound(profile_id)
+            for key in ("name", "description"):
+                if key in updates:
+                    profile[key] = str(updates[key])
+            profile["updated_at"] = _now()
+            result = copy.deepcopy(profile)
+        return result
+
+    def activate_profile(self, profile_id: str) -> Dict[str, Any]:
+        with self._system_transaction() as system:
+            profile = self._profile_metadata(profile_id, system)
+            system["active_profile_id"] = profile_id
+        return profile
+
+    def delete_profile(self, profile_id: str) -> None:
+        self.validate_profile_id(profile_id)
+        if profile_id == self.DEFAULT_PROFILE_ID:
+            raise ProfileRepositoryError("The default profile cannot be deleted")
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            profile_dir = self.profile_dir(profile_id)
+            tombstone: Optional[Path] = None
+            try:
+                with self._system_transaction() as system:
+                    self._profile_metadata(profile_id, system)
+                    if any(isinstance(agent, dict) and agent.get("profile_id", self.DEFAULT_PROFILE_ID) == profile_id for agent in system.get("agents", [])):
+                        raise ProfileInUse(profile_id)
+                    if profile_dir.exists():
+                        tombstone = self.profiles_dir / f".{profile_id}.tombstone-{uuid.uuid4().hex}"
+                        os.replace(profile_dir, tombstone)
+                    system["profiles"] = [profile for profile in system["profiles"] if profile["id"] != profile_id]
+                    if system.get("active_profile_id") == profile_id:
+                        system["active_profile_id"] = self.DEFAULT_PROFILE_ID
+            except Exception:
+                if tombstone is not None and tombstone.exists():
+                    os.replace(tombstone, profile_dir)
+                raise
+
+            # The index commit is authoritative. Cleanup is best-effort so a
+            # partially removable directory remains recoverable as a tombstone.
+            if tombstone is not None and tombstone.exists():
+                try:
+                    shutil.rmtree(tombstone)
+                except OSError:
+                    pass
+
+    def export_profile(self, profile_id: str) -> Dict[str, Any]:
+        return self.get_profile(profile_id)
+
+    def import_profile(self, profile_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise ProfileRepositoryError("Imported profile must be an object")
+        if isinstance(data.get("config"), dict):
+            data = data["config"]
+        profile_data = {
+            key: value for key, value in data.items() if key not in self.SYSTEM_FIELDS
+        }
+        return self.save_profile(profile_id, profile_data)
+
+    def write_generated(self, profile_id: str, filename: str, content: str) -> Path:
+        if Path(filename).name != filename or filename not in {"config.yaml", "config.conf"}:
+            raise ProfileValidationError("Invalid generated filename")
+        path = self.generated_dir(profile_id) / filename
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            self._profile_metadata(profile_id)
+            with self._lock(path.with_name(f"{path.name}.lock")):
+                self._write_atomic(path, content)
+        return path
+
+    def write_profile_json(self, profile_id: str, relative_path: str, data: Dict[str, Any]) -> Path:
+        path = self.profile_path(profile_id, relative_path)
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            self._profile_metadata(profile_id)
+            with self._lock(path.with_name(f"{path.name}.lock")):
+                self._write_json(path, data)
+        return path
+
+    def read_profile_json(self, profile_id: str, relative_path: str) -> Dict[str, Any]:
+        return self._read_json(self.profile_path(profile_id, relative_path))
+
+    def write_profile_text(self, profile_id: str, relative_path: str, content: str) -> Path:
+        path = self.profile_path(profile_id, relative_path)
+        with self._lock(self._profile_operation_lock_path(profile_id)):
+            self._profile_metadata(profile_id)
+            with self._lock(path.with_name(f"{path.name}.lock")):
+                self._write_atomic(path, content)
+        return path

--- a/backend/common/config_repository.py
+++ b/backend/common/config_repository.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import copy
+import errno
 import json
+import math
 import os
 import re
+import secrets
 import shutil
 import tempfile
 import threading
+import time
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -170,6 +174,11 @@ class ProfileRepository:
     )
     SYSTEM_FIELDS = frozenset({"schema_version", "active_profile_id", "profiles", "agents", "system_config", "backup", "profile_id"})
     DERIVED_DIRS = ("subscribes", "providers", "rules", "generated")
+    LOCK_TIMEOUT_ENV = "CONFIGFLOW_LOCK_TIMEOUT_SECONDS"
+    DEFAULT_LOCK_TIMEOUT_SECONDS = 300.0
+    MIN_LOCK_TIMEOUT_SECONDS = 0.1
+    MAX_LOCK_TIMEOUT_SECONDS = 3600.0
+    LOCK_POLL_INTERVAL_SECONDS = 0.05
 
     def __init__(
         self,
@@ -182,6 +191,7 @@ class ProfileRepository:
         self.system_file = self.data_dir / self.SYSTEM_FILE_NAME
         self.legacy_file = self.data_dir / self.LEGACY_FILE_NAME
         self.migrations_dir = self.data_dir / "migrations"
+        self.initialization_lock_file = self.data_dir / ".profile-repository.initialize.lock"
         self._default_config_factory = default_config_factory
         self._initial_config_factory = initial_config_factory
         self.data_dir.mkdir(parents=True, exist_ok=True)
@@ -210,11 +220,63 @@ class ProfileRepository:
                 }
             ],
             "agents": [],
-            "system_config": {"server_domain": "", "github_proxy_domain": ""},
+            "system_config": {
+                "server_domain": "",
+                "github_proxy_domain": "",
+                "retired_rule_proxy_tokens": [],
+            },
             "backup": {},
         }
 
+    def _ensure_rule_proxy_token(self, system: Dict[str, Any]) -> bool:
+        system_config = system.setdefault("system_config", {})
+        retired = system_config.get("retired_rule_proxy_tokens")
+        normalized_retired = []
+        if isinstance(retired, list):
+            for value in retired:
+                if isinstance(value, str) and value and value not in normalized_retired:
+                    normalized_retired.append(value)
+        if retired != normalized_retired:
+            system_config["retired_rule_proxy_tokens"] = normalized_retired
+            changed = True
+        else:
+            changed = False
+        token = system_config.get("rule_proxy_token")
+        config_token = system_config.get("config_token")
+        if isinstance(token, str) and token:
+            if token != config_token:
+                return changed
+            if token not in normalized_retired:
+                normalized_retired.append(token)
+                system_config["retired_rule_proxy_tokens"] = normalized_retired
+                changed = True
+        while True:
+            new_token = secrets.token_urlsafe(32)
+            if new_token and new_token != config_token:
+                break
+        system_config["rule_proxy_token"] = new_token
+        return True
+
+    def rule_proxy_tokens_for_sanitization(self) -> set[str]:
+        """Return persisted current and retired tokens for output sanitization only."""
+        system_config = self.get_system().get("system_config", {})
+        if not isinstance(system_config, dict):
+            return set()
+        values = [system_config.get("rule_proxy_token")]
+        retired = system_config.get("retired_rule_proxy_tokens", [])
+        if isinstance(retired, list):
+            values.extend(retired)
+        return {value for value in values if isinstance(value, str) and value}
+
     def _initialize(self) -> None:
+        # Initialization is one transaction across system detection, legacy
+        # snapshotting, profile staging/rename, and the system.json commit.
+        # A waiter deliberately re-runs every state check after acquiring the
+        # lock instead of acting on observations made before another process.
+        with self._lock(self.initialization_lock_file):
+            self._initialize_locked()
+
+    def _initialize_locked(self) -> None:
         if self.system_file.exists():
             system = self._read_json(self.system_file)
             self._normalize_system(system)
@@ -245,6 +307,7 @@ class ProfileRepository:
         for agent in system.get("agents", []):
             if isinstance(agent, dict):
                 agent.setdefault("profile_id", self.DEFAULT_PROFILE_ID)
+        self._ensure_rule_proxy_token(system)
         initial_config = {
             key: copy.deepcopy(value)
             for key, value in initial_config.items()
@@ -309,6 +372,8 @@ class ProfileRepository:
         if not isinstance(system.get("system_config"), dict):
             system["system_config"] = {}
             changed = True
+        if self._ensure_rule_proxy_token(system):
+            changed = True
         if not isinstance(system.get("backup"), dict):
             system["backup"] = {}
             changed = True
@@ -337,10 +402,7 @@ class ProfileRepository:
 
     def _migrate_legacy(self) -> None:
         legacy_data = self._read_json(self.legacy_file)
-        migration_dir = self.migrations_dir / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        while migration_dir.exists():
-            migration_dir = self.migrations_dir / f"{migration_dir.name}-{uuid.uuid4().hex[:8]}"
-        migration_dir.mkdir(parents=True, exist_ok=False)
+        migration_dir = self._create_migration_snapshot_dir()
         shutil.copy2(self.legacy_file, migration_dir / self.LEGACY_FILE_NAME)
 
         profile_data = {
@@ -356,15 +418,59 @@ class ProfileRepository:
         for agent in system.get("agents", []):
             if isinstance(agent, dict):
                 agent.setdefault("profile_id", self.DEFAULT_PROFILE_ID)
+        self._ensure_rule_proxy_token(system)
 
-        self._ensure_profile_layout(self.DEFAULT_PROFILE_ID)
-        self._write_profile_file(self.DEFAULT_PROFILE_ID, profile_data)
-        self._copy_legacy_derived_data()
-        # system.json is the migration commit marker. Legacy files remain recoverable.
-        self._write_system(system)
-
-    def _copy_legacy_derived_data(self) -> None:
         profile_dir = self.profile_dir(self.DEFAULT_PROFILE_ID)
+        staging_dir = self.profiles_dir / f".{self.DEFAULT_PROFILE_ID}.migration-staging-{uuid.uuid4().hex}"
+        backup_dir: Optional[Path] = None
+        previous_system = self.system_file.read_bytes() if self.system_file.exists() else None
+        installed_staging = False
+        try:
+            staging_dir.mkdir(parents=False, exist_ok=False)
+            for dirname in self.DERIVED_DIRS:
+                (staging_dir / dirname).mkdir()
+            self._write_json(staging_dir / "config.json", profile_data)
+            self._copy_legacy_derived_data(staging_dir)
+
+            if profile_dir.exists():
+                backup_dir = self.profiles_dir / f".{self.DEFAULT_PROFILE_ID}.migration-backup-{uuid.uuid4().hex}"
+                os.replace(profile_dir, backup_dir)
+            os.replace(staging_dir, profile_dir)
+            installed_staging = True
+            # system.json is the migration commit marker. Legacy files remain recoverable.
+            self._write_system(system)
+        except Exception:
+            if installed_staging and profile_dir.exists():
+                shutil.rmtree(profile_dir)
+            if backup_dir is not None and backup_dir.exists():
+                os.replace(backup_dir, profile_dir)
+            if previous_system is None:
+                if self.system_file.exists():
+                    self.system_file.unlink()
+            else:
+                self.system_file.write_bytes(previous_system)
+            if staging_dir.exists():
+                shutil.rmtree(staging_dir)
+            raise
+        else:
+            if backup_dir is not None and backup_dir.exists():
+                shutil.rmtree(backup_dir)
+
+    def _create_migration_snapshot_dir(self) -> Path:
+        """Create a unique snapshot directory, retrying an actual mkdir race."""
+        self.migrations_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for _ in range(16):
+            candidate = self.migrations_dir / f"{timestamp}-{uuid.uuid4().hex}"
+            try:
+                candidate.mkdir(exist_ok=False)
+            except FileExistsError:
+                continue
+            return candidate
+        raise ProfileRepositoryError("Unable to allocate a unique migration snapshot directory")
+
+    def _copy_legacy_derived_data(self, profile_dir: Optional[Path] = None) -> None:
+        profile_dir = profile_dir or self.profile_dir(self.DEFAULT_PROFILE_ID)
         for dirname in self.DERIVED_DIRS[:-1]:
             source = self.data_dir / dirname
             if source.is_dir():
@@ -426,6 +532,47 @@ class ProfileRepository:
         with _THREAD_LOCKS_GUARD:
             return _THREAD_LOCKS.setdefault(key, threading.RLock())
 
+    @classmethod
+    def _lock_timeout_seconds(cls) -> float:
+        raw_timeout = os.environ.get(cls.LOCK_TIMEOUT_ENV)
+        if raw_timeout is None:
+            return cls.DEFAULT_LOCK_TIMEOUT_SECONDS
+        try:
+            timeout = float(raw_timeout)
+        except (TypeError, ValueError):
+            return cls.DEFAULT_LOCK_TIMEOUT_SECONDS
+        if not math.isfinite(timeout):
+            return cls.DEFAULT_LOCK_TIMEOUT_SECONDS
+        return min(cls.MAX_LOCK_TIMEOUT_SECONDS, max(cls.MIN_LOCK_TIMEOUT_SECONDS, timeout))
+
+    @staticmethod
+    def _lock_is_contended(exc: OSError) -> bool:
+        return exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}
+
+    def _acquire_file_lock(self, handle: Any) -> None:
+        deadline = time.monotonic() + self._lock_timeout_seconds()
+        while True:
+            handle.seek(0)
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return
+            except OSError as exc:
+                if not self._lock_is_contended(exc):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ProfileRepositoryError(
+                        "Timed out waiting for profile repository lock"
+                    ) from None
+                time.sleep(min(self.LOCK_POLL_INTERVAL_SECONDS, remaining))
+
     @contextmanager
     def _lock(self, path: Path) -> Iterator[None]:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -435,15 +582,7 @@ class ProfileRepository:
                 if handle.seek(0, os.SEEK_END) == 0:
                     handle.write(b"0")
                     handle.flush()
-                handle.seek(0)
-                if os.name == "nt":
-                    import msvcrt
-
-                    msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-                else:
-                    import fcntl
-
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                self._acquire_file_lock(handle)
                 try:
                     yield
                 finally:
@@ -496,6 +635,7 @@ class ProfileRepository:
                 system = self._read_json(self.system_file)
                 self._normalize_system(system, persist=False)
                 yield system
+                self._normalize_system(system, persist=False)
                 self._write_json(self.system_file, system)
             except Exception:
                 self.system_file.write_bytes(previous)
@@ -542,8 +682,7 @@ class ProfileRepository:
                 system.clear()
                 system.update(copy.deepcopy(replacement))
                 self._normalize_system(system, persist=False)
-            result = copy.deepcopy(system)
-        return result
+        return copy.deepcopy(system)
 
     def list_profiles(self) -> List[Dict[str, Any]]:
         return [copy.deepcopy(profile) for profile in self.get_system()["profiles"]]

--- a/backend/common/profile_context.py
+++ b/backend/common/profile_context.py
@@ -1,0 +1,83 @@
+"""Request-level profile selection without mutable process-wide state."""
+
+from collections.abc import Mapping
+from typing import Optional
+import urllib.parse
+
+from flask import g, has_request_context, request
+
+
+def append_url_query(url: str, params) -> str:
+    """Append query parameters with standards-compliant percent encoding."""
+    parts = urllib.parse.urlsplit(url)
+    query_items = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+    query_items.extend(params.items() if isinstance(params, Mapping) else params)
+    encoded_query = urllib.parse.urlencode(
+        query_items,
+        doseq=True,
+        quote_via=urllib.parse.quote,
+    )
+    return urllib.parse.urlunsplit(parts._replace(query=encoded_query))
+
+def profile_api_path(config_data, suffix: str) -> str:
+    profile_id = config_data.get("profile_id") if isinstance(config_data, Mapping) else None
+    return f"/api/profiles/{profile_id}{suffix}" if profile_id else suffix
+
+
+def config_api_path(config_data, target: str) -> str:
+    profile_id = config_data.get("profile_id") if isinstance(config_data, Mapping) else None
+    return f"/api/config/{profile_id}/{target}" if profile_id else f"/api/config/{target}"
+
+
+def resolve_profile_id(explicit: Optional[str] = None, fallback: Optional[str] = None) -> str:
+    """Resolve URL, header, query, active profile in that order."""
+    from backend.common.config import get_repository
+
+    repository = get_repository()
+    if explicit is not None:
+        candidate = explicit
+    elif has_request_context():
+        route_values = request.view_args or {}
+        candidate = route_values.get("profile_id")
+        if candidate is None:
+            candidate = request.headers.get("X-ConfigFlow-Profile")
+        if candidate is None:
+            candidate = request.args.get("profile") or request.args.get("profile_id")
+    else:
+        candidate = None
+
+    candidate = candidate or fallback or repository.active_profile_id()
+    repository.validate_profile_id(candidate)
+    repository.get_profile(candidate)
+    return candidate
+
+
+def install_profile_context(app) -> None:
+    """Install request validation and response observability on a Flask app."""
+
+    @app.before_request
+    def _set_profile_context():
+        from backend.common.config import reset_config_context
+
+        reset_config_context()
+        endpoint = request.endpoint or ""
+        if endpoint.startswith("auth.") or endpoint == "profiles.handle_profiles":
+            g.configflow_profile_id = None
+            return None
+        g.configflow_profile_id = resolve_profile_id()
+
+    @app.after_request
+    def _add_profile_header(response):
+        from backend.common.config import reset_config_context
+
+        profile_id = getattr(g, "configflow_profile_id", None)
+        if profile_id:
+            response.headers.setdefault("X-ConfigFlow-Profile", profile_id)
+        reset_config_context()
+        return response
+
+    @app.teardown_request
+    def _clear_profile_context(_error=None):
+        from backend.common.config import reset_config_context
+
+        reset_config_context()

--- a/backend/common/profile_context.py
+++ b/backend/common/profile_context.py
@@ -67,6 +67,38 @@ def install_profile_context(app) -> None:
         g.configflow_profile_id = resolve_profile_id()
 
     @app.after_request
+    def _sanitize_external_json(response):
+        """Scrub ordinary JSON responses without touching internal return objects."""
+        from backend.common.config_export import sanitize_external_payload
+
+        endpoint = request.endpoint or ""
+        if (
+            response.is_json
+            and not response.direct_passthrough
+        ):
+            try:
+                payload = response.get_json(silent=True)
+            except RecursionError:
+                # The standard decoder can overflow before the iterative
+                # sanitizer sees an adversarially deep raw JSON response.
+                response.set_data(app.json.dumps("[REDACTED]"))
+                return response
+            if payload is not None:
+                sanitized = sanitize_external_payload(payload)
+                # A successful self-registration may disclose exactly one top-level
+                # credential. Nested Agent records and every other API stay scrubbed.
+                if (
+                    endpoint == "agents.register_agent"
+                    and 200 <= response.status_code < 300
+                    and isinstance(payload, dict)
+                    and payload.get("success") is True
+                    and isinstance(payload.get("token"), str)
+                ):
+                    sanitized["token"] = payload["token"]
+                response.set_data(app.json.dumps(sanitized))
+        return response
+
+    @app.after_request
     def _add_profile_header(response):
         from backend.common.config import reset_config_context
 

--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -4,6 +4,7 @@ import yaml
 from typing import Dict, Any, List, Optional
 from backend.utils.logger import get_logger
 from backend.utils.proxy_utils import fix_proxy_fields
+from backend.common.profile_context import append_url_query, profile_api_path
 
 # 获取当前模块的日志记录器
 logger = get_logger(__name__)
@@ -35,7 +36,9 @@ def apply_github_proxy_domain(url: str, config_data: Dict[str, Any]) -> str:
     if not config_data:
         return url
 
-    proxy_url = config_data.get('system_config', {}).get('github_proxy_domain', '').strip()
+    configured_proxy = config_data.get('system_config', {}).get('github_proxy_domain', '')
+    proxy_url = configured_proxy.strip() if isinstance(configured_proxy, str) else ''
+
     if not proxy_url:
         return url
 
@@ -442,11 +445,11 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
         if sub.get('enabled', True) and sub.get('id') in used_subscription_ids:
             # 构建订阅 provider 的 URL（使用本地接口）
             sub_id = sub['id']
-            sub_url = f"{effective_base_url}/api/subscriptions/{sub_id}/proxies"
+            sub_url = f"{effective_base_url}{profile_api_path(config_data, f'/subscriptions/{sub_id}/proxies')}"
 
             # 如果配置了令牌，添加到 URL
             if config_token:
-                sub_url += f"?token={config_token}"
+                sub_url = append_url_query(sub_url, {'token': config_token})
 
             logger.info(f"订阅 '{sub['name']}' 使用本地接口: {sub_url}")
 
@@ -464,11 +467,11 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
         if agg.get('enabled', True) and agg.get('id') in used_aggregation_ids:
             # 构建聚合 provider 的 URL（使用服务域名配置）
             agg_id = agg['id']
-            agg_url = f"{effective_base_url}/api/aggregations/{agg_id}/provider"
+            agg_url = f"{effective_base_url}{profile_api_path(config_data, f'/aggregations/{agg_id}/provider')}"
 
             # 如果配置了令牌，添加到 URL
             if config_token:
-                agg_url += f"?token={config_token}"
+                agg_url = append_url_query(agg_url, {'token': config_token})
 
             proxy_providers[agg['name']] = {
                 'type': 'http',
@@ -899,7 +902,7 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
                     # 这样所有规则都从本地获取，避免外部网络请求
                     rule_name = library_rule.get('name', '')
                     if rule_name:
-                        url = f"/api/rules/local/{rule_name}"
+                        url = profile_api_path(config_data, f"/rules/local/{rule_name}")
 
             # 如果 URL 是相对路径，动态拼接 server_domain
             if url and url.startswith('/') and effective_base_url:
@@ -1059,11 +1062,11 @@ def get_mihomo_provider_downloads(config_data: Dict[str, Any], base_url: str = '
     for sub in config_data.get('subscriptions', []):
         if sub.get('enabled', True) and sub.get('id') in used_subscription_ids:
             sub_id = sub['id']
-            sub_url = f"{effective_base_url}/api/subscriptions/{sub_id}/proxies"
+            sub_url = f"{effective_base_url}{profile_api_path(config_data, f'/subscriptions/{sub_id}/proxies')}"
 
             # 如果配置了令牌，添加到 URL
             if config_token:
-                sub_url += f"?token={config_token}"
+                sub_url = append_url_query(sub_url, {'token': config_token})
 
             downloads.append({
                 'name': sub['name'],
@@ -1075,11 +1078,11 @@ def get_mihomo_provider_downloads(config_data: Dict[str, Any], base_url: str = '
     for agg in config_data.get('subscription_aggregations', []):
         if agg.get('enabled', True) and agg.get('id') in used_aggregation_ids:
             agg_id = agg['id']
-            agg_url = f"{effective_base_url}/api/aggregations/{agg_id}/provider"
+            agg_url = f"{effective_base_url}{profile_api_path(config_data, f'/aggregations/{agg_id}/provider')}"
 
             # 如果配置了令牌，添加到 URL
             if config_token:
-                agg_url += f"?token={config_token}"
+                agg_url = append_url_query(agg_url, {'token': config_token})
 
             downloads.append({
                 'name': agg['name'],
@@ -1129,7 +1132,7 @@ def get_mihomo_ruleset_downloads(config_data: Dict[str, Any], base_url: str = ''
                     # 使用本地缓存的规则文件接口
                     rule_name = library_rule.get('name', '')
                     if rule_name:
-                        url = f"/api/rules/local/{rule_name}"
+                        url = profile_api_path(config_data, f"/rules/local/{rule_name}")
 
             # 如果 URL 是相对路径，动态拼接 server_domain
             if url and url.startswith('/') and effective_base_url:

--- a/backend/converters/mosdns.py
+++ b/backend/converters/mosdns.py
@@ -1,6 +1,7 @@
 """MosDNS 配置生成器"""
 import yaml
 from typing import Dict, Any, List
+from backend.common.profile_context import append_url_query, profile_api_path
 
 # 统一处理规则集 ID，避免重复的前缀
 def _normalize_ruleset_id(rule_set_id: str) -> str:
@@ -168,6 +169,17 @@ def split_rules_and_rulesets(config_data: Dict[str, Any]) -> tuple:
     return rules, rule_sets
 
 
+def _build_rule_proxy_url(config_data: Dict[str, Any], effective_base_url: str, url: str) -> str:
+    endpoint = profile_api_path(config_data, '/mosdns/rule-proxy')
+    if endpoint == '/mosdns/rule-proxy':
+        endpoint = f'/api{endpoint}'
+    query = {'url': url}
+    config_token = config_data.get('system_config', {}).get('config_token', '')
+    if config_token:
+        query['token'] = config_token
+    return append_url_query(f"{effective_base_url}{endpoint}", query)
+
+
 def parse_dns_upstreams(dns_config: str) -> List[Dict[str, Any]]:
     """
     解析 DNS 服务器配置，支持多种格式
@@ -290,8 +302,6 @@ def get_mosdns_ruleset_downloads(config_data: Dict[str, Any], base_url: str = ''
                 ...
             ]
     """
-    import urllib.parse
-
     # 从合并数组中分离规则和规则集
     rules_list, rule_sets_list = split_rules_and_rulesets(config_data)
 
@@ -332,10 +342,7 @@ def get_mosdns_ruleset_downloads(config_data: Dict[str, Any], base_url: str = ''
         # 构建下载 URL（使用代理接口）
         # rule-proxy 会将所有格式转换为 MosDNS 文本格式，所以始终使用 .txt 扩展名
         if url:
-            if effective_base_url:
-                download_url = f"{effective_base_url}/api/mosdns/rule-proxy?url={urllib.parse.quote(url)}"
-            else:
-                download_url = f"/api/mosdns/rule-proxy?url={urllib.parse.quote(url)}"
+            download_url = _build_rule_proxy_url(config_data, effective_base_url, url)
 
             downloads.append({
                 'name': rule_set['name'],
@@ -621,13 +628,9 @@ def generate_mosdns_config(config_data: Dict[str, Any], base_url: str = '') -> s
 
         # 使用代理接口转换规则格式
         # rule-proxy 会将所有格式转换为 MosDNS 文本格式，所以始终使用 .txt 扩展名
-        import urllib.parse
         if url:
             # 构建代理 URL - 用于下载规则文件
-            if effective_base_url:
-                download_url = f"{effective_base_url}/api/mosdns/rule-proxy?url={urllib.parse.quote(url)}"
-            else:
-                download_url = f"/api/mosdns/rule-proxy?url={urllib.parse.quote(url)}"
+            download_url = _build_rule_proxy_url(config_data, effective_base_url, url)
         else:
             download_url = None
 

--- a/backend/converters/mosdns.py
+++ b/backend/converters/mosdns.py
@@ -174,9 +174,10 @@ def _build_rule_proxy_url(config_data: Dict[str, Any], effective_base_url: str, 
     if endpoint == '/mosdns/rule-proxy':
         endpoint = f'/api{endpoint}'
     query = {'url': url}
-    config_token = config_data.get('system_config', {}).get('config_token', '')
-    if config_token:
-        query['token'] = config_token
+    rule_proxy_token = config_data.get('system_config', {}).get('rule_proxy_token', '')
+    if not isinstance(rule_proxy_token, str) or not rule_proxy_token:
+        raise ValueError('MosDNS rule proxy requires a rule proxy token')
+    query['token'] = rule_proxy_token
     return append_url_query(f"{effective_base_url}{endpoint}", query)
 
 

--- a/backend/converters/surge.py
+++ b/backend/converters/surge.py
@@ -4,6 +4,7 @@ import os
 from typing import Dict, Any, List
 from backend.utils.subscription_parser import parse_uri_list
 from backend.utils.logger import get_logger
+from backend.common.profile_context import append_url_query, config_api_path, profile_api_path
 
 logger = get_logger(__name__)
 
@@ -412,9 +413,9 @@ def generate_surge_config(config_data: Dict[str, Any], base_url: str = '') -> st
 
     # 在最上方添加远程托管配置
     config_token = config_data.get('system_config', {}).get('config_token', '')
-    surge_url = f"{effective_base_url}/api/config/surge"
+    surge_url = f"{effective_base_url}{config_api_path(config_data, 'surge')}"
     if config_token:
-        surge_url += f"?token={config_token}"
+        surge_url = append_url_query(surge_url, {'token': config_token})
     managed_line = f"#!MANAGED-CONFIG {surge_url} interval=86400 strict=true"
 
     return f"{managed_line}\n\n{config_output}"
@@ -954,12 +955,12 @@ def convert_proxy_group_to_surge(group: Dict[str, Any], config_data: Dict[str, A
             sub = next((s for s in all_subs if s['id'] == sub_id and s.get('enabled', True)), None)
             if sub:
                 # 构建订阅 URL（使用本地接口）
-                sub_url = f"{effective_base_url}/api/subscriptions/{sub_id}/proxies"
+                sub_url = f"{effective_base_url}{profile_api_path(config_data, f'/subscriptions/{sub_id}/proxies')}"
                 # 如果配置了令牌，添加到 URL
+                query = {'format': 'surge'}
                 if config_token:
-                    sub_url += f"?token={config_token}&format=surge"
-                else:
-                    sub_url += f"?format=surge"
+                    query['token'] = config_token
+                sub_url = append_url_query(sub_url, query)
                 policy_paths.append(sub_url)
 
     # 添加聚合的 policy-path
@@ -969,12 +970,12 @@ def convert_proxy_group_to_surge(group: Dict[str, Any], config_data: Dict[str, A
             agg = next((a for a in aggregations if a['id'] == agg_id and a.get('enabled', True)), None)
             if agg:
                 # 构建聚合 URL
-                agg_url = f"{effective_base_url}/api/aggregations/{agg_id}/provider"
+                agg_url = f"{effective_base_url}{profile_api_path(config_data, f'/aggregations/{agg_id}/provider')}"
                 # 如果配置了令牌，添加到 URL
+                query = {'format': 'surge'}
                 if config_token:
-                    agg_url += f"?token={config_token}&format=surge"
-                else:
-                    agg_url += f"?format=surge"
+                    query['token'] = config_token
+                agg_url = append_url_query(agg_url, query)
                 policy_paths.append(agg_url)
 
     # 如果没有普通节点但有 policy-path，允许继续生成

--- a/backend/mcp_server/auth.py
+++ b/backend/mcp_server/auth.py
@@ -16,7 +16,12 @@ MCP 令牌，而不是继续共用此令牌。
 """
 from flask import request
 
-from backend.common.auth import is_auth_enabled, verify_token
+from backend.common.auth import (
+    is_auth_enabled,
+    is_token_within_length,
+    parse_bearer_token,
+    verify_token,
+)
 
 
 def _config_token() -> str:
@@ -25,11 +30,14 @@ def _config_token() -> str:
     return (get_config().get('system_config', {}) or {}).get('config_token', '') or ''
 
 
+def _internal_rule_proxy_tokens() -> set[str]:
+    from backend.common.config import get_repository
+
+    return get_repository().rule_proxy_tokens_for_sanitization()
+
+
 def _bearer() -> str:
-    header = request.headers.get('Authorization', '')
-    if header.startswith('Bearer '):
-        return header[len('Bearer '):].strip()
-    return ''
+    return parse_bearer_token(request.headers.get('Authorization', '')) or ''
 
 
 def _is_valid_jwt(token: str) -> bool:
@@ -43,9 +51,17 @@ def authenticate() -> bool:
     """校验当前 MCP 请求，返回是否放行"""
     config_token = _config_token()
     bearer = _bearer()
+    url_token = request.args.get('token', '')
+    if not is_token_within_length(url_token):
+        url_token = ''
+
+    # rule-proxy 的内部能力令牌只能访问规则代理，绝不能授权 MCP。
+    internal_tokens = _internal_rule_proxy_tokens()
+    if bearer in internal_tokens or url_token in internal_tokens:
+        return False
 
     # 配置令牌（两种带法）
-    if config_token and (bearer == config_token or request.args.get('token', '') == config_token):
+    if config_token and (bearer == config_token or url_token == config_token):
         return True
 
     # 启用账号密码登录时，前端签发的 JWT 同样可用

--- a/backend/mcp_server/invoker.py
+++ b/backend/mcp_server/invoker.py
@@ -4,6 +4,7 @@ MCP 工具不复制业务逻辑，而是在进程内复用现有 REST 路由：
 所有既有的参数校验、持久化和副作用都保持单一实现。
 """
 import json
+from contextvars import ContextVar
 from typing import Any, Dict, Optional
 
 from flask import current_app
@@ -20,11 +21,24 @@ class ApiError(Exception):
         self.message = message
 
 
+_MCP_PROFILE_ID: ContextVar[Optional[str]] = ContextVar('mcp_profile_id', default=None)
+
+
+def set_profile_context(profile_id: Optional[str]):
+    return _MCP_PROFILE_ID.set(profile_id)
+
+
+def reset_profile_context(token) -> None:
+    _MCP_PROFILE_ID.reset(token)
+
+
 def call_api(
     method: str,
     path: str,
     body: Optional[Dict[str, Any]] = None,
     query: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    profile_id: Optional[str] = None,
 ) -> Any:
     """在进程内调用自身的 REST 接口
 
@@ -43,12 +57,18 @@ def call_api(
     client = current_app.test_client()
     clean_query = {k: v for k, v in (query or {}).items() if v is not None}
 
+    request_headers = dict(headers or {})
+    selected_profile_id = profile_id or _MCP_PROFILE_ID.get()
+    if selected_profile_id:
+        request_headers.setdefault('X-ConfigFlow-Profile', selected_profile_id)
+    request_headers[INTERNAL_CALL_HEADER] = INTERNAL_CALL_TOKEN
+
     response = client.open(
         path,
         method=method,
         json=body if body is not None else None,
         query_string=clean_query,
-        headers={INTERNAL_CALL_HEADER: INTERNAL_CALL_TOKEN},
+        headers=request_headers,
     )
 
     # 部分接口（如 MosDNS 配置生成）返回 zip 等二进制，不能按文本解码

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from flask import Blueprint, Response, jsonify, request
 
+from backend.common.config import get_config
+from backend.common.config_export import sanitize_external_payload
 from backend.mcp_server import auth
 from backend.mcp_server.invoker import ApiError
 from backend.mcp_server.tools import call_tool, list_tools, has_tool
@@ -50,6 +52,8 @@ def _error(request_id: Any, code: int, message: str) -> Dict[str, Any]:
 
 
 def _text_content(payload: Any) -> List[Dict[str, str]]:
+    system_config = get_config().get('system_config', {}) or {}
+    payload = sanitize_external_payload(payload, system_config)
     if isinstance(payload, str):
         text = payload
     else:

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -12,7 +12,12 @@
 import time
 from typing import Any, Callable, Dict, List, Optional
 
-from backend.mcp_server.invoker import ApiError, call_api
+from backend.mcp_server.invoker import (
+    ApiError,
+    call_api,
+    reset_profile_context,
+    set_profile_context,
+)
 
 # 工具注册表：name -> {'definition': {...}, 'handler': callable}
 _REGISTRY: Dict[str, Dict[str, Any]] = {}
@@ -47,12 +52,26 @@ def has_tool(name: str) -> bool:
 
 def call_tool(name: str, arguments: Dict[str, Any]) -> Any:
     """执行一个工具（tools/call）"""
-    return _REGISTRY[name]['handler'](arguments or {})
+    arguments = arguments or {}
+    selected_profile_id = arguments.get('profile_id') or 'default'
+    token = set_profile_context(selected_profile_id)
+    try:
+        result = _REGISTRY[name]['handler'](arguments)
+        if isinstance(result, dict):
+            result.setdefault('profile_id', selected_profile_id)
+        return result
+    finally:
+        reset_profile_context(token)
 
 
 # ---------------------------------------------------------------- schema 助手
 
 def obj(properties: Dict[str, Any], required: Optional[List[str]] = None) -> Dict[str, Any]:
+    properties = dict(properties)
+    properties.setdefault(
+        'profile_id',
+        {'type': 'string', 'description': '目标 profile id；留空使用 active/default profile'},
+    )
     return {
         'type': 'object',
         'properties': properties,
@@ -166,6 +185,86 @@ def _unwrap(result: Any, fallback: Any) -> Any:
     if isinstance(result, dict) and 'data' in result:
         return result['data']
     return fallback
+
+
+# ================================================================ Profiles
+
+@tool(
+    'list_profiles',
+    '列出所有配置 profile。',
+    NO_ARGS,
+)
+def _list_profiles(args):
+    return call_api('GET', '/api/profiles')
+
+
+@tool(
+    'get_profile',
+    '获取一个 profile 的元数据。',
+    obj({'id': string('profile id')}, ['id']),
+)
+def _get_profile(args):
+    profile_id = _require(args, 'id')
+    return call_api('GET', f'/api/profiles/{profile_id}')
+
+
+@tool(
+    'manage_profile',
+    '创建、更新、激活或删除 profile。默认 profile 不可删除。',
+    obj(
+        {
+            'action': string('操作类型', ['create', 'update', 'activate', 'delete']),
+            'id': string('profile id，update / activate / delete 时必填'),
+            'data': free_object('profile 元数据；create 时至少包含 id 或 name'),
+        },
+        ['action'],
+    ),
+)
+def _manage_profile(args):
+    action = _require(args, 'action')
+    profile_id = args.get('id')
+    if action == 'create':
+        return call_api('POST', '/api/profiles', body=args.get('data') or {})
+    profile_id = _require(args, 'id')
+    if action == 'update':
+        return call_api('PUT', f'/api/profiles/{profile_id}', body=args.get('data') or {})
+    if action == 'activate':
+        return call_api('POST', f'/api/profiles/{profile_id}/activate', body={})
+    if action == 'delete':
+        call_api('DELETE', f'/api/profiles/{profile_id}')
+        return {'success': True, 'profile_id': profile_id}
+    raise ApiError(400, f'不支持的 action: {action}')
+
+
+@tool(
+    'clone_profile',
+    '从一个 profile 克隆出新的 profile。',
+    obj(
+        {
+            'source_profile_id': string('源 profile id'),
+            'data': free_object('目标 profile 元数据，至少包含 id 或 name'),
+        },
+        ['source_profile_id', 'data'],
+    ),
+)
+def _clone_profile(args):
+    source_id = _require(args, 'source_profile_id')
+    return call_api('POST', f'/api/profiles/{source_id}/clone', body=args['data'])
+
+
+@tool(
+    'bind_agent_profile',
+    '把 Agent 绑定到指定 profile；后续配置读取和推送都使用该 profile。',
+    obj(
+        {'id': string('Agent id'), 'profile_id': string('目标 profile id')},
+        ['id', 'profile_id'],
+    ),
+)
+def _bind_agent_profile(args):
+    agent_id = _require(args, 'id')
+    profile_id = _require(args, 'profile_id')
+    current = call_api('GET', f'/api/agents/{agent_id}') or {}
+    return call_api('PUT', f'/api/agents/{agent_id}', body={**current, 'profile_id': profile_id})
 
 
 # ================================================================ 订阅

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -17,6 +17,7 @@ mosdns_bp = Blueprint('mosdns', __name__, url_prefix='/api/mosdns')
 settings_bp = Blueprint('settings', __name__, url_prefix='/api')
 logs_bp = Blueprint('logs', __name__, url_prefix='/api/logs')
 stats_bp = Blueprint('stats', __name__, url_prefix='/api/stats')
+profiles_bp = Blueprint('profiles', __name__, url_prefix='/api/profiles')
 
 
 def register_blueprints(app):
@@ -39,6 +40,7 @@ def register_blueprints(app):
     from backend.routes import settings
     from backend.routes.logs import logs_bp  # 日志路由
     from backend.routes.stats import stats_bp  # 统计路由
+    from backend.routes import profiles
 
     # 注册所有蓝图
     app.register_blueprint(auth_bp)
@@ -57,3 +59,21 @@ def register_blueprints(app):
     app.register_blueprint(settings_bp)
     app.register_blueprint(logs_bp)  # 注册日志路由
     app.register_blueprint(stats_bp)  # 注册统计路由
+    app.register_blueprint(profiles_bp)
+
+    from backend.common.config_repository import ProfileRepositoryError, ProfileNotFound, ProfileValidationError
+    from backend.common.profile_context import install_profile_context
+
+    @app.errorhandler(ProfileValidationError)
+    def _profile_validation_error(error):
+        return {'success': False, 'message': str(error)}, 400
+
+    @app.errorhandler(ProfileNotFound)
+    def _profile_not_found(error):
+        return {'success': False, 'message': f'Profile not found: {error.args[0]}'}, 404
+
+    @app.errorhandler(ProfileRepositoryError)
+    def _profile_repository_error(error):
+        return {'success': False, 'message': str(error)}, 400
+
+    install_profile_context(app)

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -17,7 +17,8 @@ from backend.converters.mosdns import generate_mosdns_config, get_mosdns_ruleset
 from backend.converters.surge import generate_surge_config
 from backend.routes import agents_bp as bp
 from backend.common.auth import require_auth
-from backend.common.config import config_data, save_config
+from backend.common.config import get_config
+from backend.common.config_repository import ProfileRepositoryError
 from backend.common.agent_manager import get_agent_manager
 from backend.common.utils import str_to_bool
 from backend.utils.logger import get_logger
@@ -191,7 +192,6 @@ def register_agent():
 
         # 注册 Agent
         result = agent_manager.register_agent(agent_data)
-        save_config()
 
         response_data = {'success': True, **result}
         logger.info(f"注册成功: {result.get('id')}")
@@ -239,10 +239,12 @@ def get_agent_config(agent_id):
             return jsonify({'success': False, 'message': 'Invalid token'}), 401
 
         # 生成配置
-        config_result = generate_agent_config(config_data, agent)
+        profile_id = agent.get('profile_id', 'default')
+        config_result = generate_agent_config(get_config(profile_id), agent)
 
         return jsonify({
             'success': True,
+            'profile_id': profile_id,
             'content': config_result['content'],
             'md5': config_result['md5'],
             'version': config_result['version']
@@ -303,7 +305,6 @@ def handle_agents():
         try:
             agent_data = request.json
             result = agent_manager.register_agent(agent_data)
-            save_config()
             return jsonify({'success': True, 'data': result}), 200
         except Exception as e:
             return jsonify({'success': False, 'message': str(e)}), 500
@@ -327,7 +328,6 @@ def handle_agent_item(agent_id):
             agent_data = request.json
             result = agent_manager.update_agent(agent_id, agent_data)
             if result:
-                save_config()
                 return jsonify({'success': True, 'data': result}), 200
             else:
                 return jsonify({'success': False, 'message': 'Agent not found'}), 404
@@ -338,7 +338,6 @@ def handle_agent_item(agent_id):
         try:
             result = agent_manager.delete_agent(agent_id)
             if result:
-                save_config()
                 return jsonify({'success': True}), 200
             else:
                 return jsonify({'success': False, 'message': 'Agent not found'}), 404
@@ -444,9 +443,6 @@ def set_logging_config(agent_id):
         agent_manager = get_agent_manager()
         result = agent_manager.set_logging_config(agent_id, enabled)
 
-        if result.get('success'):
-            save_config()
-
         return jsonify(result), 200 if result.get('success') else 500
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500
@@ -462,7 +458,6 @@ def uninstall_agent(agent_id):
         if result.get('success'):
             # 卸载成功后从数据库删除
             agent_manager.delete_agent(agent_id)
-            save_config()
         return jsonify(result), 200 if result.get('success') else 500
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500
@@ -614,6 +609,12 @@ def push_config_to_agent(agent_id):
 
         logger.info(f"Agent: {agent.get('name')}, Service Type: {agent.get('service_type')}, Base URL: {base_url}")
 
+        profile_id = agent.get('profile_id', 'default')
+        try:
+            config_data = get_config(profile_id)
+        except ProfileRepositoryError as exc:
+            return jsonify({'success': False, 'message': f'Agent profile unavailable: {exc}'}), 409
+
         # 根据 service_type 生成配置
         service_type = agent.get('service_type', 'mihomo')
         provider_downloads = []  # Provider 下载信息（Mihomo 需要）
@@ -725,6 +726,7 @@ def push_config_to_agent(agent_id):
 
         # 处理推送结果
         if result['success']:
+            result['profile_id'] = profile_id
             logger.info(f"配置推送成功: {agent_id}")
             if service_type == 'mihomo':
                 # 在返回结果中包含下载信息（用于前端显示）
@@ -739,7 +741,6 @@ def push_config_to_agent(agent_id):
                 result['directories'] = ['rules']
                 if ruleset_downloads:
                     result['ruleset_downloads'] = ruleset_downloads
-            save_config()
 
             # 重启由 Agent 在配置落盘后自行完成（见 restart_after_update）。
             # 旧版 Agent 不认识该字段，只能退回服务端触发重启——那样存在竞态，

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -2,6 +2,9 @@
 
 提供 Agent 的注册、管理、配置推送等功能
 """
+import hmac
+import json
+import math
 import os
 from flask import request, jsonify, send_file
 
@@ -16,7 +19,7 @@ from backend.converters.mihomo import generate_mihomo_config, get_mihomo_provide
 from backend.converters.mosdns import generate_mosdns_config, get_mosdns_ruleset_downloads, get_mosdns_custom_files
 from backend.converters.surge import generate_surge_config
 from backend.routes import agents_bp as bp
-from backend.common.auth import require_auth
+from backend.common.auth import is_token_within_length, parse_bearer_token, require_auth
 from backend.common.config import get_config
 from backend.common.config_repository import ProfileRepositoryError
 from backend.common.agent_manager import get_agent_manager
@@ -28,6 +31,90 @@ logger = get_logger(__name__)
 # 支持「配置落盘后由 Agent 自行重启」的最低 Agent 版本。
 # 更早的版本不认识 restart_after_update 字段，只能由服务端触发重启。
 _SELF_RESTART_MIN_VERSION = "1.1.0-go"
+_HEARTBEAT_MAX_CONTENT_LENGTH = 32 * 1024
+_HEARTBEAT_FIELDS = frozenset({'version', 'config_version', 'service_status', 'system_metrics'})
+_METRIC_FIELDS = {
+    'cpu': frozenset({'usage_percent', 'core_count'}),
+    'memory': frozenset({'total', 'used', 'available', 'used_percent'}),
+    'disk': frozenset({'total', 'used', 'free', 'used_percent'}),
+    'network': frozenset({'bytes_sent', 'bytes_recv', 'speed_sent', 'speed_recv'}),
+}
+_PERCENT_FIELDS = frozenset({'usage_percent', 'used_percent'})
+_REGISTRATION_LOG_FIELDS = ('name', 'host', 'port', 'service_type', 'version')
+_REGISTRATION_LOG_VALUE_MAX_LENGTH = 128
+
+
+def _bounded_log_value(value):
+    """Return a bounded scalar safe for a single-line registration log."""
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        return None
+    text = str(value)
+    control_index = next(
+        (index for index, char in enumerate(text) if not char.isprintable()),
+        len(text),
+    )
+    return text[:control_index][:_REGISTRATION_LOG_VALUE_MAX_LENGTH]
+
+
+def _registration_log_fields(agent_data):
+    """Select only explicitly public, scalar registration fields for logging."""
+    safe_fields = {}
+    for field in _REGISTRATION_LOG_FIELDS:
+        if field not in agent_data:
+            continue
+        safe_value = _bounded_log_value(agent_data[field])
+        if safe_value is not None:
+            safe_fields[field] = safe_value
+    return safe_fields
+
+
+def _valid_metric_number(field, value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        return False
+    if field in _PERCENT_FIELDS:
+        return 0 <= value <= 100
+    if not isinstance(value, int) or value < 0:
+        return False
+    return value <= (65536 if field == 'core_count' else (2 ** 64 - 1))
+
+
+def _validate_system_metrics(metrics):
+    if not isinstance(metrics, dict) or set(metrics) - (set(_METRIC_FIELDS) | {'collected_at'}):
+        return False
+    if len(json.dumps(metrics, ensure_ascii=False).encode('utf-8')) > 16 * 1024:
+        return False
+    collected_at = metrics.get('collected_at')
+    if collected_at is not None and (not isinstance(collected_at, str) or len(collected_at) > 64):
+        return False
+    for section, allowed_fields in _METRIC_FIELDS.items():
+        if section not in metrics:
+            continue
+        values = metrics[section]
+        if not isinstance(values, dict) or set(values) - allowed_fields:
+            return False
+        if any(not _valid_metric_number(field, value) for field, value in values.items()):
+            return False
+    return True
+
+
+def _validate_heartbeat_payload(payload):
+    if not isinstance(payload, dict) or set(payload) - _HEARTBEAT_FIELDS:
+        return False
+    for field, max_length in (('version', 128), ('config_version', 128), ('service_status', 64)):
+        if field in payload:
+            value = payload[field]
+            if not isinstance(value, str) or len(value) > max_length:
+                return False
+    return 'system_metrics' not in payload or _validate_system_metrics(payload['system_metrics'])
+
+
+def _constant_time_ascii_equal(provided, expected):
+    if not isinstance(provided, str) or not isinstance(expected, str):
+        return False
+    try:
+        return hmac.compare_digest(provided.encode('ascii'), expected.encode('ascii'))
+    except UnicodeEncodeError:
+        return False
 
 
 def _supports_self_restart(agent_version: str) -> bool:
@@ -35,6 +122,11 @@ def _supports_self_restart(agent_version: str) -> bool:
     if not agent_version:
         return False
     return compare_versions(agent_version, _SELF_RESTART_MIN_VERSION) >= 0
+
+
+def _public_agent(agent):
+    """Return an API-safe copy of an Agent without its capability token."""
+    return {key: value for key, value in agent.items() if key != 'token'}
 
 
 @bp.route('/install-script', methods=['GET'])
@@ -139,10 +231,6 @@ def register_agent():
     try:
         agent_manager = get_agent_manager()
 
-        # 记录请求信息以便调试
-        logger.info("收到Agent注册请求")
-        logger.info(f"Content-Type: {request.content_type}")
-
         # 获取 JSON 数据
         agent_data = request.get_json(force=True, silent=False)
 
@@ -155,13 +243,11 @@ def register_agent():
         if registration_key:
             provided_key = agent_data.get('registration_key', '')
             if provided_key != registration_key:
-                logger.warning(f"Agent 注册被拒绝：注册密钥不匹配（来源 IP: {request.remote_addr}）")
+                logger.warning("Agent 注册被拒绝：注册密钥不匹配")
                 return jsonify({'success': False, 'message': 'Invalid registration key'}), 403
 
         # 移除注册密钥（不存入配置，并先于日志记录以防止泄露）
         agent_data.pop('registration_key', None)
-
-        logger.info(f"Agent数据: {agent_data}")
 
         # 获取客户端真实 IP（用于 Docker 容器等场景）
         agent_host = agent_data.get('host', '')
@@ -185,18 +271,26 @@ def register_agent():
 
         # 如果是 Docker 容器 IP 或没有提供 host，使用客户端 IP
         if not agent_host or is_docker_ip:
-            logger.info(f"Agent提供的host为Docker容器IP或为空({agent_host})，使用客户端IP: {client_ip}")
             agent_data['host'] = client_ip
-        else:
-            logger.info(f"保留Agent提供的host: {agent_host}")
 
-        # 注册 Agent
-        result = agent_manager.register_agent(agent_data)
+        logger.info("Agent注册字段: %s", _registration_log_fields(agent_data))
+
+        # 已有 Agent 的重注册必须使用其当前能力令牌。注册密钥仅控制首次
+        # 注册资格，不能替代已有 Agent 的令牌认证。
+        existing_token = parse_bearer_token(
+            request.headers.get('Authorization', '')
+        )
+
+        # host 已按真实客户端 IP 归一化后，才允许 Manager 做 name/host 匹配。
+        result = agent_manager.register_agent(agent_data, existing_token=existing_token)
 
         response_data = {'success': True, **result}
         logger.info(f"注册成功: {result.get('id')}")
 
         return jsonify(response_data), 200
+
+    except PermissionError:
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
 
     except Exception as e:
         import traceback
@@ -211,14 +305,37 @@ def agent_heartbeat(agent_id):
     """Agent 心跳"""
     try:
         agent_manager = get_agent_manager()
-        heartbeat_data = request.json or {}
+        agent = agent_manager.get_agent_by_id(agent_id)
+        provided_token = parse_bearer_token(
+            request.headers.get('Authorization', '')
+        )
+        expected_token = agent.get('token', '') if agent else ''
+        if (
+            provided_token is None
+            or not isinstance(expected_token, str)
+            or not expected_token
+            or not _constant_time_ascii_equal(provided_token, expected_token)
+        ):
+            return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+
+        if request.content_length is not None and request.content_length > _HEARTBEAT_MAX_CONTENT_LENGTH:
+            return jsonify({'success': False, 'message': 'Request body too large'}), 413
+        raw_body = request.stream.read(_HEARTBEAT_MAX_CONTENT_LENGTH + 1)
+        if len(raw_body) > _HEARTBEAT_MAX_CONTENT_LENGTH:
+            return jsonify({'success': False, 'message': 'Request body too large'}), 413
+        if not request.is_json:
+            return jsonify({'success': False, 'message': 'Invalid heartbeat data'}), 400
+        try:
+            heartbeat_data = json.loads(raw_body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return jsonify({'success': False, 'message': 'Invalid heartbeat data'}), 400
+        if not _validate_heartbeat_payload(heartbeat_data):
+            return jsonify({'success': False, 'message': 'Invalid heartbeat data'}), 400
+
         result = agent_manager.update_heartbeat(agent_id, heartbeat_data)
         if result:
-            # 心跳信息是临时状态，不需要持久化到配置文件
-            # 只在内存中更新即可
             return jsonify({'success': True}), 200
-        else:
-            return jsonify({'success': False, 'message': 'Agent not found'}), 404
+        return jsonify({'success': False, 'message': 'Agent not found'}), 404
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500
 
@@ -229,7 +346,7 @@ def get_agent_config(agent_id):
     try:
         # 从查询参数获取 token
         token = request.args.get('token')
-        if not token:
+        if not is_token_within_length(token):
             return jsonify({'success': False, 'message': 'Token required'}), 401
 
         agent_manager = get_agent_manager()
@@ -293,7 +410,7 @@ def handle_agents():
     agent_manager = get_agent_manager()
 
     if request.method == 'GET':
-        agents = agent_manager.get_all_agents()
+        agents = [_public_agent(agent) for agent in agent_manager.get_all_agents()]
         # 为每个 agent 添加 has_update 字段
         for agent in agents:
             current_version = agent.get('version', '0.0.0')
@@ -319,7 +436,7 @@ def handle_agent_item(agent_id):
     if request.method == 'GET':
         agent = agent_manager.get_agent_by_id(agent_id)
         if agent:
-            return jsonify(agent), 200
+            return jsonify(_public_agent(agent)), 200
         else:
             return jsonify({'success': False, 'message': 'Agent not found'}), 404
 

--- a/backend/routes/aggregations.py
+++ b/backend/routes/aggregations.py
@@ -13,7 +13,15 @@ from typing import Dict, Any
 from datetime import datetime
 from flask import request, jsonify, send_file, current_app, Response
 
-from backend.common.config import config_data, save_config, DATA_DIR
+from backend.common.config import (
+    config_data,
+    save_config,
+    update_config_transaction,
+    DATA_DIR,
+    get_repository,
+    get_config,
+)
+from backend.common.profile_context import resolve_profile_id
 from backend.common.auth import validate_token_or_jwt, require_auth
 from backend.routes import subscription_aggregations_bp as bp
 from backend.converters.mihomo import convert_node_to_mihomo
@@ -30,9 +38,6 @@ logger = get_logger(__name__)
 # 聚合 provider 文件存储目录
 AGGREGATION_PROVIDERS_DIR = os.path.join(DATA_DIR, 'providers')
 
-# 确保目录存在
-if not os.path.exists(AGGREGATION_PROVIDERS_DIR):
-    os.makedirs(AGGREGATION_PROVIDERS_DIR)
 
 
 # ============================================================================
@@ -60,6 +65,8 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
     4. 转换为 mihomo 格式
     5. 生成并保存 YAML 文件
     """
+    profile_id = resolve_profile_id()
+    config_data = get_config(profile_id)
     agg_id = aggregation['id']
     agg_name = aggregation['name']
 
@@ -106,7 +113,8 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
                     {
                         'subscription_name': sub['name'],
                         'url': sub.get('url')
-                    }
+                    },
+                    profile_id=profile_id,
                 )
                 if source == 'rendered_yaml':
                     logger.info(f"成功直接复用订阅 URL 返回的 Sub-Store YAML 并更新缓存: '{sub['name']}', 节点数: {len(nodes_list)}")
@@ -123,7 +131,7 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
 
             # 如果从 Sub-Store 获取失败，从本地缓存读取
             if not nodes_list:
-                cache = load_subscription_cache(sub_id)
+                cache = load_subscription_cache(sub_id, profile_id=profile_id)
                 if cache:
                     nodes_list = cache.get('nodes', [])
                     logger.info(f"从本地缓存读取订阅 '{sub['name']}', 节点数: {len(nodes_list)}")
@@ -226,16 +234,18 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
         indent=2
     )
 
-    # 6. 保存到文件
-    file_path = os.path.join(AGGREGATION_PROVIDERS_DIR, f"{agg_id}.yaml")
-    with open(file_path, 'w', encoding='utf-8') as f:
-        f.write(yaml_content)
+    # 6. 保存到当前 profile 的文件
+    file_path = get_repository().write_profile_text(
+        profile_id,
+        os.path.join('providers', f"{agg_id}.yaml"),
+        yaml_content,
+    )
 
     logger.info(f"生成聚合 provider: {agg_name}, {len(proxies)} 个节点")
 
     # 7. 返回文件路径和统计数据（不保存到配置文件）
     return {
-        'file_path': file_path,
+        'file_path': str(file_path),
         'subscription_node_counts': subscription_node_counts,
         'total_count': len(proxies)
     }
@@ -317,11 +327,9 @@ def handle_subscription_aggregations():
         aggregation.pop('subscription_node_counts', None)
         aggregation.pop('loading_count', None)
 
-        if 'subscription_aggregations' not in config_data:
-            config_data['subscription_aggregations'] = []
-
-        config_data['subscription_aggregations'].append(aggregation)
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('subscription_aggregations', []).append(aggregation)
+        )
 
         return jsonify({'success': True, 'data': aggregation})
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,120 +1,60 @@
 """认证相关路由"""
+import re
 from flask import request, jsonify
 from backend.routes import auth_bp
 from backend.common.internal_call import is_internal_call
-from backend.common.auth import (
-    is_auth_enabled,
-    generate_token,
-    verify_token,
-    require_auth,
-    ADMIN_USERNAME,
-    ADMIN_PASSWORD,
-    JWT_EXPIRATION_HOURS
-)
-
+from backend.common.auth import is_auth_enabled, generate_token, verify_token, require_auth, ADMIN_USERNAME, ADMIN_PASSWORD, JWT_EXPIRATION_HOURS
 
 @auth_bp.route('/status', methods=['GET'])
 def auth_status():
-    """检查认证状态"""
-    return jsonify({
-        'authEnabled': is_auth_enabled()
-    })
-
+    return jsonify({'authEnabled': is_auth_enabled()})
 
 @auth_bp.route('/login', methods=['POST'])
 def login():
-    """用户登录"""
     try:
         data = request.json
-        username = data.get('username')
-        password = data.get('password')
-
-        # 如果没有启用认证，返回错误
+        username, password = data.get('username'), data.get('password')
         if not is_auth_enabled():
             return jsonify({'success': False, 'message': 'Authentication is not enabled'}), 400
-
-        # 验证用户名和密码
         if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
-            token = generate_token(username)
-            return jsonify({
-                'success': True,
-                'token': token,
-                'username': username,
-                'expiresIn': JWT_EXPIRATION_HOURS * 3600  # 以秒为单位
-            })
-        else:
-            return jsonify({'success': False, 'message': 'Invalid username or password'}), 401
-
+            return jsonify({'success': True, 'token': generate_token(username), 'username': username, 'expiresIn': JWT_EXPIRATION_HOURS * 3600})
+        return jsonify({'success': False, 'message': 'Invalid username or password'}), 401
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500
-
 
 @auth_bp.route('/verify', methods=['GET'])
 @require_auth
 def verify():
-    """验证 token 是否有效"""
     return jsonify({'success': True, 'message': 'Token is valid'})
 
-
 def setup_before_request(app):
-    """设置全局认证中间件"""
     @app.before_request
     def before_request_auth():
-        """全局认证检查 - 只在启用认证时生效"""
-        # 由 MCP 层发起的进程内调用，认证已在 /mcp 入口完成，不再重复校验
-        if is_internal_call():
+        if is_internal_call() or not is_auth_enabled():
             return None
-
-        # 如果没有启用认证，跳过
-        if not is_auth_enabled():
-            return None
-
-        # 不需要认证的路径列表
-        public_paths = [
-            '/api/auth/status',
-            '/api/auth/login',
-            '/api/config/mihomo',  # 配置订阅 URL
-            '/api/config/surge',
-            '/api/config/mosdns',
-            '/api/agents/register',  # Agent 注册
-            '/api/agents/install-script',  # 安装脚本
-            '/api/agents/docker-compose',
-            '/api/agents/docker-run',
-            '/api/agents/docker-mihomo-compose',  # Docker Mihomo 脚本
-            '/api/agents/docker-mihomo-run',
-            '/api/agents/docker-mosdns-compose',  # Docker mosdns 脚本
-            '/api/agents/docker-mosdns-run',
-            '/api/rule-library/content/',  # 规则库内容
-            '/api/rules/local/',  # 本地规则文件（供 Mihomo 访问）
-            '/api/mosdns/rule-proxy',  # MosDNS 规则代理
-            '/api/version',  # 版本信息
-            '/mcp',  # MCP 端点（在 mcp_server.auth 中自行校验 JWT / 配置令牌）
-            '/api/static/agents/',  # Agent 二进制文件下载
-            '/',  # 前端首页
-        ]
-
-        # Agent 心跳路径（动态匹配）
+        public_exact_paths = {
+            '/api/auth/status', '/api/auth/login', '/api/config/mihomo', '/api/config/surge', '/api/config/mosdns',
+            '/api/mosdns/rule-proxy',
+            '/api/agents/register', '/api/agents/install-script', '/api/agents/docker-compose', '/api/agents/docker-run',
+            '/api/agents/docker-mihomo-compose', '/api/agents/docker-mihomo-run', '/api/agents/docker-mosdns-compose',
+            '/api/agents/docker-mosdns-run', '/api/version', '/', '/mcp',
+        }
+        public_prefixes = ('/api/rule-library/content/', '/api/rules/local/', '/mcp/', '/api/static/agents/', '/assets/', '/static/')
         if request.path.startswith('/api/agents/') and request.path.endswith('/heartbeat'):
             return None
-
-        # 检查是否是公共路径
-        is_public = any(request.path.startswith(path) for path in public_paths)
+        profile_public_patterns = (
+            r'^/api/config/[A-Za-z0-9][A-Za-z0-9_-]{0,63}/(?:mihomo|surge|mosdns)$',
+            r'^/api/profiles/[A-Za-z0-9][A-Za-z0-9_-]{0,63}/mosdns/rule-proxy$',
+            r'^/api/profiles/[A-Za-z0-9][A-Za-z0-9_-]{0,63}/(?:subscriptions/[^/]+/proxies|aggregations/[^/]+/provider|rules/local/[^/]+|rule-library/content/[^/]+)$',
+        )
+        is_public = request.path in public_exact_paths or any(request.path.startswith(path) for path in public_prefixes)
+        is_public = is_public or any(re.match(pattern, request.path) for pattern in profile_public_patterns)
         if is_public:
             return None
-
-        # 静态文件不需要认证
-        if request.path.startswith('/assets/') or request.path.startswith('/static/'):
-            return None
-
-        # 检查 token
         auth_header = request.headers.get('Authorization')
         if not auth_header or not auth_header.startswith('Bearer '):
             return jsonify({'success': False, 'message': 'Unauthorized'}), 401
-
-        token = auth_header.split(' ')[1]
-        payload = verify_token(token)
-
-        if not payload:
+        payload = verify_token(auth_header.split(' ', 1)[1])
+        if not payload or (isinstance(payload, dict) and 'error' in payload):
             return jsonify({'success': False, 'message': 'Invalid or expired token'}), 401
-
         return None

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -3,7 +3,7 @@ import re
 from flask import request, jsonify
 from backend.routes import auth_bp
 from backend.common.internal_call import is_internal_call
-from backend.common.auth import is_auth_enabled, generate_token, verify_token, require_auth, ADMIN_USERNAME, ADMIN_PASSWORD, JWT_EXPIRATION_HOURS
+from backend.common.auth import is_auth_enabled, generate_token, parse_bearer_token, verify_token, require_auth, ADMIN_USERNAME, ADMIN_PASSWORD, JWT_EXPIRATION_HOURS
 
 @auth_bp.route('/status', methods=['GET'])
 def auth_status():
@@ -51,10 +51,10 @@ def setup_before_request(app):
         is_public = is_public or any(re.match(pattern, request.path) for pattern in profile_public_patterns)
         if is_public:
             return None
-        auth_header = request.headers.get('Authorization')
-        if not auth_header or not auth_header.startswith('Bearer '):
+        token = parse_bearer_token(request.headers.get('Authorization'))
+        if token is None:
             return jsonify({'success': False, 'message': 'Unauthorized'}), 401
-        payload = verify_token(auth_header.split(' ', 1)[1])
+        payload = verify_token(token)
         if not payload or (isinstance(payload, dict) and 'error' in payload):
             return jsonify({'success': False, 'message': 'Invalid or expired token'}), 401
         return None

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -2,20 +2,29 @@
 import os
 import json
 import copy
-import tempfile
-import jwt
-
+import io
 from flask import request, jsonify, send_file
 
 from backend.routes import config_bp
-from backend.common.auth import require_auth, JWT_SECRET_KEY, JWT_ALGORITHM
-from backend.common.config import get_config, save_config, CONFIG_FILE
+from backend.common.auth import require_auth, validate_token_or_jwt
+from backend.common.config import get_config, save_config
+from backend.common.profile_context import resolve_profile_id
 from backend.utils.logger import get_logger
 
 logger = get_logger(__name__)
 from backend.converters.mihomo import generate_mihomo_config
 from backend.converters.surge import generate_surge_config
 from backend.converters.mosdns import generate_mosdns_config
+
+
+def _reject_invalid_config_auth(config_data):
+    auth_result = validate_token_or_jwt(request, config_data)
+    if auth_result.get('valid'):
+        return None
+    return jsonify({
+        'success': False,
+        'message': auth_result.get('message', 'Unauthorized'),
+    }), 401
 
 
 @config_bp.route('/mihomo', methods=['GET'])
@@ -27,30 +36,11 @@ def get_mihomo_config():
     2. 外部请求：使用 URL 参数 ?token=xxx
     """
     try:
-        config_data = get_config()
+        config_data = get_config(resolve_profile_id(fallback='default'))
 
-        # 检查是否有 Authorization header（前端请求）
-        auth_header = request.headers.get('Authorization', '')
-        has_valid_jwt = False
-
-        if auth_header and auth_header.startswith('Bearer '):
-            # 尝试验证 JWT token
-            try:
-                jwt_token = auth_header.split(' ')[1]
-                jwt.decode(jwt_token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-                has_valid_jwt = True
-            except Exception:
-                pass
-
-        # 如果没有有效的 JWT，检查配置令牌（外部请求）
-        if not has_valid_jwt:
-            config_token = config_data.get('system_config', {}).get('config_token', '')
-            if config_token:
-                # 从查询参数获取令牌
-                request_token = request.args.get('token', '')
-                if not request_token or request_token != config_token:
-                    return jsonify({'success': False, 'message': 'Invalid or missing token'}), 401
-            # 如果没有配置令牌，则允许访问（向后兼容）
+        auth_error = _reject_invalid_config_auth(config_data)
+        if auth_error:
+            return auth_error
 
         # 获取前端传递的 base_url（协议 + 主机 + 端口）
         # 优先从query参数获取，如果没有则尝试从JSON body获取（兼容POST请求）
@@ -80,30 +70,11 @@ def get_surge_config():
     2. 外部请求：使用 URL 参数 ?token=xxx
     """
     try:
-        config_data = get_config()
+        config_data = get_config(resolve_profile_id(fallback='default'))
 
-        # 检查是否有 Authorization header（前端请求）
-        auth_header = request.headers.get('Authorization', '')
-        has_valid_jwt = False
-
-        if auth_header and auth_header.startswith('Bearer '):
-            # 尝试验证 JWT token
-            try:
-                jwt_token = auth_header.split(' ')[1]
-                jwt.decode(jwt_token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-                has_valid_jwt = True
-            except Exception:
-                pass
-
-        # 如果没有有效的 JWT，检查配置令牌（外部请求）
-        if not has_valid_jwt:
-            config_token = config_data.get('system_config', {}).get('config_token', '')
-            if config_token:
-                # 从查询参数获取令牌
-                request_token = request.args.get('token', '')
-                if not request_token or request_token != config_token:
-                    return jsonify({'success': False, 'message': 'Invalid or missing token'}), 401
-            # 如果没有配置令牌，则允许访问（向后兼容）
+        auth_error = _reject_invalid_config_auth(config_data)
+        if auth_error:
+            return auth_error
 
         # 获取 base_url（从请求头构建）
         scheme = request.headers.get('X-Forwarded-Proto', request.scheme)
@@ -131,30 +102,11 @@ def get_mosdns_config():
     2. 外部请求：使用 URL 参数 ?token=xxx
     """
     try:
-        config_data = get_config()
+        config_data = get_config(resolve_profile_id(fallback='default'))
 
-        # 检查是否有 Authorization header（前端请求）
-        auth_header = request.headers.get('Authorization', '')
-        has_valid_jwt = False
-
-        if auth_header and auth_header.startswith('Bearer '):
-            # 尝试验证 JWT token
-            try:
-                jwt_token = auth_header.split(' ')[1]
-                jwt.decode(jwt_token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-                has_valid_jwt = True
-            except Exception:
-                pass
-
-        # 如果没有有效的 JWT，检查配置令牌（外部请求）
-        if not has_valid_jwt:
-            config_token = config_data.get('system_config', {}).get('config_token', '')
-            if config_token:
-                # 从查询参数获取令牌
-                request_token = request.args.get('token', '')
-                if not request_token or request_token != config_token:
-                    return jsonify({'success': False, 'message': 'Invalid or missing token'}), 401
-            # 如果没有配置令牌，则允许访问（向后兼容）
+        auth_error = _reject_invalid_config_auth(config_data)
+        if auth_error:
+            return auth_error
 
         # 获取 base_url（从请求头构建）
         scheme = request.headers.get('X-Forwarded-Proto', request.scheme)
@@ -173,6 +125,21 @@ def get_mosdns_config():
         return jsonify({'success': False, 'message': str(e)}), 500
 
 
+@config_bp.route('/<profile_id>/mihomo', methods=['GET'])
+def get_profile_mihomo_config(profile_id):
+    return get_mihomo_config()
+
+
+@config_bp.route('/<profile_id>/surge', methods=['GET'])
+def get_profile_surge_config(profile_id):
+    return get_surge_config()
+
+
+@config_bp.route('/<profile_id>/mosdns', methods=['GET'])
+def get_profile_mosdns_config(profile_id):
+    return get_mosdns_config()
+
+
 @config_bp.route('/export', methods=['GET'])
 @require_auth
 def export_config():
@@ -186,6 +153,7 @@ def export_config():
         # 脱敏导出：移除敏感信息
         # 深拷贝配置数据，避免影响原始数据
         desensitized_data = copy.deepcopy(config_data)
+        desensitized_data.pop('profile_id', None)
 
         # 脱敏订阅的 URL
         for sub in desensitized_data.get('subscriptions', []):
@@ -196,22 +164,24 @@ def export_config():
             if 'proxy_string' in node:
                 node['proxy_string'] = '***已脱敏***'
 
-        # 创建临时文件
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False, encoding='utf-8') as f:
-            json.dump(desensitized_data, f, ensure_ascii=False, indent=2)
-            temp_file = f.name
-
-        try:
-            return send_file(temp_file, as_attachment=True, download_name='config_desensitized.json')
-        finally:
-            # 清理临时文件
-            try:
-                os.unlink(temp_file)
-            except Exception as e:
-                logger.warning(f"清理临时文件失败: {temp_file}, 错误: {e}")
+        payload = json.dumps(desensitized_data, ensure_ascii=False, indent=2).encode('utf-8')
+        return send_file(
+            io.BytesIO(payload),
+            as_attachment=True,
+            download_name='config_desensitized.json',
+            mimetype='application/json',
+        )
     else:
-        # 正常导出
-        return send_file(CONFIG_FILE, as_attachment=True, download_name='config.json')
+        # 正常导出：旧接口继续返回完整配置，但数据来源改为当前 Profile。
+        export_data = copy.deepcopy(config_data)
+        export_data.pop('profile_id', None)
+        payload = json.dumps(export_data, ensure_ascii=False, indent=2).encode('utf-8')
+        return send_file(
+            io.BytesIO(payload),
+            as_attachment=True,
+            download_name='config.json',
+            mimetype='application/json',
+        )
 
 
 @config_bp.route('/import', methods=['POST'])

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -1,13 +1,13 @@
 """配置管理路由"""
 import os
 import json
-import copy
 import io
 from flask import request, jsonify, send_file
 
 from backend.routes import config_bp
 from backend.common.auth import require_auth, validate_token_or_jwt
 from backend.common.config import get_config, save_config
+from backend.common.config_export import prepare_config_export
 from backend.common.profile_context import resolve_profile_id
 from backend.utils.logger import get_logger
 
@@ -146,42 +146,15 @@ def export_config():
     """导出配置为 JSON"""
     config_data = get_config()
 
-    # 检查是否是脱敏导出
     desensitize = request.args.get('desensitize', 'false').lower() == 'true'
-
-    if desensitize:
-        # 脱敏导出：移除敏感信息
-        # 深拷贝配置数据，避免影响原始数据
-        desensitized_data = copy.deepcopy(config_data)
-        desensitized_data.pop('profile_id', None)
-
-        # 脱敏订阅的 URL
-        for sub in desensitized_data.get('subscriptions', []):
-            sub['url'] = '***已脱敏***'
-
-        # 脱敏节点的 proxy_string
-        for node in desensitized_data.get('nodes', []):
-            if 'proxy_string' in node:
-                node['proxy_string'] = '***已脱敏***'
-
-        payload = json.dumps(desensitized_data, ensure_ascii=False, indent=2).encode('utf-8')
-        return send_file(
-            io.BytesIO(payload),
-            as_attachment=True,
-            download_name='config_desensitized.json',
-            mimetype='application/json',
-        )
-    else:
-        # 正常导出：旧接口继续返回完整配置，但数据来源改为当前 Profile。
-        export_data = copy.deepcopy(config_data)
-        export_data.pop('profile_id', None)
-        payload = json.dumps(export_data, ensure_ascii=False, indent=2).encode('utf-8')
-        return send_file(
-            io.BytesIO(payload),
-            as_attachment=True,
-            download_name='config.json',
-            mimetype='application/json',
-        )
+    export_data = prepare_config_export(config_data, desensitize=desensitize)
+    payload = json.dumps(export_data, ensure_ascii=False, indent=2).encode('utf-8')
+    return send_file(
+        io.BytesIO(payload),
+        as_attachment=True,
+        download_name='config_desensitized.json' if desensitize else 'config.json',
+        mimetype='application/json',
+    )
 
 
 @config_bp.route('/import', methods=['POST'])

--- a/backend/routes/generate.py
+++ b/backend/routes/generate.py
@@ -1,6 +1,5 @@
 """配置生成路由"""
 import io
-import os
 import zipfile
 
 import requests
@@ -8,7 +7,8 @@ from flask import request, jsonify, send_file
 
 from backend.routes import generate_bp
 from backend.common.auth import require_auth
-from backend.common.config import get_config, DATA_DIR
+from backend.common.config import get_config, get_repository
+from backend.common.profile_context import resolve_profile_id
 from backend.converters.mihomo import generate_mihomo_config
 from backend.converters.surge import generate_surge_config
 from backend.converters.mosdns import (
@@ -32,9 +32,9 @@ def generate_mihomo():
         yaml_content = generate_mihomo_config(config_data, base_url=base_url)
 
         # 保存到数据目录
-        output_file = os.path.join(DATA_DIR, 'config.yaml')
-        with open(output_file, 'w', encoding='utf-8') as f:
-            f.write(yaml_content)
+        output_file = get_repository().write_generated(
+            resolve_profile_id(), 'config.yaml', yaml_content
+        )
 
         return send_file(output_file, as_attachment=True, download_name='mihomo.yaml')
     except Exception as e:
@@ -55,9 +55,9 @@ def generate_surge():
         config_content = generate_surge_config(config_data, base_url=base_url)
 
         # 保存到数据目录
-        output_file = os.path.join(DATA_DIR, 'config.conf')
-        with open(output_file, 'w', encoding='utf-8') as f:
-            f.write(config_content)
+        output_file = get_repository().write_generated(
+            resolve_profile_id(), 'config.conf', config_content
+        )
 
         return send_file(output_file, as_attachment=True, download_name='surge.conf')
     except Exception as e:

--- a/backend/routes/mosdns.py
+++ b/backend/routes/mosdns.py
@@ -450,14 +450,30 @@ def _fetch_remote_content(url: str) -> str:
 
 
 def _require_rule_proxy_auth():
-    from backend.common.auth import verify_token
-    config_token = config_data.get('system_config', {}).get('config_token', '')
+    from backend.common.auth import is_token_within_length, parse_bearer_token, verify_token
+    from backend.common.config import get_repository
+    system_config = config_data.get('system_config', {})
+    config_token = system_config.get('config_token', '')
+    rule_proxy_token = system_config.get('rule_proxy_token', '')
     header = request.headers.get('Authorization', '')
-    if header.startswith('Bearer '):
-        payload = verify_token(header.split(' ', 1)[1])
+    bearer = parse_bearer_token(header) or ''
+    internal_tokens = get_repository().rule_proxy_tokens_for_sanitization()
+    retired_tokens = internal_tokens - {rule_proxy_token}
+    if bearer in retired_tokens:
+        return False
+    if bearer:
+        payload = verify_token(bearer)
         if payload and not (isinstance(payload, dict) and 'error' in payload):
             return True
-    return bool(config_token and request.args.get('token') == config_token)
+    url_token = request.args.get('token', '')
+    if not is_token_within_length(url_token):
+        url_token = ''
+    if url_token in retired_tokens:
+        return False
+    return bool(
+        (rule_proxy_token and url_token == rule_proxy_token)
+        or (config_token and url_token == config_token)
+    )
 
 
 @bp.route('/rule-proxy', methods=['GET'])

--- a/backend/routes/mosdns.py
+++ b/backend/routes/mosdns.py
@@ -364,6 +364,32 @@ def handle_mosdns_cache_settings():
 
 _MAX_RULE_PROXY_BYTES = 5 * 1024 * 1024
 _MAX_RULE_PROXY_REDIRECTS = 3
+_FORBIDDEN_REMOTE_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        # Multicast.
+        '224.0.0.0/4',
+        'ff00::/8',
+        # Carrier-grade NAT.
+        '100.64.0.0/10',
+        # Documentation and benchmarking ranges.
+        '192.0.2.0/24',
+        '198.51.100.0/24',
+        '203.0.113.0/24',
+        '2001:db8::/32',
+        '198.18.0.0/15',
+        '2001:2::/48',
+        # IPv6 unique-local addresses.
+        'fc00::/7',
+        # Link-local, loopback, and unspecified ranges.
+        '169.254.0.0/16',
+        'fe80::/10',
+        '127.0.0.0/8',
+        '::1/128',
+        '0.0.0.0/32',
+        '::/128',
+    )
+)
 
 
 def _validate_remote_url(url: str) -> str:
@@ -382,12 +408,28 @@ def _resolve_remote_url(url: str):
         addresses = {item[4][0] for item in socket.getaddrinfo(hostname, parsed.port, type=socket.SOCK_STREAM)}
     except (OSError, ValueError) as exc:
         raise ValueError('Unable to resolve remote host') from exc
-    for address in addresses:
-        ip = ipaddress.ip_address(address)
-        if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified or ip.is_reserved:
-            raise ValueError('Private network targets are not allowed')
     if not addresses:
         raise ValueError('Unable to resolve remote host')
+    for address in addresses:
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError as exc:
+            raise ValueError('Unable to resolve remote host') from exc
+        explicitly_forbidden = any(
+            ip.version == network.version and ip in network
+            for network in _FORBIDDEN_REMOTE_NETWORKS
+        )
+        if (
+            explicitly_forbidden
+            or ip.is_multicast
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_loopback
+            or ip.is_unspecified
+            or ip.is_reserved
+            or not ip.is_global
+        ):
+            raise ValueError('Public network targets only')
     return parsed, sorted(addresses)[0]
 
 

--- a/backend/routes/mosdns.py
+++ b/backend/routes/mosdns.py
@@ -1,7 +1,9 @@
 """MosDNS 配置路由模块"""
 import logging
 import os
-from urllib.parse import urlparse
+import ipaddress
+import socket
+from urllib.parse import urlparse, urljoin
 
 from flask import request, jsonify
 
@@ -37,7 +39,7 @@ def _load_cached_rule_content_for_url(original_url: str) -> str:
     # 2. 如果是 rule-library/content/<id> 形式，按 id 找规则库名称
     parsed = urlparse(original_url)
     path = parsed.path or ''
-    marker = '/api/rule-library/content/'
+    marker = '/rule-library/content/'
     if marker in path:
         rule_id = path.split(marker, 1)[1].strip('/').split('/', 1)[0]
         if rule_id:
@@ -360,6 +362,104 @@ def handle_mosdns_cache_settings():
             return jsonify({'success': False, 'message': str(e)}), 500
 
 
+_MAX_RULE_PROXY_BYTES = 5 * 1024 * 1024
+_MAX_RULE_PROXY_REDIRECTS = 3
+
+
+def _validate_remote_url(url: str) -> str:
+    _resolve_remote_url(url)
+    return url
+
+
+def _resolve_remote_url(url: str):
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https') or not parsed.hostname:
+        raise ValueError('Only absolute http/https URLs are allowed')
+    hostname = parsed.hostname.rstrip('.').lower()
+    if hostname == 'localhost' or hostname.endswith('.localhost'):
+        raise ValueError('Private network targets are not allowed')
+    try:
+        addresses = {item[4][0] for item in socket.getaddrinfo(hostname, parsed.port, type=socket.SOCK_STREAM)}
+    except (OSError, ValueError) as exc:
+        raise ValueError('Unable to resolve remote host') from exc
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified or ip.is_reserved:
+            raise ValueError('Private network targets are not allowed')
+    if not addresses:
+        raise ValueError('Unable to resolve remote host')
+    return parsed, sorted(addresses)[0]
+
+
+def _fetch_remote_content(url: str) -> str:
+    import requests
+    import urllib3
+
+    current = url
+    for _ in range(_MAX_RULE_PROXY_REDIRECTS + 1):
+        parsed, address = _resolve_remote_url(current)
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+        hostname = parsed.hostname.rstrip('.')
+        host_header = f'[{hostname}]' if ':' in hostname else hostname
+        if parsed.port and parsed.port != (443 if parsed.scheme == 'https' else 80):
+            host_header = f'{host_header}:{parsed.port}'
+        pool_kwargs = {'timeout': urllib3.Timeout(connect=3, read=10), 'maxsize': 1}
+        if parsed.scheme == 'https':
+            pool_kwargs.update(
+                cert_reqs='CERT_REQUIRED',
+                assert_hostname=hostname,
+                server_hostname=hostname,
+            )
+            pool = urllib3.HTTPSConnectionPool(address, port, **pool_kwargs)
+        else:
+            pool = urllib3.HTTPConnectionPool(address, port, **pool_kwargs)
+        target = parsed.path or '/'
+        if parsed.query:
+            target = f'{target}?{parsed.query}'
+        response = None
+        try:
+            response = pool.urlopen(
+                'GET', target, headers={'Host': host_header}, redirect=False,
+                retries=False, preload_content=False,
+            )
+            if 300 <= response.status < 400:
+                location = response.headers.get('Location')
+                if not location:
+                    raise ValueError('Redirect without Location')
+                current = urljoin(current, location)
+                continue
+            if not 200 <= response.status < 300:
+                raise requests.exceptions.HTTPError(f'Remote server returned HTTP {response.status}')
+            content_length = response.headers.get('Content-Length')
+            if content_length and int(content_length) > _MAX_RULE_PROXY_BYTES:
+                raise ValueError('Remote response exceeds size limit')
+            chunks, total = [], 0
+            for chunk in response.stream(64 * 1024):
+                total += len(chunk)
+                if total > _MAX_RULE_PROXY_BYTES:
+                    raise ValueError('Remote response exceeds size limit')
+                chunks.append(chunk)
+            return b''.join(chunks).decode('utf-8', errors='replace')
+        except urllib3.exceptions.HTTPError as exc:
+            raise requests.exceptions.RequestException(str(exc)) from exc
+        finally:
+            if response is not None:
+                response.release_conn()
+            pool.close()
+    raise ValueError('Too many redirects')
+
+
+def _require_rule_proxy_auth():
+    from backend.common.auth import verify_token
+    config_token = config_data.get('system_config', {}).get('config_token', '')
+    header = request.headers.get('Authorization', '')
+    if header.startswith('Bearer '):
+        payload = verify_token(header.split(' ', 1)[1])
+        if payload and not (isinstance(payload, dict) and 'error' in payload):
+            return True
+    return bool(config_token and request.args.get('token') == config_token)
+
+
 @bp.route('/rule-proxy', methods=['GET'])
 def mosdns_rule_proxy():
     """
@@ -375,8 +475,8 @@ def mosdns_rule_proxy():
 
     2. List 格式:
        - +.example.com → domain:example.com (匹配域名及所有子域名)
-       - .example.com → regexp:.+\.example\.com$ (仅匹配子域名)
-       - *.example.com → regexp:^[^.]+\.example\.com$ (仅匹配直接子域名)
+       - .example.com → regexp:.+\\.example\\.com$ (仅匹配子域名)
+       - *.example.com → regexp:^[^.]+\\.example\\.com$ (仅匹配直接子域名)
        - example.com → full:example.com (精确匹配)
        - ip -> ip
 
@@ -386,20 +486,23 @@ def mosdns_rule_proxy():
         import re
         import requests
 
+        if not _require_rule_proxy_auth():
+            return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+
         # 获取原始 URL
         original_url = request.args.get('url')
         if not original_url:
             return jsonify({'success': False, 'message': 'URL parameter is required'}), 400
 
-        # 应用 GitHub 代理域名替换
+        # 应用代理替换后仍须按最终 URL 做 SSRF 校验。
         fetch_url = apply_github_proxy_domain(original_url, config_data)
+        _validate_remote_url(fetch_url)
 
         # 拉取原始规则文件
         original_content = ''
         try:
-            response = requests.get(fetch_url, timeout=10)
-            response.raise_for_status()
-            original_content = response.text
+            original_content = _fetch_remote_content(fetch_url)
+
         except requests.exceptions.RequestException as e:
             logger.warning(f"远程拉取规则失败，尝试使用本地缓存兜底: {original_url}, 错误: {e}")
             original_content = _load_cached_rule_content_for_url(original_url)
@@ -528,5 +631,7 @@ def mosdns_rule_proxy():
         converted_content = '\n'.join(converted_lines)
         return converted_content, 200, {'Content-Type': 'text/plain; charset=utf-8'}
 
+    except ValueError as e:
+        return jsonify({'success': False, 'message': str(e)}), 400
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -4,7 +4,7 @@ import uuid
 
 from backend.routes import nodes_bp
 from backend.common.auth import require_auth
-from backend.common.config import get_config, save_config
+from backend.common.config import get_config, save_config, update_config_transaction
 
 
 def clean_aggregations_node(node_id):
@@ -63,8 +63,9 @@ def handle_nodes():
         # 如果没有 ID，生成一个唯一 ID
         if 'id' not in node:
             node['id'] = f"node_{uuid.uuid4().hex[:8]}"
-        config_data['nodes'].append(node)
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('nodes', []).append(node)
+        )
         return jsonify({'success': True, 'data': node})
 
 

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -1,0 +1,198 @@
+"""Profile management and explicit profile URL aliases."""
+
+from flask import jsonify, request
+
+from backend.common.auth import require_auth
+from backend.common.config import get_repository
+from backend.routes import profiles_bp
+
+
+@profiles_bp.route('', methods=['GET', 'POST'])
+@require_auth
+def handle_profiles():
+    repository = get_repository()
+    if request.method == 'GET':
+        return jsonify(repository.list_profiles())
+
+    data = request.get_json(silent=True) or {}
+    clone_from = data.pop('clone_from', None)
+    return jsonify(repository.create_profile(data, clone_from=clone_from)), 201
+
+
+@profiles_bp.route('/<profile_id>', methods=['GET', 'PUT', 'DELETE'])
+@require_auth
+def handle_profile(profile_id):
+    repository = get_repository()
+    if request.method == 'GET':
+        return jsonify(repository._profile_metadata(profile_id))
+    if request.method == 'PUT':
+        return jsonify(repository.update_profile(profile_id, request.get_json(silent=True) or {}))
+    repository.delete_profile(profile_id)
+    return '', 204
+
+
+@profiles_bp.route('/<profile_id>/clone', methods=['POST'])
+@require_auth
+def clone_profile(profile_id):
+    data = request.get_json(silent=True) or {}
+    return jsonify(get_repository().clone_profile(profile_id, data)), 201
+
+
+@profiles_bp.route('/<profile_id>/activate', methods=['POST'])
+@require_auth
+def activate_profile(profile_id):
+    profile = get_repository().activate_profile(profile_id)
+    return jsonify({'success': True, 'active_profile_id': profile_id, 'profile': profile})
+
+
+@profiles_bp.route('/<profile_id>/export', methods=['GET'])
+@require_auth
+def export_profile(profile_id):
+    response = jsonify(get_repository().export_profile(profile_id))
+    response.headers['Content-Disposition'] = f'attachment; filename={profile_id}.json'
+    return response
+
+
+@profiles_bp.route('/<profile_id>/import', methods=['POST'])
+@require_auth
+def import_profile(profile_id):
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'success': False, 'message': '请求数据必须是 JSON 对象'}), 400
+    get_repository().import_profile(profile_id, data)
+    return jsonify({'success': True, 'profile_id': profile_id})
+
+
+@profiles_bp.route('/<profile_id>/subscriptions', methods=['GET', 'POST'])
+@require_auth
+def profile_subscriptions(profile_id):
+    from backend.routes.subscriptions import handle_subscriptions
+    return handle_subscriptions()
+
+
+@profiles_bp.route('/<profile_id>/subscriptions/<sub_id>', methods=['DELETE', 'PUT'])
+@require_auth
+def profile_subscription(profile_id, sub_id):
+    from backend.routes.subscriptions import handle_subscription
+    return handle_subscription(sub_id)
+
+
+@profiles_bp.route('/<profile_id>/subscriptions/<sub_id>/nodes', methods=['GET'])
+@require_auth
+def profile_subscription_nodes(profile_id, sub_id):
+    from backend.routes.subscriptions import get_subscription_nodes
+    return get_subscription_nodes(sub_id)
+
+
+@profiles_bp.route('/<profile_id>/subscriptions/<sub_id>/proxies', methods=['GET'])
+def profile_subscription_proxies(profile_id, sub_id):
+    from backend.routes.subscriptions import get_subscription_proxies
+    return get_subscription_proxies(sub_id)
+
+
+@profiles_bp.route('/<profile_id>/nodes', methods=['GET', 'POST'])
+@require_auth
+def profile_nodes(profile_id):
+    from backend.routes.nodes import handle_nodes
+    return handle_nodes()
+
+
+@profiles_bp.route('/<profile_id>/rules', methods=['GET', 'POST'])
+@require_auth
+def profile_rules(profile_id):
+    from backend.routes.rules import handle_rules
+    return handle_rules()
+
+
+@profiles_bp.route('/<profile_id>/rules/local/<name>', methods=['GET'])
+def profile_local_rule(profile_id, name):
+    from backend.routes.rules import get_local_rule
+    return get_local_rule(name)
+
+
+@profiles_bp.route('/<profile_id>/rule-library', methods=['GET', 'POST'])
+@require_auth
+def profile_rule_library(profile_id):
+    from backend.routes.rule_library import handle_rule_library
+    return handle_rule_library()
+
+
+@profiles_bp.route('/<profile_id>/rule-library/<rule_id>', methods=['DELETE', 'PUT'])
+@require_auth
+def profile_rule_library_item(profile_id, rule_id):
+    from backend.routes.rule_library import handle_rule_library_item
+    return handle_rule_library_item(rule_id)
+
+
+@profiles_bp.route('/<profile_id>/rule-library/content/<rule_id>', methods=['GET'])
+def profile_rule_library_content(profile_id, rule_id):
+    from backend.routes.rule_library import get_rule_library_content
+    return get_rule_library_content(rule_id)
+
+
+@profiles_bp.route('/<profile_id>/proxy-groups', methods=['GET', 'POST'])
+@require_auth
+def profile_proxy_groups(profile_id):
+    from backend.routes.proxy_groups import handle_proxy_groups
+    return handle_proxy_groups()
+
+
+@profiles_bp.route('/<profile_id>/aggregations', methods=['GET', 'POST'])
+@require_auth
+def profile_aggregations(profile_id):
+    from backend.routes.aggregations import handle_subscription_aggregations
+    return handle_subscription_aggregations()
+
+
+@profiles_bp.route('/<profile_id>/aggregations/<agg_id>/provider', methods=['GET'])
+def profile_aggregation_provider(profile_id, agg_id):
+    from backend.routes.aggregations import get_aggregation_provider
+    return get_aggregation_provider(agg_id)
+
+
+@profiles_bp.route('/<profile_id>/mosdns/rule-proxy', methods=['GET'])
+def profile_mosdns_rule_proxy(profile_id):
+    from backend.routes.mosdns import mosdns_rule_proxy
+    return mosdns_rule_proxy()
+
+
+@profiles_bp.route('/<profile_id>/generate/mihomo', methods=['POST'])
+@require_auth
+def profile_generate_mihomo(profile_id):
+    from backend.routes.generate import generate_mihomo
+    return generate_mihomo()
+
+
+@profiles_bp.route('/<profile_id>/generate/surge', methods=['POST'])
+@require_auth
+def profile_generate_surge(profile_id):
+    from backend.routes.generate import generate_surge
+    return generate_surge()
+
+
+@profiles_bp.route('/<profile_id>/generate/mosdns', methods=['POST'])
+@require_auth
+def profile_generate_mosdns(profile_id):
+    from backend.routes.generate import generate_mosdns
+    return generate_mosdns()
+
+
+@profiles_bp.route('/<profile_id>/generate/mihomo/preview', methods=['POST'])
+@require_auth
+def profile_preview_mihomo(profile_id):
+    from backend.routes.generate import preview_mihomo
+    return preview_mihomo()
+
+
+@profiles_bp.route('/<profile_id>/generate/surge/preview', methods=['POST'])
+@require_auth
+def profile_preview_surge(profile_id):
+    from backend.routes.generate import preview_surge
+    return preview_surge()
+
+
+@profiles_bp.route('/<profile_id>/generate/mosdns/preview', methods=['POST'])
+@require_auth
+def profile_preview_mosdns(profile_id):
+    from backend.routes.generate import preview_mosdns
+    return preview_mosdns()

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -4,6 +4,7 @@ from flask import jsonify, request
 
 from backend.common.auth import require_auth
 from backend.common.config import get_repository
+from backend.common.config_export import sanitize_config_for_output
 from backend.routes import profiles_bp
 
 
@@ -48,7 +49,7 @@ def activate_profile(profile_id):
 @profiles_bp.route('/<profile_id>/export', methods=['GET'])
 @require_auth
 def export_profile(profile_id):
-    response = jsonify(get_repository().export_profile(profile_id))
+    response = jsonify(sanitize_config_for_output(get_repository().export_profile(profile_id)))
     response.headers['Content-Disposition'] = f'attachment; filename={profile_id}.json'
     return response
 

--- a/backend/routes/proxy_groups.py
+++ b/backend/routes/proxy_groups.py
@@ -5,7 +5,7 @@ from flask import request, jsonify
 
 from backend.routes import proxy_groups_bp
 from backend.common.auth import require_auth
-from backend.common.config import get_config, save_config
+from backend.common.config import get_config, save_config, update_config_transaction
 from backend.utils.subscription_cache import load_subscription_cache
 
 
@@ -72,8 +72,9 @@ def handle_proxy_groups():
 
     elif request.method == 'POST':
         group = request.json
-        config_data['proxy_groups'].append(group)
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('proxy_groups', []).append(group)
+        )
         return jsonify({'success': True, 'data': group})
 
 

--- a/backend/routes/rule_library.py
+++ b/backend/routes/rule_library.py
@@ -6,7 +6,8 @@ import os
 from flask import request, jsonify
 from flask import Blueprint
 from backend.common.auth import require_auth
-from backend.common.config import config_data, save_config, get_config
+from backend.common.config import config_data, save_config, get_config, update_config_transaction
+from backend.common.profile_context import profile_api_path, resolve_profile_id
 from backend.utils.rule_utils import sanitize_rule_name, get_rules_dir, save_rule_to_local
 from backend.utils.logger import get_logger
 
@@ -37,12 +38,11 @@ def handle_rule_library():
             if 'content' in rule:
                 del rule['content']
 
-        config_data.setdefault('rule_library', []).append(rule)
-
         # 保存规则到本地文件
         save_rule_to_local(rule)
-
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('rule_library', []).append(rule)
+        )
         return jsonify({'success': True, 'data': rule})
 
 
@@ -148,7 +148,10 @@ def handle_rule_library_item(rule_id):
                             if source_type_changed:
                                 if new_source_type == 'content':
                                     # 使用内容接口的相对路径
-                                    rule_config['url'] = f"/api/rule-library/content/{rule_id}"
+                                    rule_config['url'] = profile_api_path(
+                                        config_data,
+                                        f'/rule-library/content/{rule_id}',
+                                    )
                                 else:
                                     # 使用规则库中的 URL
                                     rule_config['url'] = new_rule.get('url', '')
@@ -389,6 +392,7 @@ def cache_rules():
     try:
         data = request.get_json()
         rule_ids = data.get('rule_ids', [])
+        profile_id = resolve_profile_id()
 
         if not rule_ids:
             return jsonify({'success': False, 'message': '请选择要缓存的规则'}), 400
@@ -407,7 +411,7 @@ def cache_rules():
         def cache_single_rule(rule):
             """缓存单个规则"""
             try:
-                local_path = save_rule_to_local(rule)
+                local_path = save_rule_to_local(rule, profile_id=profile_id)
                 return {
                     'id': rule.get('id', ''),
                     'name': rule.get('name', ''),

--- a/backend/routes/rules.py
+++ b/backend/routes/rules.py
@@ -6,7 +6,14 @@ from urllib.parse import urlparse
 from flask import request, jsonify, make_response
 from backend.routes import rules_bp as bp, rule_sets_bp as rule_sets_bp
 from backend.common.auth import require_auth
-from backend.common.config import config_data, save_config, get_config
+from backend.common.config import (
+    config_data,
+    save_config,
+    update_config_transaction,
+    get_config,
+    get_repository,
+)
+from backend.common.profile_context import profile_api_path, resolve_profile_id
 from backend.utils.rule_matcher import parse_rule_line, match_query, is_valid_domain, is_valid_ip
 from backend.utils.rule_utils import get_rules_dir, sanitize_rule_name
 from backend.utils.logger import get_logger
@@ -56,7 +63,10 @@ def normalize_rule_config_url(rule_item: dict) -> None:
 
         source_type = library_rule.get('source_type', 'url')
         if source_type == 'content':
-            rule_item['url'] = f"/api/rule-library/content/{library_rule_id}"
+            rule_item['url'] = profile_api_path(
+                config_data,
+                f'/rule-library/content/{library_rule_id}',
+            )
         else:
             rule_item['url'] = library_rule.get('url', '')
         return
@@ -106,9 +116,9 @@ def handle_rules():
         if 'itemType' not in rule:
             rule['itemType'] = 'rule' if 'rule_type' in rule else 'ruleset'
         normalize_rule_config_url(rule)
-        rule_configs = config_data.setdefault('rule_configs', [])
-        rule_configs.insert(0, rule)  # 新规则添加到第一位
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('rule_configs', []).insert(0, rule)
+        )
         return jsonify({'success': True, 'data': rule})
 
 
@@ -192,9 +202,9 @@ def batch_add_rules():
         }
         new_rules.append(rule)
 
-    rule_configs = config_data.setdefault('rule_configs', [])
-    rule_configs[:0] = new_rules  # 新规则添加到最前面
-    save_config()
+    update_config_transaction(
+        lambda profile: profile.setdefault('rule_configs', []).__setitem__(slice(0, 0), new_rules)
+    )
     return jsonify({'success': True, 'count': len(new_rules), 'rules': new_rules})
 
 
@@ -212,7 +222,8 @@ def get_local_rule(name):
     """
     import os
     from flask import send_file
-    from backend.common.config import DATA_DIR
+    from backend.common.config import get_repository
+    from backend.common.profile_context import resolve_profile_id
     from backend.utils.logger import get_logger
 
     logger = get_logger(__name__)
@@ -221,8 +232,10 @@ def get_local_rule(name):
         # 对规则名称进行清理，确保与文件名匹配
         from backend.utils.rule_utils import sanitize_rule_name, get_rules_dir, save_rule_to_local
 
+        profile_id = resolve_profile_id()
+        repository = get_repository()
         filename = f"{sanitize_rule_name(name)}.list"
-        filepath = os.path.join(get_rules_dir(), filename)
+        filepath = repository.profile_path(profile_id, os.path.join('rules', filename))
 
         logger.info(f"Requesting local rule: {name}, filepath: {filepath}")
 
@@ -260,9 +273,11 @@ def get_local_rule(name):
                 if response.status_code == 200:
                     logger.info(f"Successfully fetched latest data for rule '{name}'")
                     # 更新本地缓存
-                    os.makedirs(get_rules_dir(), exist_ok=True)
-                    with open(filepath, 'w', encoding='utf-8') as f:
-                        f.write(response.text)
+                    repository.write_profile_text(
+                        profile_id,
+                        os.path.join('rules', filename),
+                        response.text,
+                    )
                     # 返回响应并添加 Content-Length 头
                     content = response.text.encode('utf-8')
                     resp = make_response(content, 200)
@@ -289,7 +304,7 @@ def get_local_rule(name):
             # 缓存文件不存在，尝试重新生成
             logger.warning(f"Cache file not found for rule '{name}', regenerating...")
             try:
-                save_rule_to_local(rule)
+                save_rule_to_local(rule, profile_id=profile_id)
                 if os.path.exists(filepath):
                     logger.info(f"Successfully regenerated cache for rule '{name}'")
                     with open(filepath, 'rb') as f:
@@ -337,9 +352,9 @@ def handle_rule_sets():
         # 确保有 itemType 字段
         rule_set['itemType'] = 'ruleset'
         normalize_rule_config_url(rule_set)
-        rule_configs = config_data.setdefault('rule_configs', [])
-        rule_configs.insert(0, rule_set)  # 新规则集添加到第一位
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('rule_configs', []).insert(0, rule_set)
+        )
         return jsonify({'success': True, 'data': rule_set})
 
 
@@ -399,6 +414,8 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
     rule_content = ''
     rule_name = ''
     filepath = ''
+    profile_id = resolve_profile_id()
+    repository = get_repository()
 
     # 获取规则名称和缓存路径
     if library_rule:
@@ -408,7 +425,7 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
 
     if rule_name:
         filename = f"{sanitize_rule_name(rule_name)}.list"
-        filepath = os.path.join(get_rules_dir(), filename)
+        filepath = str(repository.profile_path(profile_id, os.path.join('rules', filename)))
 
     # 1. 优先尝试从本地缓存读取
     if filepath and os.path.exists(filepath):
@@ -441,9 +458,11 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
                         # 保存到本地缓存
                         if filepath:
                             try:
-                                os.makedirs(get_rules_dir(), exist_ok=True)
-                                with open(filepath, 'w', encoding='utf-8') as f:
-                                    f.write(rule_content)
+                                repository.write_profile_text(
+                                    profile_id,
+                                    os.path.join('rules', filename),
+                                    rule_content,
+                                )
                                 logger.info(f"Cached rule content to: {filepath}")
                             except Exception as cache_error:
                                 logger.warning(f"Failed to cache rule content to {filepath}: {cache_error}")
@@ -471,9 +490,11 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
                     # 保存到本地缓存
                     if filepath:
                         try:
-                            os.makedirs(get_rules_dir(), exist_ok=True)
-                            with open(filepath, 'w', encoding='utf-8') as f:
-                                f.write(rule_content)
+                            repository.write_profile_text(
+                                profile_id,
+                                os.path.join('rules', filename),
+                                rule_content,
+                            )
                             logger.info(f"Cached rule content to: {filepath}")
                         except Exception as cache_error:
                             logger.warning(f"Failed to cache rule content to {filepath}: {cache_error}")

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -9,6 +9,10 @@ from backend.routes import settings_bp
 from backend.common.auth import require_auth
 from backend.common.utils import generate_random_token
 from backend.common.config import get_config, save_config
+from backend.common.config_export import (
+    contains_internal_rule_proxy_token,
+    prepare_config_export,
+)
 from backend.version import get_version_info
 
 
@@ -75,6 +79,12 @@ def handle_config_token():
             # 如果没有提供令牌且不生成，返回错误
             if not new_token:
                 return jsonify({'success': False, 'message': 'Token is required or set generate=true'}), 400
+
+            if contains_internal_rule_proxy_token(new_token):
+                return jsonify({
+                    'success': False,
+                    'message': 'Config token must not contain an internal rule proxy token',
+                }), 400
 
             # 确保 system_config 存在
             if 'system_config' not in config_data:
@@ -264,9 +274,8 @@ def backup_now():
 
         # 创建临时文件保存配置
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp_file:
-            # 复制配置并脱敏
-            import copy
-            backup_data = copy.deepcopy(config_data)
+            # 复制配置、移除内部能力字段，并脱敏备份凭证
+            backup_data = prepare_config_export(config_data)
             if 'backup' in backup_data and 'webdav_password' in backup_data['backup']:
                 backup_data['backup']['webdav_password'] = '******'
 

--- a/backend/routes/subscriptions.py
+++ b/backend/routes/subscriptions.py
@@ -6,7 +6,7 @@ import yaml
 
 from backend.routes import subscriptions_bp
 from backend.common.auth import require_auth, validate_token_or_jwt
-from backend.common.config import get_config, save_config
+from backend.common.config import get_config, save_config, update_config_transaction
 from backend.utils.subscription_cache import (
     load_subscription_cache,
     save_subscription_nodes,
@@ -82,8 +82,9 @@ def handle_subscriptions():
 
     elif request.method == 'POST':
         sub = request.json
-        config_data['subscriptions'].append(sub)
-        save_config()
+        update_config_transaction(
+            lambda profile: profile.setdefault('subscriptions', []).append(sub)
+        )
         return jsonify({'success': True, 'data': sub})
 
 

--- a/backend/test_agent_heartbeat_security.py
+++ b/backend/test_agent_heartbeat_security.py
@@ -1,0 +1,299 @@
+import copy
+import io
+
+
+import pytest
+from flask import Flask, Request
+
+from backend.common import config as config_module
+from backend.common.agent_manager import init_agent_manager
+from backend.common.auth import MAX_AUTH_TOKEN_LENGTH
+from backend.common.config_repository import ProfileRepository
+from backend.routes import register_blueprints
+
+
+def _heartbeat_app(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    manager = init_agent_manager()
+    registered = manager.register_agent({"name": "secured", "host": "127.0.0.1"})
+    app = Flask(__name__)
+    register_blueprints(app)
+    return app, repository, registered
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "Basic ignored", "Bearer wrong-token"],
+    ids=["missing", "wrong-scheme", "wrong-token"],
+)
+def test_heartbeat_rejects_unauthorized_without_mutating_system(tmp_path, authorization):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+    headers = {"Authorization": authorization} if authorization else {}
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers=headers,
+        json={"version": "attacker", "config_version": "attacker"},
+    )
+
+    assert response.status_code == 401
+    assert repository.get_system() == before
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        "Bearer 令牌",
+        "Bearer café",
+        "Bearer token with spaces",
+        "Bearer  token",
+        "Bearer\twrong",
+        f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=["unicode", "latin-unicode", "trailing-field", "double-space", "tab", "oversized"],
+)
+def test_heartbeat_rejects_non_ascii_or_malformed_bearer_without_mutating_system(
+    tmp_path, authorization
+):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers={"Authorization": authorization},
+        json={"version": "attacker"},
+    )
+
+    assert response.status_code == 401
+    assert repository.get_system() == before
+
+
+def test_heartbeat_accepts_matching_bearer_token(tmp_path):
+    app, repository, registered = _heartbeat_app(tmp_path)
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers={"Authorization": f"Bearer {registered['token']}"},
+        json={"version": "2.0.0", "config_version": "cfg-2", "service_status": "running"},
+    )
+
+    assert response.status_code == 200
+    agent = next(item for item in repository.get_system()["agents"] if item["id"] == registered["id"])
+    assert agent["version"] == "2.0.0"
+    assert agent["config_version"] == "cfg-2"
+    assert agent["service_status"] == "running"
+
+
+def test_agent_token_is_one_time_registration_only_and_still_authorizes_heartbeat(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    init_agent_manager()
+    app = Flask(__name__)
+    register_blueprints(app)
+    client = app.test_client()
+
+    registered_response = client.post(
+        "/api/agents/register", json={"name": "one-time", "host": "10.0.0.8"}
+    )
+    assert registered_response.status_code == 200
+    registered = registered_response.get_json()
+    token = registered["token"]
+    agent_id = registered["id"]
+    assert token
+    assert set(registered) == {"success", "id", "status", "is_new", "token"}
+
+    ordinary_responses = [
+        client.get("/api/agents"),
+        client.get(f"/api/agents/{agent_id}"),
+        client.get(f"/api/agents/{agent_id}/status"),
+        client.get("/api/config/export"),
+        client.get("/api/profiles/default/export"),
+    ]
+    for response in ordinary_responses:
+        assert response.status_code == 200
+        assert token not in response.get_data(as_text=True)
+
+    heartbeat = client.post(
+        f"/api/agents/{agent_id}/heartbeat",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"version": "2.1.0"},
+    )
+    assert heartbeat.status_code == 200
+    assert token not in heartbeat.get_data(as_text=True)
+
+
+def test_manual_agent_create_does_not_return_token_even_without_auth(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    init_agent_manager()
+    app = Flask(__name__)
+    register_blueprints(app)
+
+    response = app.test_client().post(
+        "/api/agents", json={"name": "manual", "host": "10.0.0.9"}
+    )
+
+    assert response.status_code == 200
+    persisted_token = repository.get_system()["agents"][0]["token"]
+    assert persisted_token not in response.get_data(as_text=True)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {"unexpected": "value"},
+        {"version": 2},
+        {"version": "v" * 129},
+        {"config_version": None},
+        {"config_version": "c" * 129},
+        {"service_status": False},
+        {"service_status": "s" * 65},
+        {"system_metrics": []},
+        {"system_metrics": {"unexpected": {}}},
+        {"system_metrics": {"cpu": {"unexpected": 1}}},
+        {"system_metrics": {"cpu": {"usage_percent": "high"}}},
+        {"system_metrics": {"memory": {"total": -1}}},
+        {"system_metrics": {"collected_at": "t" * 65}},
+    ],
+)
+def test_heartbeat_rejects_unapproved_or_malformed_fields_without_mutation(tmp_path, payload):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers={"Authorization": f"Bearer {registered['token']}"},
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert repository.get_system() == before
+
+
+def test_heartbeat_rejects_malformed_json_without_mutation(tmp_path):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers={
+            "Authorization": f"Bearer {registered['token']}",
+            "Content-Type": "application/json",
+        },
+        data=b'{"version":',
+    )
+
+    assert response.status_code == 400
+    assert repository.get_system() == before
+
+
+def test_heartbeat_rejects_oversized_body_without_mutation(tmp_path):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers={
+            "Authorization": f"Bearer {registered['token']}",
+            "Content-Type": "application/json",
+        },
+        data=b" " * 32769,
+    )
+
+    assert response.status_code == 413
+    assert repository.get_system() == before
+
+
+class CountingStream(io.BytesIO):
+    def __init__(self, payload):
+        super().__init__(payload)
+        self.bytes_returned = 0
+
+    def read(self, size=-1):
+        result = super().read(size)
+        self.bytes_returned += len(result)
+        return result
+
+    def readinto(self, buffer):
+        count = super().readinto(buffer)
+        self.bytes_returned += count or 0
+        return count
+
+
+def _post_stream_without_content_length(app, registered, stream):
+    return app.test_client().open(
+        f"/api/agents/{registered['id']}/heartbeat",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {registered['token']}",
+            "Content-Type": "application/json",
+        },
+        environ_overrides={
+            "wsgi.input": stream,
+            "wsgi.input_terminated": True,
+            "CONTENT_LENGTH": "",
+        },
+    )
+
+
+def test_heartbeat_without_content_length_reads_only_max_plus_one_bytes(tmp_path, monkeypatch):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+    stream = CountingStream(b" " * (1024 * 1024))
+
+    def fail_get_data(*args, **kwargs):
+        raise AssertionError("heartbeat must not call Request.get_data")
+
+    monkeypatch.setattr(Request, "get_data", fail_get_data)
+    response = _post_stream_without_content_length(app, registered, stream)
+
+    assert response.status_code == 413
+    assert stream.bytes_returned == 32769
+    assert repository.get_system() == before
+
+
+def test_heartbeat_accepts_chunked_json_without_content_length(tmp_path):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    stream = CountingStream(b'{"version":"chunked"}')
+
+    response = _post_stream_without_content_length(app, registered, stream)
+
+    assert response.status_code == 200
+    assert stream.bytes_returned == len(b'{"version":"chunked"}')
+    agent = next(item for item in repository.get_system()["agents"] if item["id"] == registered["id"])
+    assert agent["version"] == "chunked"
+
+
+@pytest.mark.parametrize("raw_body", [b"\xff", b'{"version":'])
+def test_heartbeat_rejects_malformed_encoding_or_json_without_mutation(tmp_path, raw_body):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    before = copy.deepcopy(repository.get_system())
+
+    response = _post_stream_without_content_length(app, registered, CountingStream(raw_body))
+
+    assert response.status_code == 400
+    assert repository.get_system() == before
+
+
+def test_heartbeat_accepts_whitelisted_system_metrics(tmp_path):
+    app, repository, registered = _heartbeat_app(tmp_path)
+    metrics = {
+        "cpu": {"usage_percent": 12.5, "core_count": 4},
+        "memory": {"total": 1024, "used": 512, "available": 512, "used_percent": 50.0},
+        "disk": {"total": 2048, "used": 1024, "free": 1024, "used_percent": 50.0},
+        "network": {"bytes_sent": 10, "bytes_recv": 20, "speed_sent": 1, "speed_recv": 2},
+        "collected_at": "2026-08-31T00:00:00Z",
+    }
+
+    response = app.test_client().post(
+        f"/api/agents/{registered['id']}/heartbeat",
+        headers={"Authorization": f"Bearer {registered['token']}"},
+        json={"system_metrics": metrics},
+    )
+
+    assert response.status_code == 200
+    agent = next(item for item in repository.get_system()["agents"] if item["id"] == registered["id"])
+    assert agent["system_metrics"] == metrics

--- a/backend/test_agent_profiles.py
+++ b/backend/test_agent_profiles.py
@@ -21,10 +21,12 @@ def test_agents_are_system_scoped_and_bind_profiles(tmp_path, monkeypatch):
     app, repository = setup_agent_app(tmp_path, monkeypatch)
     manager = init_agent_manager()
 
-    legacy = manager.register_agent({"name": "legacy", "host": "127.0.0.1"})["agent"]
-    bound = manager.register_agent(
+    legacy_result = manager.register_agent({"name": "legacy", "host": "127.0.0.1"})
+    legacy = next(agent for agent in repository.get_system()["agents"] if agent["id"] == legacy_result["id"])
+    bound_result = manager.register_agent(
         {"name": "bound", "host": "127.0.0.2", "profile_id": "alpha"}
-    )["agent"]
+    )
+    bound = next(agent for agent in repository.get_system()["agents"] if agent["id"] == bound_result["id"])
     config_module.save_config()
 
     agents = repository.get_system()["agents"]

--- a/backend/test_agent_profiles.py
+++ b/backend/test_agent_profiles.py
@@ -1,0 +1,164 @@
+from flask import Flask
+
+from backend.common import config as config_module
+from backend.common.agent_manager import init_agent_manager
+from backend.common.config_repository import ProfileRepository
+from backend.routes import register_blueprints
+
+
+def setup_agent_app(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.create_profile({"id": "beta", "name": "Beta"})
+    config_module.set_repository(repository)
+    init_agent_manager()
+    app = Flask(__name__)
+    register_blueprints(app)
+    return app, repository
+
+
+def test_agents_are_system_scoped_and_bind_profiles(tmp_path, monkeypatch):
+    app, repository = setup_agent_app(tmp_path, monkeypatch)
+    manager = init_agent_manager()
+
+    legacy = manager.register_agent({"name": "legacy", "host": "127.0.0.1"})["agent"]
+    bound = manager.register_agent(
+        {"name": "bound", "host": "127.0.0.2", "profile_id": "alpha"}
+    )["agent"]
+    config_module.save_config()
+
+    agents = repository.get_system()["agents"]
+    assert next(agent for agent in agents if agent["id"] == legacy["id"])["profile_id"] == "default"
+    assert next(agent for agent in agents if agent["id"] == bound["id"])["profile_id"] == "alpha"
+
+
+def test_agent_config_endpoint_uses_bound_profile(tmp_path, monkeypatch):
+    app, repository = setup_agent_app(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {"marker": "alpha"})
+    manager = init_agent_manager()
+    result = manager.register_agent(
+        {"name": "bound", "host": "127.0.0.2", "profile_id": "alpha"}
+    )
+    config_module.save_config()
+    monkeypatch.setattr(
+        "backend.routes.agents.generate_agent_config",
+        lambda data, agent: {
+            "content": data["marker"],
+            "md5": "hash",
+            "version": "hash",
+        },
+    )
+
+    response = app.test_client().get(
+        f"/api/agents/{result['id']}/config?token={result['token']}",
+        headers={"X-ConfigFlow-Profile": "beta"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["content"] == "alpha"
+    assert response.get_json()["profile_id"] == "alpha"
+
+
+def test_push_config_uses_bound_profile_even_with_other_request_context(tmp_path, monkeypatch):
+    app, repository = setup_agent_app(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {"marker": "alpha"})
+    manager = init_agent_manager()
+    result = manager.register_agent(
+        {"name": "bound", "host": "127.0.0.2", "profile_id": "alpha"}
+    )
+    config_module.save_config()
+    seen = {}
+
+    monkeypatch.setattr(
+        "backend.routes.agents.generate_mihomo_config",
+        lambda data, **kwargs: seen.setdefault("marker", data["marker"]) or "content",
+    )
+    monkeypatch.setattr("backend.routes.agents.get_mihomo_provider_downloads", lambda *args, **kwargs: [])
+    monkeypatch.setattr("backend.routes.agents.get_mihomo_ruleset_downloads", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        manager,
+        "push_config_to_agent",
+        lambda agent_id, content, extra_data=None: {"success": True},
+    )
+
+    response = app.test_client().post(
+        f"/api/agents/{result['id']}/push-config",
+        headers={"X-ConfigFlow-Profile": "beta"},
+        json={"restart": False},
+    )
+
+    assert response.status_code == 200
+    assert seen["marker"] == "alpha"
+    assert response.get_json()["profile_id"] == "alpha"
+
+
+def test_agent_registration_does_not_overwrite_system_agents_from_profile_snapshot(tmp_path, monkeypatch):
+    app, repository = setup_agent_app(tmp_path, monkeypatch)
+    manager = init_agent_manager()
+    repository.update_system_transaction(
+        lambda system: system.update({
+            "agents": [{"id": "stable", "name": "stable", "host": "10.0.0.1", "profile_id": "default"}],
+        })
+    )
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        manager.get_all_agents()
+        repository.update_system_transaction(
+            lambda system: system.update({"agents": [
+                {"id": "stable", "name": "stable", "host": "10.0.0.1", "profile_id": "default"},
+                {"id": "concurrent", "name": "concurrent", "host": "10.0.0.2", "profile_id": "beta"},
+            ]}),
+        )
+        manager.register_agent({"name": "new", "host": "10.0.0.3", "profile_id": "alpha"})
+        config_module.save_config()
+
+    assert {agent["id"] for agent in repository.get_system()["agents"]} >= {"stable", "concurrent"}
+
+
+def test_agent_mutations_persist_through_system_transactions(tmp_path, monkeypatch):
+    _app, repository = setup_agent_app(tmp_path, monkeypatch)
+    manager = init_agent_manager()
+    registered = manager.register_agent({"name": "managed", "host": "10.0.0.9", "profile_id": "alpha"})
+    agent_id = registered["id"]
+
+    assert next(agent for agent in repository.get_system()["agents"] if agent["id"] == agent_id)["name"] == "managed"
+
+    assert manager.update_agent(agent_id, {"name": "updated", "profile_id": "beta"})
+    assert manager.update_heartbeat(agent_id, {"version": "2.0.0", "config_version": "heartbeat"})
+    persisted = next(agent for agent in repository.get_system()["agents"] if agent["id"] == agent_id)
+    assert persisted["name"] == "updated"
+    assert persisted["profile_id"] == "beta"
+    assert persisted["version"] == "2.0.0"
+    assert persisted["config_version"] == "heartbeat"
+
+    class SuccessfulResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"success": True}
+
+    monkeypatch.setattr("backend.agents.manager.requests.post", lambda *args, **kwargs: SuccessfulResponse())
+    assert manager.push_config_to_agent(agent_id, "new config")["success"]
+    persisted = next(agent for agent in repository.get_system()["agents"] if agent["id"] == agent_id)
+    assert persisted["config_version"] != "heartbeat"
+
+    assert manager.delete_agent(agent_id)
+    assert all(agent["id"] != agent_id for agent in repository.get_system()["agents"])
+
+
+def test_agent_registration_validates_profile_inside_system_transaction(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha"})
+    manager = __import__("backend.agents.manager", fromlist=["AgentManager"]).AgentManager(repository)
+    original_transaction = repository.update_system_transaction
+
+    def delete_profile_then_run(updater):
+        repository.delete_profile("alpha")
+        return original_transaction(updater)
+
+    monkeypatch.setattr(repository, "update_system_transaction", delete_profile_then_run)
+    with __import__("pytest").raises(Exception):
+        manager.register_agent({"name": "race", "host": "127.0.0.9", "profile_id": "alpha"})
+
+    assert repository.get_system()["agents"] == []

--- a/backend/test_agent_registration_security.py
+++ b/backend/test_agent_registration_security.py
@@ -1,0 +1,274 @@
+import copy
+import logging
+
+import pytest
+from flask import Flask
+
+from backend.agents.manager import AgentManager
+from backend.common import config as config_module
+from backend.common.agent_manager import init_agent_manager
+from backend.common.auth import MAX_AUTH_TOKEN_LENGTH
+from backend.common.config_repository import ProfileRepository
+from backend.routes import register_blueprints
+
+
+def _app(repository):
+    config_module.set_repository(repository)
+    init_agent_manager()
+    app = Flask(__name__)
+    register_blueprints(app)
+    return app
+
+
+def _registration_payload(**overrides):
+    payload = {
+        "name": "secure-agent",
+        "host": "10.0.0.8",
+        "port": 8080,
+        "service_type": "mihomo",
+        "version": "1.2.3",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_manager_distinguishes_new_registration_from_authenticated_existing_registration(tmp_path):
+    manager = AgentManager(ProfileRepository(tmp_path))
+
+    created = manager.register_agent(_registration_payload())
+    registered = manager.register_agent(
+        _registration_payload(port=9090), existing_token=created["token"]
+    )
+
+    assert created["is_new"] is True
+    assert created["token"]
+    assert registered == {
+        "id": created["id"],
+        "status": "online",
+        "is_new": False,
+    }
+    assert manager.get_agent_by_id(created["id"])["port"] == 9090
+
+
+@pytest.mark.parametrize("provided_token", [None, "wrong-token", "令牌🔐"])
+def test_manager_rejects_unauthenticated_existing_registration_without_mutation(
+    tmp_path, provided_token
+):
+    repository = ProfileRepository(tmp_path)
+    manager = AgentManager(repository)
+    created = manager.register_agent(_registration_payload())
+    before = copy.deepcopy(repository.get_system()["agents"])
+
+    with pytest.raises(PermissionError):
+        manager.register_agent(
+            _registration_payload(port=9999, version="attacker"),
+            existing_token=provided_token,
+        )
+
+    assert repository.get_system()["agents"] == before
+    assert manager.get_agent_by_id(created["id"])["token"] == created["token"]
+
+
+def test_first_registration_returns_token_and_persists_it(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+
+    response = app.test_client().post("/api/agents/register", json=_registration_payload())
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert set(body) == {"success", "id", "status", "is_new", "token"}
+    assert body["success"] is True
+    assert body["is_new"] is True
+    assert body["token"]
+    persisted = repository.get_system()["agents"][0]
+    assert persisted["id"] == body["id"]
+    assert persisted["token"] == body["token"]
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        "Bearer wrong-token",
+        "Bearer wrong-token extra",
+        "Bearer  wrong-token",
+        "Bearer\twrong-token",
+        "Bearer 令牌🔐",
+        f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=["missing", "wrong", "trailing-field", "double-space", "tab", "unicode", "oversized"],
+)
+def test_duplicate_registration_requires_existing_bearer_and_does_not_mutate(
+    tmp_path, monkeypatch, authorization
+):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+    client = app.test_client()
+    created = client.post("/api/agents/register", json=_registration_payload()).get_json()
+    before = copy.deepcopy(repository.get_system()["agents"])
+    headers = {"Authorization": authorization} if authorization else {}
+
+    response = client.post(
+        "/api/agents/register",
+        json=_registration_payload(port=9999, version="attacker"),
+        headers=headers,
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"success": False, "message": "Unauthorized"}
+    assert repository.get_system()["agents"] == before
+    assert repository.get_system()["agents"][0]["token"] == created["token"]
+
+
+def test_authenticated_duplicate_registration_never_returns_token(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+    client = app.test_client()
+    created = client.post("/api/agents/register", json=_registration_payload()).get_json()
+
+    response = client.post(
+        "/api/agents/register",
+        json=_registration_payload(port=9090),
+        headers={"Authorization": f"Bearer {created['token']}"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "success": True,
+        "id": created["id"],
+        "status": "online",
+        "is_new": False,
+    }
+    assert "token" not in response.get_data(as_text=True)
+    persisted = repository.get_system()["agents"][0]
+    assert persisted["token"] == created["token"]
+    assert persisted["port"] == 9090
+
+
+def test_agent_list_and_item_never_expose_token(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    monkeypatch.setenv("API_TOKEN", "admin-token")
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+    client = app.test_client()
+    created = client.post("/api/agents/register", json=_registration_payload()).get_json()
+    auth = {"Authorization": "Bearer admin-token"}
+
+    listed = client.get("/api/agents", headers=auth)
+    item = client.get(f"/api/agents/{created['id']}", headers=auth)
+
+    assert listed.status_code == 200
+    assert item.status_code == 200
+    assert "token" not in listed.get_data(as_text=True)
+    assert "token" not in item.get_data(as_text=True)
+
+
+def test_registration_key_does_not_bypass_existing_agent_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_REGISTRATION_KEY", "valid-registration-key")
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+    client = app.test_client()
+    payload = _registration_payload(registration_key="valid-registration-key")
+    created = client.post("/api/agents/register", json=payload).get_json()
+    before = copy.deepcopy(repository.get_system()["agents"])
+
+    response = client.post("/api/agents/register", json=payload)
+
+    assert created["token"]
+    assert response.status_code == 401
+    assert repository.get_system()["agents"] == before
+
+
+def test_host_matching_happens_after_real_client_ip_normalization(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+    client = app.test_client()
+    payload = _registration_payload(host="172.18.0.4")
+    proxy_headers = {"X-Forwarded-For": "203.0.113.9, 172.18.0.1"}
+    created = client.post(
+        "/api/agents/register", json=payload, headers=proxy_headers
+    ).get_json()
+
+    rejected = client.post(
+        "/api/agents/register", json=payload, headers=proxy_headers
+    )
+    accepted = client.post(
+        "/api/agents/register",
+        json=payload,
+        headers={**proxy_headers, "Authorization": f"Bearer {created['token']}"},
+    )
+
+    assert repository.get_system()["agents"][0]["host"] == "203.0.113.9"
+    assert rejected.status_code == 401
+    assert accepted.status_code == 200
+    assert "token" not in accepted.get_json()
+
+
+def test_registration_logs_only_bounded_control_free_whitelisted_fields(
+    tmp_path, monkeypatch, caplog
+):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    repository = ProfileRepository(tmp_path)
+    app = _app(repository)
+    raw_secret = "raw-secret-8d2f"
+    prefix_secret = "prefix-secret-4a6c"
+    nested_secret = "nested-secret-1b9e"
+    unicode_control_secret = "unicode-control-secret-3c7a"
+    payload = _registration_payload(
+        name="safe-agent-" + ("x" * 256) + prefix_secret,
+        service_type="mihomo\r\n" + raw_secret,
+        version="1.2.3\u2028" + unicode_control_secret,
+        raw=raw_secret,
+        prefix={"value": prefix_secret},
+        nested={"authorization": {"token": nested_secret}},
+    )
+
+    with caplog.at_level(logging.INFO):
+        response = app.test_client().post("/api/agents/register", json=payload)
+
+    assert response.status_code == 200
+    response_text = response.get_data(as_text=True)
+    log_text = caplog.text
+    for secret in (raw_secret, prefix_secret, nested_secret, unicode_control_secret):
+        assert secret not in log_text
+        assert secret not in response_text
+    assert "safe-agent-" in log_text
+    assert "mihomo" in log_text
+    assert all("\r" not in record.getMessage() and "\n" not in record.getMessage() for record in caplog.records)
+    assert "authorization" not in log_text
+
+
+def test_duplicate_registration_attack_is_rejected_after_repository_restart(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    first_repository = ProfileRepository(tmp_path)
+    first_client = _app(first_repository).test_client()
+    created = first_client.post(
+        "/api/agents/register", json=_registration_payload()
+    ).get_json()
+
+    restarted_repository = ProfileRepository(tmp_path)
+    restarted_client = _app(restarted_repository).test_client()
+    before = copy.deepcopy(restarted_repository.get_system()["agents"])
+    attacked = restarted_client.post(
+        "/api/agents/register",
+        json=_registration_payload(port=9999, version="attacker"),
+    )
+    legitimate = restarted_client.post(
+        "/api/agents/register",
+        json=_registration_payload(port=9090),
+        headers={"Authorization": f"Bearer {created['token']}"},
+    )
+
+    assert attacked.status_code == 401
+    assert before[0]["port"] != 9999
+    assert legitimate.status_code == 200
+    assert legitimate.get_json()["id"] == created["id"]
+    assert "token" not in legitimate.get_json()
+    persisted = restarted_repository.get_system()["agents"][0]
+    assert persisted["token"] == created["token"]
+    assert persisted["port"] == 9090

--- a/backend/test_bearer_auth.py
+++ b/backend/test_bearer_auth.py
@@ -1,0 +1,175 @@
+import pytest
+from flask import Flask, jsonify
+
+from backend.common import config as config_module
+from backend.common.auth import (
+    MAX_AUTH_TOKEN_LENGTH,
+    generate_token,
+    parse_bearer_token,
+    require_auth,
+)
+from backend.common.config_repository import ProfileRepository
+from backend.mcp_server import mcp_bp
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        ("Bearer abc.DEF-_~+/=", "abc.DEF-_~+/="),
+        (f"Bearer {'x' * MAX_AUTH_TOKEN_LENGTH}", "x" * MAX_AUTH_TOKEN_LENGTH),
+    ],
+    ids=["printable-ascii", "maximum-length"],
+)
+def test_parse_bearer_token_accepts_exact_printable_ascii_token(header, expected):
+    assert parse_bearer_token(header) == expected
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        None,
+        "",
+        "Bearer ",
+        "Bearer  token",
+        "Bearer\ttoken",
+        "Bearer token extra",
+        " Bearer token",
+        "Bearer token ",
+        "bearer token",
+        "Basic token",
+        "Bearer café",
+        "Bearer 令牌🔐",
+        "Bearer token\tmore",
+        "Bearer token\n",
+        f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=[
+        "none",
+        "empty",
+        "empty-token",
+        "double-space",
+        "tab-separator",
+        "trailing-field",
+        "leading-whitespace",
+        "trailing-whitespace",
+        "wrong-case",
+        "wrong-scheme",
+        "latin-unicode",
+        "unicode",
+        "tab-in-token",
+        "newline",
+        "oversized",
+    ],
+)
+def test_parse_bearer_token_rejects_malformed_headers(header):
+    assert parse_bearer_token(header) is None
+
+
+def _protected_app(monkeypatch):
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    app = Flask(__name__)
+
+    @app.get("/protected")
+    @require_auth
+    def protected():
+        return jsonify({"success": True})
+
+    return app
+
+
+def test_require_auth_accepts_valid_jwt(monkeypatch):
+    response = _protected_app(monkeypatch).test_client().get(
+        "/protected",
+        headers={"Authorization": f"Bearer {generate_token('admin')}"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        lambda token: f"Bearer {token} extra",
+        lambda token: f"Bearer  {token}",
+        lambda token: f"Bearer\t{token}",
+        lambda token: "Bearer café",
+        lambda token: f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=["trailing-field", "double-space", "tab", "unicode", "oversized"],
+)
+def test_require_auth_rejects_malformed_bearer(monkeypatch, authorization):
+    token = generate_token("admin")
+    response = _protected_app(monkeypatch).test_client().get(
+        "/protected", headers={"Authorization": authorization(token)}
+    )
+
+    assert response.status_code == 401
+
+
+def _mcp_app(monkeypatch, tmp_path, *, config_token=""):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": config_token}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.mcp_server.auth.is_auth_enabled", lambda: True)
+    app = Flask(__name__)
+    app.register_blueprint(mcp_bp)
+    return app
+
+
+def _mcp_ping(client, *, authorization=None, query_token=None):
+    headers = {"Authorization": authorization} if authorization is not None else {}
+    query = {"token": query_token} if query_token is not None else {}
+    return client.post(
+        "/mcp",
+        headers=headers,
+        query_string=query,
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+
+
+def test_mcp_accepts_valid_jwt_bearer(monkeypatch, tmp_path):
+    app = _mcp_app(monkeypatch, tmp_path)
+
+    response = _mcp_ping(
+        app.test_client(), authorization=f"Bearer {generate_token('admin')}"
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        lambda token: f"Bearer {token} extra",
+        lambda token: f"Bearer  {token}",
+        lambda token: f"Bearer\t{token}",
+        lambda token: "Bearer café",
+        lambda token: f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=["trailing-field", "double-space", "tab", "unicode", "oversized"],
+)
+def test_mcp_rejects_malformed_bearer(monkeypatch, tmp_path, authorization):
+    app = _mcp_app(monkeypatch, tmp_path)
+    token = generate_token("admin")
+
+    response = _mcp_ping(app.test_client(), authorization=authorization(token))
+
+    assert response.status_code == 401
+
+
+def test_mcp_query_token_keeps_non_bearer_grammar(monkeypatch, tmp_path):
+    token = "token /&? 令牌"
+    app = _mcp_app(monkeypatch, tmp_path, config_token=token)
+
+    response = _mcp_ping(app.test_client(), query_token=token)
+
+    assert response.status_code == 200
+
+
+def test_mcp_rejects_oversized_query_token(monkeypatch, tmp_path):
+    token = "x" * (MAX_AUTH_TOKEN_LENGTH + 1)
+    app = _mcp_app(monkeypatch, tmp_path, config_token=token)
+
+    response = _mcp_ping(app.test_client(), query_token=token)
+
+    assert response.status_code == 401

--- a/backend/test_mcp_profiles.py
+++ b/backend/test_mcp_profiles.py
@@ -1,0 +1,120 @@
+import json
+
+from flask import Flask, request
+
+from backend.common import config as config_module
+from backend.common.config_repository import ProfileRepository
+from backend.mcp_server import invoker, tools
+from backend.routes import register_blueprints
+
+
+def test_mcp_registers_profile_management_tools_and_profile_schema():
+    definitions = {tool["name"]: tool for tool in tools.list_tools()}
+
+    assert {"list_profiles", "get_profile", "manage_profile", "clone_profile", "bind_agent_profile"} <= definitions.keys()
+    assert "profile_id" in definitions["list_subscriptions"]["inputSchema"]["properties"]
+    assert "profile_id" in definitions["generate_config"]["inputSchema"]["properties"]
+
+
+def test_mcp_profile_id_becomes_request_header_for_existing_tools(monkeypatch):
+    app = Flask(__name__)
+
+    @app.get("/api/subscriptions")
+    def subscriptions():
+        return {"profile": request.headers.get("X-ConfigFlow-Profile")}
+
+    with app.app_context():
+        result = tools.call_tool("list_subscriptions", {"profile_id": "alpha"})
+
+    assert result["profile"] == "alpha"
+
+
+def test_invoker_accepts_explicit_headers_and_profile_id(tmp_path):
+    app = Flask(__name__)
+
+    @app.get("/echo")
+    def echo():
+        return {"profile": request.headers.get("X-ConfigFlow-Profile"), "custom": request.headers.get("X-Custom")}
+
+    with app.app_context():
+        result = invoker.call_api(
+            "GET",
+            "/echo",
+            profile_id="alpha",
+            headers={"X-Custom": "yes"},
+        )
+
+    assert result == {"profile": "alpha", "custom": "yes"}
+
+
+def test_mcp_can_manage_profiles_and_bind_agents(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    from backend.mcp_server import mcp_bp
+    app.register_blueprint(mcp_bp)
+    client = app.test_client()
+
+    def call(name, arguments):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": name,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            },
+        )
+        assert response.status_code == 200
+        return json.loads(response.get_json()["result"]["content"][0]["text"])
+
+    created = call("manage_profile", {"action": "create", "data": {"id": "alpha", "name": "Alpha"}})
+    assert created["id"] == "alpha"
+    assert created["profile_id"] == "default"
+    assert call("get_profile", {"id": "alpha"})["id"] == "alpha"
+    cloned = call("clone_profile", {"source_profile_id": "alpha", "data": {"id": "beta"}})
+    assert cloned["id"] == "beta"
+
+    repository.update_system_transaction(
+        lambda system: system.update({
+            "agents": [
+                {
+                    "id": "agent-1",
+                    "name": "Agent",
+                    "host": "127.0.0.1",
+                    "port": 8080,
+                    "token": "test-token",
+                    "profile_id": "default",
+                }
+            ]
+        }),
+    )
+    bound = call("bind_agent_profile", {"id": "agent-1", "profile_id": "alpha"})
+    assert bound["profile_id"] == "alpha"
+
+
+def test_mcp_without_profile_id_keeps_legacy_default_profile(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("default", {"subscriptions": [{"id": "default-sub"}]})
+    repository.save_profile("alpha", {"subscriptions": [{"id": "alpha-sub"}]})
+    repository.activate_profile("alpha")
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    from backend.mcp_server import mcp_bp
+    app.register_blueprint(mcp_bp)
+
+    response = app.test_client().post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": "legacy-list",
+            "method": "tools/call",
+            "params": {"name": "list_subscriptions", "arguments": {}},
+        },
+    )
+    payload = json.loads(response.get_json()["result"]["content"][0]["text"])
+
+    assert payload[0]["id"] == "default-sub"

--- a/backend/test_mcp_profiles.py
+++ b/backend/test_mcp_profiles.py
@@ -49,16 +49,21 @@ def test_invoker_accepts_explicit_headers_and_profile_id(tmp_path):
 
 def test_mcp_can_manage_profiles_and_bind_agents(tmp_path, monkeypatch):
     repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": "mcp-admin-token"}})
     config_module.set_repository(repository)
     app = Flask(__name__)
     register_blueprints(app)
     from backend.mcp_server import mcp_bp
     app.register_blueprint(mcp_bp)
     client = app.test_client()
+    auth_headers = {
+        "Authorization": f"Bearer {repository.get_system()['system_config']['config_token']}"
+    }
 
     def call(name, arguments):
         response = client.post(
             "/mcp",
+            headers=auth_headers,
             json={
                 "jsonrpc": "2.0",
                 "id": name,
@@ -96,6 +101,7 @@ def test_mcp_can_manage_profiles_and_bind_agents(tmp_path, monkeypatch):
 
 def test_mcp_without_profile_id_keeps_legacy_default_profile(tmp_path, monkeypatch):
     repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": "mcp-admin-token"}})
     repository.create_profile({"id": "alpha", "name": "Alpha"})
     repository.save_profile("default", {"subscriptions": [{"id": "default-sub"}]})
     repository.save_profile("alpha", {"subscriptions": [{"id": "alpha-sub"}]})
@@ -108,6 +114,9 @@ def test_mcp_without_profile_id_keeps_legacy_default_profile(tmp_path, monkeypat
 
     response = app.test_client().post(
         "/mcp",
+        headers={
+            "Authorization": f"Bearer {repository.get_system()['system_config']['config_token']}"
+        },
         json={
             "jsonrpc": "2.0",
             "id": "legacy-list",
@@ -118,3 +127,55 @@ def test_mcp_without_profile_id_keeps_legacy_default_profile(tmp_path, monkeypat
     payload = json.loads(response.get_json()["result"]["content"][0]["text"])
 
     assert payload[0]["id"] == "default-sub"
+
+
+def test_mcp_rejects_internal_rule_proxy_token_when_anonymous_mode_is_enabled(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    from backend.mcp_server import mcp_bp
+    app.register_blueprint(mcp_bp)
+
+    token = repository.get_system()["system_config"]["rule_proxy_token"]
+    responses = [
+        app.test_client().post(
+            "/mcp",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"jsonrpc": "2.0", "id": "blocked-header", "method": "tools/list"},
+        ),
+        app.test_client().post(
+            "/mcp",
+            query_string={"token": token},
+            json={"jsonrpc": "2.0", "id": "blocked-query", "method": "tools/list"},
+        ),
+    ]
+
+    assert [response.status_code for response in responses] == [401, 401]
+
+
+def test_mcp_rejects_rule_proxy_token_before_equal_config_token(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    shared_token = repository.get_system()["system_config"]["rule_proxy_token"]
+    monkeypatch.setattr("backend.mcp_server.auth._config_token", lambda: shared_token)
+    monkeypatch.setattr(
+        "backend.mcp_server.auth._internal_rule_proxy_tokens", lambda: {shared_token}
+    )
+    app = Flask(__name__)
+    from backend.mcp_server import mcp_bp
+    app.register_blueprint(mcp_bp)
+
+    responses = [
+        app.test_client().post(
+            "/mcp",
+            headers={"Authorization": f"Bearer {shared_token}"},
+            json={"jsonrpc": "2.0", "id": "equal-header", "method": "tools/list"},
+        ),
+        app.test_client().post(
+            "/mcp",
+            query_string={"token": shared_token},
+            json={"jsonrpc": "2.0", "id": "equal-query", "method": "tools/list"},
+        ),
+    ]
+
+    assert [response.status_code for response in responses] == [401, 401]

--- a/backend/test_multi_profile_repository.py
+++ b/backend/test_multi_profile_repository.py
@@ -1,0 +1,416 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.common.config_repository import ProfileRepository, ProfileValidationError
+
+
+def test_repository_creates_isolated_default_profile(tmp_path):
+    repository = ProfileRepository(tmp_path)
+
+    assert repository.list_profiles()[0]["id"] == "default"
+    assert repository.profile_dir("default") == tmp_path / "profiles" / "default"
+    assert (tmp_path / "profiles" / "default" / "config.json").exists()
+    assert (tmp_path / "profiles" / "default" / "subscribes").is_dir()
+    assert (tmp_path / "profiles" / "default" / "providers").is_dir()
+    assert (tmp_path / "profiles" / "default" / "rules").is_dir()
+    assert (tmp_path / "profiles" / "default" / "generated").is_dir()
+
+
+def test_profile_id_cannot_escape_profiles_directory(tmp_path):
+    repository = ProfileRepository(tmp_path)
+
+    for profile_id in ("../outside", "..", "a/b", "a\\b", "C:"):
+        with pytest.raises(ProfileValidationError):
+            repository.profile_dir(profile_id)
+        with pytest.raises(ProfileValidationError):
+            repository.get_profile(profile_id)
+
+    for relative_path in ("../outside", "", None):
+        with pytest.raises(ProfileValidationError):
+            repository.profile_path("default", relative_path)
+
+
+def test_legacy_config_migrates_without_data_loss_and_is_idempotent(tmp_path):
+    legacy = {
+        "subscriptions": [{"id": "sub-1", "name": "legacy"}],
+        "nodes": [{"id": "node-1", "name": "node"}],
+        "rule_configs": [{"id": "rule-1", "value": "example.com"}],
+        "proxy_groups": [],
+        "rule_library": [],
+        "system_config": {"server_domain": "https://config.example", "config_token": "keep"},
+        "agents": [{"id": "agent-1", "name": "legacy-agent"}],
+        "backup": {"webdav_url": "https://backup.example"},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(legacy), encoding="utf-8")
+    (tmp_path / "subscribes").mkdir()
+    (tmp_path / "subscribes" / "sub-1.json").write_text("{\"nodes\": []}", encoding="utf-8")
+    (tmp_path / "providers").mkdir()
+    (tmp_path / "providers" / "agg.yaml").write_text("proxies: []", encoding="utf-8")
+    (tmp_path / "rules").mkdir()
+    (tmp_path / "rules" / "legacy.list").write_text("DOMAIN,example.com", encoding="utf-8")
+
+    repository = ProfileRepository(tmp_path)
+    first_profile = repository.get_profile("default")
+    first_system = repository.get_system()
+
+    assert first_profile["subscriptions"] == legacy["subscriptions"]
+    assert first_profile["rule_configs"] == legacy["rule_configs"]
+    assert first_system["agents"] == [{**legacy["agents"][0], "profile_id": "default"}]
+    assert first_system["system_config"] == legacy["system_config"]
+    assert first_system["backup"] == legacy["backup"]
+    assert (tmp_path / "profiles" / "default" / "subscribes" / "sub-1.json").exists()
+    assert (tmp_path / "profiles" / "default" / "providers" / "agg.yaml").exists()
+    assert (tmp_path / "profiles" / "default" / "rules" / "legacy.list").exists()
+
+    second = ProfileRepository(tmp_path)
+    assert second.get_profile("default") == first_profile
+    assert second.get_system() == first_system
+    assert len(list((tmp_path / "migrations").glob("*/config.json"))) == 1
+
+
+def test_atomic_profile_save_keeps_previous_file_when_replace_fails(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"subscriptions": [{"id": "old"}]})
+    config_path = repository.profile_dir("default") / "config.json"
+
+    def fail_replace(source, target):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr("backend.common.config_repository.os.replace", fail_replace)
+    with pytest.raises(OSError):
+        repository.save_profile("default", {"subscriptions": [{"id": "new"}]})
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["subscriptions"] == [{"id": "old"}]
+
+
+def test_partial_system_metadata_save_keeps_other_fields(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": "token"}})
+    repository.save_profile("default", {"system_config": {"server_domain": "http://configflow.test"}})
+
+    assert repository.get_system()["system_config"] == {
+        "server_domain": "http://configflow.test",
+        "github_proxy_domain": "",
+        "config_token": "token",
+    }
+
+
+def test_concurrent_profile_saves_do_not_cross_contaminate(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.create_profile({"id": "beta", "name": "Beta"})
+    failures = []
+
+    def save(profile_id, value):
+        try:
+            for _ in range(20):
+                repository.save_profile(profile_id, {"subscriptions": [{"id": value}]})
+        except Exception as exc:  # pragma: no cover - assertion below reports it
+            failures.append(exc)
+
+    threads = [
+        threading.Thread(target=save, args=("alpha", "alpha")),
+        threading.Thread(target=save, args=("beta", "beta")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not failures
+    assert repository.get_profile("alpha")["subscriptions"] == [{"id": "alpha"}]
+    assert repository.get_profile("beta")["subscriptions"] == [{"id": "beta"}]
+
+
+def test_concurrent_profile_creation_preserves_system_index(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    original_write_system = repository._write_system
+    barrier = threading.Barrier(2)
+
+    def delayed_write_system(system):
+        barrier.wait(timeout=5)
+        original_write_system(system)
+
+    monkeypatch.setattr(repository, "_write_system", delayed_write_system)
+    failures = []
+
+    def create(profile_id):
+        try:
+            repository.create_profile({"id": profile_id})
+        except Exception as exc:
+            failures.append(exc)
+
+    workers = [threading.Thread(target=create, args=(profile_id,)) for profile_id in ("alpha", "beta")]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert not failures
+    assert {profile["id"] for profile in repository.list_profiles()} >= {"default", "alpha", "beta"}
+
+
+def test_profile_transaction_preserves_concurrent_list_updates(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    failures = []
+
+    def append_subscription(index):
+        try:
+            repository.update_profile_transaction(
+                "default",
+                lambda profile: profile["subscriptions"].append({"id": f"sub-{index}"}),
+            )
+        except Exception as exc:  # pragma: no cover - assertion below reports it
+            failures.append(exc)
+
+    workers = [threading.Thread(target=append_subscription, args=(index,)) for index in range(12)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert not failures
+    assert {item["id"] for item in repository.get_profile("default")["subscriptions"]} == {
+        f"sub-{index}" for index in range(12)
+    }
+
+
+def test_save_profile_rolls_back_profile_when_system_commit_fails(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"subscriptions": [{"id": "old"}]})
+    system_path = repository.system_file
+    original_write_json = repository._write_json
+
+    def fail_system_commit(path, data):
+        if path == system_path:
+            raise OSError("injected system commit failure")
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", fail_system_commit)
+    with pytest.raises(OSError, match="injected system commit failure"):
+        repository.save_profile("default", {"subscriptions": [{"id": "new"}]})
+
+    assert repository.get_profile("default")["subscriptions"] == [{"id": "old"}]
+
+
+def test_save_profile_rolls_back_system_when_commit_fails_after_replace(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    before = repository.get_system()
+    system_path = repository.system_file
+    original_write_json = repository._write_json
+
+    def write_then_fail(path, data):
+        if path == system_path:
+            original_write_json(path, data)
+            raise OSError("injected post-replace failure")
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", write_then_fail)
+    with pytest.raises(OSError, match="injected post-replace failure"):
+        repository.save_profile("default", {"subscriptions": [{"id": "new"}]})
+
+    assert repository.get_system() == before
+
+
+def test_create_profile_cleans_directory_when_system_commit_fails(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    system_path = repository.system_file
+    original_write_json = repository._write_json
+
+    def fail_system_commit(path, data):
+        if path == system_path:
+            raise OSError("injected system commit failure")
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", fail_system_commit)
+    with pytest.raises(OSError, match="injected system commit failure"):
+        repository.create_profile({"id": "orphan"})
+
+    assert not repository.profile_dir("orphan").exists()
+    assert "orphan" not in {profile["id"] for profile in repository.list_profiles()}
+
+
+def test_create_profile_restores_preexisting_orphan_directory_on_commit_failure(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    orphan_dir = repository.profile_dir("orphan")
+    orphan_dir.mkdir()
+    original_config = b'{"unregistered": "original"}\n'
+    (orphan_dir / "config.json").write_bytes(original_config)
+    (orphan_dir / "important.txt").write_text("keep me", encoding="utf-8")
+    original_write_json = repository._write_json
+
+    def fail_system_commit(path, data):
+        if path == repository.system_file:
+            raise OSError("system commit failed")
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", fail_system_commit)
+    with pytest.raises(OSError, match="system commit failed"):
+        repository.create_profile({"id": "orphan"})
+
+    assert (orphan_dir / "config.json").read_bytes() == original_config
+    assert (orphan_dir / "important.txt").read_text(encoding="utf-8") == "keep me"
+    assert sorted(path.name for path in orphan_dir.iterdir()) == ["config.json", "important.txt"]
+    assert "orphan" not in {profile["id"] for profile in repository.list_profiles()}
+
+
+def test_delete_profile_serializes_with_in_flight_profile_write(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "deletable"})
+    write_started = threading.Event()
+    allow_write = threading.Event()
+    original_write_json = repository._write_json
+
+    def blocked_profile_write(path, data):
+        if path == repository.profile_dir("deletable") / "config.json":
+            write_started.set()
+            assert allow_write.wait(timeout=5)
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", blocked_profile_write)
+    write_error = []
+
+    def write_profile():
+        try:
+            repository.save_profile("deletable", {"subscriptions": [{"id": "write"}]})
+        except Exception as exc:  # pragma: no cover - assertion below reports it
+            write_error.append(exc)
+
+    writer = threading.Thread(target=write_profile)
+    writer.start()
+    assert write_started.wait(timeout=5)
+
+    deleter = threading.Thread(target=repository.delete_profile, args=("deletable",))
+    deleter.start()
+    assert deleter.is_alive()
+    allow_write.set()
+    writer.join(timeout=5)
+    deleter.join(timeout=5)
+
+    assert not write_error
+    assert not deleter.is_alive()
+    assert not repository.profile_dir("deletable").exists()
+    assert "deletable" not in {profile["id"] for profile in repository.list_profiles()}
+
+
+def test_update_profile_transaction_rolls_back_profile_when_system_commit_fails(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"subscriptions": [{"id": "old"}]})
+    system_path = repository.system_file
+    original_write_json = repository._write_json
+
+    def fail_system_commit(path, data):
+        if path == system_path:
+            raise OSError("system commit failed")
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", fail_system_commit)
+    with pytest.raises(OSError, match="system commit failed"):
+        repository.update_profile_transaction(
+            "default", lambda profile: profile.update({"subscriptions": [{"id": "new"}]}),
+        )
+
+    assert repository.get_profile("default")["subscriptions"] == [{"id": "old"}]
+
+
+def test_delete_profile_keeps_tombstone_when_post_commit_cleanup_fails(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "keep", "name": "Keep"})
+    (repository.profile_dir("keep") / "important.txt").write_text("keep me", encoding="utf-8")
+
+    def fail_rmtree(path):
+        raise OSError("directory removal failed")
+
+    monkeypatch.setattr("backend.common.config_repository.shutil.rmtree", fail_rmtree)
+    repository.delete_profile("keep")
+
+    assert "keep" not in {profile["id"] for profile in repository.list_profiles()}
+    assert not repository.profile_dir("keep").exists()
+    tombstones = list(repository.profiles_dir.glob(".keep.tombstone-*"))
+    assert len(tombstones) == 1
+    assert (tombstones[0] / "important.txt").read_text(encoding="utf-8") == "keep me"
+
+
+def test_delete_profile_restores_directory_when_system_commit_fails(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "keep", "name": "Keep"})
+    marker = repository.profile_dir("keep") / "important.txt"
+    marker.write_text("original", encoding="utf-8")
+    before = repository.get_system()
+    original_write_json = repository._write_json
+
+    def fail_system_commit(path, data):
+        if path == repository.system_file:
+            raise OSError("system commit failed")
+        return original_write_json(path, data)
+
+    monkeypatch.setattr(repository, "_write_json", fail_system_commit)
+    with pytest.raises(OSError, match="system commit failed"):
+        repository.delete_profile("keep")
+
+    assert repository.get_system() == before
+    assert marker.read_text(encoding="utf-8") == "original"
+    assert not list(repository.profiles_dir.glob(".keep.tombstone-*"))
+
+
+def test_independent_repositories_merge_locked_field_and_list_updates(tmp_path):
+    first = ProfileRepository(tmp_path)
+    second = ProfileRepository(tmp_path)
+    first.save_profile("default", {"mihomo": {"custom_config": "before"}})
+    failures = []
+
+    def update_field():
+        try:
+            first.update_profile_fields("default", {"mihomo": {"custom_config": "field"}})
+        except Exception as exc:
+            failures.append(exc)
+
+    def append_item():
+        try:
+            second.update_profile_transaction(
+                "default", lambda profile: profile["subscriptions"].append({"id": "concurrent"}),
+            )
+        except Exception as exc:
+            failures.append(exc)
+
+    threads = [threading.Thread(target=update_field), threading.Thread(target=append_item)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not failures
+    result = first.get_profile("default")
+    assert result["mihomo"]["custom_config"] == "field"
+    assert result["subscriptions"] == [{"id": "concurrent"}]
+
+
+def test_update_profile_fields_three_way_merges_stale_list_appends(tmp_path):
+    first = ProfileRepository(tmp_path)
+    second = ProfileRepository(tmp_path)
+    first.save_profile("default", {"subscriptions": [{"id": "existing"}]})
+
+    first_baseline = first.get_profile("default")
+    second_baseline = second.get_profile("default")
+    first_value = first_baseline["subscriptions"] + [{"id": "from-first"}]
+    second_value = second_baseline["subscriptions"] + [{"id": "from-second"}]
+
+    first.update_profile_fields(
+        "default",
+        {"subscriptions": first_value},
+        baseline={"subscriptions": first_baseline["subscriptions"]},
+    )
+    second.update_profile_fields(
+        "default",
+        {"subscriptions": second_value},
+        baseline={"subscriptions": second_baseline["subscriptions"]},
+    )
+
+    assert first.get_profile("default")["subscriptions"] == [
+        {"id": "existing"},
+        {"id": "from-first"},
+        {"id": "from-second"},
+    ]

--- a/backend/test_multi_profile_repository.py
+++ b/backend/test_multi_profile_repository.py
@@ -1,10 +1,239 @@
 import json
+import multiprocessing
+import os
+import shutil
 import threading
+import time
 from pathlib import Path
 
 import pytest
 
-from backend.common.config_repository import ProfileRepository, ProfileValidationError
+from backend.common.config_repository import (
+    ProfileRepository,
+    ProfileRepositoryError,
+    ProfileValidationError,
+)
+
+
+def _initialize_repository_rounds_worker(data_dirs, barrier, results):
+    rounds = []
+    for round_index, data_dir in enumerate(data_dirs):
+        try:
+            barrier.wait(timeout=20)
+            repository = ProfileRepository(data_dir)
+            rounds.append(
+                {
+                    "round": round_index,
+                    "ok": True,
+                    "profile": (repository.profile_dir("default") / "config.json").read_text(
+                        encoding="utf-8"
+                    ),
+                    "system": repository.system_file.read_text(encoding="utf-8"),
+                    "derived": (
+                        repository.profile_dir("default") / "rules" / "legacy.list"
+                    ).read_text(encoding="utf-8"),
+                }
+            )
+        except BaseException as exc:  # pragma: no cover - parent reports exact failure
+            rounds.append(
+                {
+                    "round": round_index,
+                    "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+    results.put(rounds)
+
+
+def _hold_repository_lock_worker(lock_path, hold_seconds, ready):
+    repository = ProfileRepository.__new__(ProfileRepository)
+    with repository._lock(Path(lock_path)):
+        ready.set()
+        time.sleep(hold_seconds)
+
+
+def _acquire_repository_lock_worker(lock_path, results, raise_inside=False):
+    repository = ProfileRepository.__new__(ProfileRepository)
+    started = time.monotonic()
+    try:
+        with repository._lock(Path(lock_path)):
+            elapsed = time.monotonic() - started
+            if raise_inside:
+                raise RuntimeError("injected protected operation failure")
+        results.put({"ok": True, "elapsed": elapsed})
+    except BaseException as exc:  # pragma: no cover - parent reports exact failure
+        results.put(
+            {
+                "ok": False,
+                "elapsed": time.monotonic() - started,
+                "type": type(exc).__name__,
+                "error": str(exc),
+            }
+        )
+
+
+def _crash_while_holding_repository_lock_worker(lock_path, ready):
+    repository = ProfileRepository.__new__(ProfileRepository)
+    with repository._lock(Path(lock_path)):
+        ready.set()
+        os._exit(23)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="exercises the Windows msvcrt retry path")
+def test_windows_cross_process_lock_waits_beyond_msvcrt_implicit_retry_window(tmp_path):
+    lock_path = tmp_path / "long-held.lock"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    results = context.Queue()
+    holder = context.Process(
+        target=_hold_repository_lock_worker,
+        args=(str(lock_path), 11.5, ready),
+    )
+    contender = context.Process(
+        target=_acquire_repository_lock_worker,
+        args=(str(lock_path), results),
+    )
+
+    holder.start()
+    assert ready.wait(timeout=10)
+    contender.start()
+    result = results.get(timeout=30)
+    contender.join(timeout=10)
+    holder.join(timeout=10)
+
+    assert holder.exitcode == 0
+    assert contender.exitcode == 0
+    assert result["ok"], result
+    assert 10.5 <= result["elapsed"] < 25
+
+
+@pytest.mark.skipif(os.name == "nt", reason="exercises the POSIX flock retry path")
+def test_posix_cross_process_lock_waits_then_succeeds(tmp_path):
+    lock_path = tmp_path / "posix-held.lock"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    results = context.Queue()
+    holder = context.Process(
+        target=_hold_repository_lock_worker,
+        args=(str(lock_path), 0.4, ready),
+    )
+    contender = context.Process(
+        target=_acquire_repository_lock_worker,
+        args=(str(lock_path), results),
+    )
+
+    holder.start()
+    assert ready.wait(timeout=10)
+    contender.start()
+    result = results.get(timeout=10)
+    contender.join(timeout=10)
+    holder.join(timeout=10)
+
+    assert holder.exitcode == contender.exitcode == 0
+    assert result["ok"], result
+    assert 0.2 <= result["elapsed"] < 5
+
+
+def test_cross_process_lock_timeout_is_short_configurable_and_path_safe(tmp_path, monkeypatch):
+    lock_path = tmp_path / "sensitive-profile-name.lock"
+    monkeypatch.setenv("CONFIGFLOW_LOCK_TIMEOUT_SECONDS", "0.2")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    results = context.Queue()
+    holder = context.Process(
+        target=_hold_repository_lock_worker,
+        args=(str(lock_path), 1.0, ready),
+    )
+    contender = context.Process(
+        target=_acquire_repository_lock_worker,
+        args=(str(lock_path), results),
+    )
+
+    holder.start()
+    assert ready.wait(timeout=10)
+    contender.start()
+    result = results.get(timeout=10)
+    contender.join(timeout=10)
+    holder.join(timeout=10)
+
+    assert holder.exitcode == contender.exitcode == 0
+    assert not result["ok"]
+    assert result["type"] == ProfileRepositoryError.__name__
+    assert 0.1 <= result["elapsed"] < 0.9
+    assert "Timed out waiting for profile repository lock" in result["error"]
+    assert str(lock_path) not in result["error"]
+
+
+@pytest.mark.parametrize("configured", ["-1", "0", "nan", "inf", "999999", "not-a-number"])
+def test_lock_timeout_environment_is_bounded_and_nonfinite_values_are_safe(monkeypatch, configured):
+    monkeypatch.setenv("CONFIGFLOW_LOCK_TIMEOUT_SECONDS", configured)
+
+    timeout = ProfileRepository._lock_timeout_seconds()
+
+    assert 0.1 <= timeout <= 3600.0
+
+
+def test_file_lock_is_released_when_protected_operation_raises(tmp_path):
+    lock_path = tmp_path / "exception.lock"
+    context = multiprocessing.get_context("spawn")
+    failed_results = context.Queue()
+    failed = context.Process(
+        target=_acquire_repository_lock_worker,
+        args=(str(lock_path), failed_results, True),
+    )
+    failed.start()
+    failed_result = failed_results.get(timeout=10)
+    failed.join(timeout=10)
+
+    retry_results = context.Queue()
+    retry = context.Process(
+        target=_acquire_repository_lock_worker,
+        args=(str(lock_path), retry_results),
+    )
+    retry.start()
+    retry_result = retry_results.get(timeout=10)
+    retry.join(timeout=10)
+
+    assert failed.exitcode == retry.exitcode == 0
+    assert failed_result["type"] == "RuntimeError"
+    assert retry_result["ok"], retry_result
+    assert retry_result["elapsed"] < 2
+
+
+def test_operating_system_releases_file_lock_when_holder_process_crashes(tmp_path):
+    lock_path = tmp_path / "crashed-holder.lock"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    crashed = context.Process(
+        target=_crash_while_holding_repository_lock_worker,
+        args=(str(lock_path), ready),
+    )
+    crashed.start()
+    assert ready.wait(timeout=10)
+    crashed.join(timeout=10)
+    assert crashed.exitcode == 23
+
+    results = context.Queue()
+    retry = context.Process(
+        target=_acquire_repository_lock_worker,
+        args=(str(lock_path), results),
+    )
+    retry.start()
+    result = results.get(timeout=10)
+    retry.join(timeout=10)
+
+    assert retry.exitcode == 0
+    assert result["ok"], result
+    assert result["elapsed"] < 2
+
+
+def test_thread_lock_remains_reentrant_for_same_thread(tmp_path):
+    repository = ProfileRepository.__new__(ProfileRepository)
+    lock = repository._thread_lock(tmp_path / "reentrant.lock")
+
+    with lock:
+        with lock:
+            assert repository._thread_lock(tmp_path / "reentrant.lock") is lock
 
 
 def test_repository_creates_isolated_default_profile(tmp_path):
@@ -17,6 +246,197 @@ def test_repository_creates_isolated_default_profile(tmp_path):
     assert (tmp_path / "profiles" / "default" / "providers").is_dir()
     assert (tmp_path / "profiles" / "default" / "rules").is_dir()
     assert (tmp_path / "profiles" / "default" / "generated").is_dir()
+
+
+def test_empty_data_directory_generates_and_atomically_persists_rule_proxy_token(tmp_path, monkeypatch):
+    monkeypatch.setattr("backend.common.config_repository.secrets.token_urlsafe", lambda size: "generated-default-token")
+
+    repository = ProfileRepository(tmp_path)
+
+    assert repository.get_system()["system_config"]["rule_proxy_token"] == "generated-default-token"
+    assert repository.get_system()["system_config"].get("config_token", "") == ""
+    persisted = json.loads((tmp_path / "system.json").read_text(encoding="utf-8"))
+    assert persisted["system_config"]["rule_proxy_token"] == "generated-default-token"
+    assert not list(tmp_path.glob(".system.json.*.tmp"))
+
+
+@pytest.mark.parametrize(
+    "legacy_system_config",
+    [
+        {},
+        {"rule_proxy_token": ""},
+        {"config_token": "legacy-public-token"},
+        {"config_token": "shared-token", "rule_proxy_token": "shared-token"},
+    ],
+)
+def test_legacy_missing_or_empty_rule_proxy_token_is_generated_and_persisted(
+    tmp_path, monkeypatch, legacy_system_config
+):
+    monkeypatch.setattr("backend.common.config_repository.secrets.token_urlsafe", lambda size: "generated-legacy-token")
+    legacy = {
+        "system_config": legacy_system_config,
+        "rule_configs": [],
+    }
+    (tmp_path / "config.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+    repository = ProfileRepository(tmp_path)
+
+    assert repository.get_system()["system_config"]["rule_proxy_token"] == "generated-legacy-token"
+    if legacy_system_config.get("config_token"):
+        assert repository.get_system()["system_config"]["config_token"] == legacy_system_config["config_token"]
+    persisted = json.loads((tmp_path / "system.json").read_text(encoding="utf-8"))
+    assert persisted["system_config"]["rule_proxy_token"] == "generated-legacy-token"
+
+
+def test_new_repository_rotates_equal_factory_tokens(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "backend.common.config_repository.secrets.token_urlsafe",
+        lambda size: "generated-new-token",
+    )
+
+    repository = ProfileRepository(
+        tmp_path,
+        initial_config_factory=lambda: {
+            "system_config": {
+                "config_token": "factory-shared-token",
+                "rule_proxy_token": "factory-shared-token",
+            },
+        },
+    )
+
+    assert repository.get_system()["system_config"] == {
+        "server_domain": "",
+        "github_proxy_domain": "",
+        "config_token": "factory-shared-token",
+        "rule_proxy_token": "generated-new-token",
+        "retired_rule_proxy_tokens": ["factory-shared-token"],
+    }
+
+
+def test_existing_nonempty_rule_proxy_token_is_preserved(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"rule_proxy_token": "keep-existing"}})
+    monkeypatch.setattr(
+        "backend.common.config_repository.secrets.token_urlsafe",
+        lambda size: pytest.fail("must not replace an existing token"),
+    )
+
+    reloaded = ProfileRepository(tmp_path)
+
+    assert reloaded.get_system()["system_config"]["rule_proxy_token"] == "keep-existing"
+
+
+def test_restart_atomically_rotates_rule_proxy_token_equal_to_config_token(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    system = repository.get_system()
+    system["system_config"].update({
+        "config_token": "shared-token",
+        "rule_proxy_token": "shared-token",
+    })
+    repository._write_system(system)
+    monkeypatch.setattr(
+        "backend.common.config_repository.secrets.token_urlsafe",
+        lambda size: "rotated-internal-token",
+    )
+
+    restarted = ProfileRepository(tmp_path)
+
+    system_config = restarted.get_system()["system_config"]
+    assert system_config["config_token"] == "shared-token"
+    assert system_config["rule_proxy_token"] == "rotated-internal-token"
+    assert json.loads((tmp_path / "system.json").read_text(encoding="utf-8"))["system_config"] == system_config
+    assert restarted.rule_proxy_tokens_for_sanitization() == {
+        "shared-token",
+        "rotated-internal-token",
+    }
+    assert system_config["retired_rule_proxy_tokens"] == ["shared-token"]
+    for _ in range(3):
+        restarted = ProfileRepository(tmp_path)
+        assert restarted.rule_proxy_tokens_for_sanitization() == {
+            "shared-token",
+            "rotated-internal-token",
+        }
+        assert restarted.get_system()["system_config"]["retired_rule_proxy_tokens"] == [
+            "shared-token"
+        ]
+    assert not list(tmp_path.glob(".system.json.*.tmp"))
+
+
+def test_legacy_retired_rule_proxy_tokens_are_normalized_and_preserved(tmp_path):
+    legacy = {
+        "system_config": {
+            "rule_proxy_token": "current-internal",
+            "retired_rule_proxy_tokens": [
+                "retired-one",
+                "",
+                None,
+                "retired-one",
+                "retired-two",
+            ],
+        }
+    }
+    (tmp_path / "config.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+    repository = ProfileRepository(tmp_path)
+
+    assert repository.get_system()["system_config"]["retired_rule_proxy_tokens"] == [
+        "retired-one",
+        "retired-two",
+    ]
+    assert repository.rule_proxy_tokens_for_sanitization() == {
+        "current-internal",
+        "retired-one",
+        "retired-two",
+    }
+    assert ProfileRepository(tmp_path).get_system()["system_config"][
+        "retired_rule_proxy_tokens"
+    ] == ["retired-one", "retired-two"]
+
+
+def test_system_transaction_never_persists_equal_config_and_rule_proxy_tokens(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    internal_token = repository.get_system()["system_config"]["rule_proxy_token"]
+    monkeypatch.setattr(
+        "backend.common.config_repository.secrets.token_urlsafe",
+        lambda size: "transaction-rotated-token",
+    )
+
+    repository.update_system_transaction(
+        lambda system: system["system_config"].update({"config_token": internal_token})
+    )
+
+    persisted_system_config = json.loads(
+        (tmp_path / "system.json").read_text(encoding="utf-8")
+    )["system_config"]
+    assert persisted_system_config["config_token"] == internal_token
+    assert persisted_system_config["rule_proxy_token"] == "transaction-rotated-token"
+    assert repository.get_system()["system_config"] == persisted_system_config
+
+
+@pytest.mark.parametrize(
+    "old_token",
+    ["legacy token/&?=秘密", " whitespace ", "🔐/+=?%token", "\n\t"],
+)
+def test_existing_nonempty_rule_proxy_token_is_preserved_across_restarts(
+    tmp_path, monkeypatch, old_token
+):
+    original = ProfileRepository(tmp_path)
+    system = original.get_system()
+    system["system_config"]["rule_proxy_token"] = old_token
+    original._write_system(system)
+    monkeypatch.setattr(
+        "backend.common.config_repository.secrets.token_urlsafe",
+        lambda size: pytest.fail("must not replace any existing nonempty token"),
+    )
+
+    for _ in range(3):
+        restarted = ProfileRepository(tmp_path)
+        assert restarted.get_system()["system_config"]["rule_proxy_token"] == old_token
+        assert restarted.rule_proxy_tokens_for_sanitization() == {old_token}
+
+    persisted = json.loads((tmp_path / "system.json").read_text(encoding="utf-8"))
+    assert persisted["system_config"]["rule_proxy_token"] == old_token
+    assert not list(tmp_path.glob(".system.json.*.tmp"))
 
 
 def test_profile_id_cannot_escape_profiles_directory(tmp_path):
@@ -59,7 +479,9 @@ def test_legacy_config_migrates_without_data_loss_and_is_idempotent(tmp_path):
     assert first_profile["subscriptions"] == legacy["subscriptions"]
     assert first_profile["rule_configs"] == legacy["rule_configs"]
     assert first_system["agents"] == [{**legacy["agents"][0], "profile_id": "default"}]
-    assert first_system["system_config"] == legacy["system_config"]
+    assert first_system["system_config"]["server_domain"] == "https://config.example"
+    assert first_system["system_config"]["config_token"] == "keep"
+    assert first_system["system_config"]["rule_proxy_token"]
     assert first_system["backup"] == legacy["backup"]
     assert (tmp_path / "profiles" / "default" / "subscribes" / "sub-1.json").exists()
     assert (tmp_path / "profiles" / "default" / "providers" / "agg.yaml").exists()
@@ -69,6 +491,146 @@ def test_legacy_config_migrates_without_data_loss_and_is_idempotent(tmp_path):
     assert second.get_profile("default") == first_profile
     assert second.get_system() == first_system
     assert len(list((tmp_path / "migrations").glob("*/config.json"))) == 1
+
+
+def test_legacy_initialization_is_serialized_across_processes_over_multiple_rounds(
+    tmp_path,
+):
+    round_count = 6
+    data_dirs = []
+    for round_index in range(round_count):
+        data_dir = tmp_path / f"round-{round_index}"
+        data_dir.mkdir()
+        legacy = {
+            "subscriptions": [{"id": f"legacy-{round_index}"}],
+            "agents": [{"id": "agent-1", "token": f"agent-token-{round_index}"}],
+            "system_config": {"config_token": f"config-token-{round_index}"},
+        }
+        (data_dir / "config.json").write_text(json.dumps(legacy), encoding="utf-8")
+        rules_dir = data_dir / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "legacy.list").write_text(
+            f"DOMAIN,round-{round_index}.example", encoding="utf-8"
+        )
+        data_dirs.append(str(data_dir))
+
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    results = context.Queue()
+    workers = [
+        context.Process(
+            target=_initialize_repository_rounds_worker,
+            args=(data_dirs, barrier, results),
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+
+    worker_results = [results.get(timeout=90) for _ in workers]
+    for worker in workers:
+        worker.join(timeout=30)
+        assert worker.exitcode == 0
+
+    for round_index, data_dir_text in enumerate(data_dirs):
+        data_dir = Path(data_dir_text)
+        first = worker_results[0][round_index]
+        second = worker_results[1][round_index]
+        assert first["ok"] and second["ok"], (first, second)
+        assert first["profile"] == second["profile"]
+        assert first["derived"] == second["derived"] == f"DOMAIN,round-{round_index}.example"
+        assert first["system"] == second["system"]
+        assert len(list((data_dir / "migrations").glob("*/config.json"))) == 1
+        assert len(list(data_dir.glob("system.json"))) == 1
+        assert not list((data_dir / "profiles").glob(".*staging*"))
+        assert not list((data_dir / "profiles").glob(".*migration-backup*"))
+
+
+def test_legacy_migration_cleans_partial_derived_copy_and_retry_succeeds(tmp_path, monkeypatch):
+    legacy = {
+        "subscriptions": [{"id": "legacy-sub"}],
+        "system_config": {"config_token": "public-token"},
+    }
+    legacy_bytes = json.dumps(legacy).encode("utf-8")
+    (tmp_path / "config.json").write_bytes(legacy_bytes)
+    for dirname, filename, content in (
+        ("subscribes", "sub.json", "{}"),
+        ("providers", "provider.yaml", "proxies: []"),
+        ("rules", "legacy.list", "DOMAIN,example.com"),
+    ):
+        source_dir = tmp_path / dirname
+        source_dir.mkdir()
+        (source_dir / filename).write_text(content, encoding="utf-8")
+
+    original_copytree = shutil.copytree
+    copied = 0
+
+    def fail_midway(source, destination, *args, **kwargs):
+        nonlocal copied
+        result = original_copytree(source, destination, *args, **kwargs)
+        copied += 1
+        if copied == 2:
+            raise OSError("injected derived-data copy failure")
+        return result
+
+    monkeypatch.setattr("backend.common.config_repository.shutil.copytree", fail_midway)
+    with pytest.raises(OSError, match="injected derived-data copy failure"):
+        ProfileRepository(tmp_path)
+
+    assert (tmp_path / "config.json").read_bytes() == legacy_bytes
+    assert not (tmp_path / "system.json").exists()
+    assert not (tmp_path / "profiles" / "default").exists()
+    assert not list((tmp_path / "profiles").glob(".*staging*"))
+
+    monkeypatch.setattr("backend.common.config_repository.shutil.copytree", original_copytree)
+    repository = ProfileRepository(tmp_path)
+
+    assert repository.get_profile("default")["subscriptions"] == legacy["subscriptions"]
+    assert (repository.profile_dir("default") / "subscribes" / "sub.json").exists()
+    assert (repository.profile_dir("default") / "providers" / "provider.yaml").exists()
+    assert (repository.profile_dir("default") / "rules" / "legacy.list").exists()
+    assert repository.get_system()["system_config"]["config_token"] == "public-token"
+    assert not list((tmp_path / "profiles").glob(".*staging*"))
+
+
+def test_legacy_migration_restores_preexisting_default_when_system_commit_fails(tmp_path, monkeypatch):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"subscriptions": [{"id": "legacy"}]}),
+        encoding="utf-8",
+    )
+    previous_default = tmp_path / "profiles" / "default"
+    previous_default.mkdir(parents=True)
+    (previous_default / "config.json").write_bytes(b"previous-profile")
+    (previous_default / "keep.bin").write_bytes(b"previous-derived")
+    before = {
+        path.relative_to(previous_default).as_posix(): path.read_bytes()
+        for path in previous_default.rglob("*")
+        if path.is_file()
+    }
+    original_write_system = ProfileRepository._write_system
+
+    def fail_system_commit(self, system):
+        original_write_system(self, system)
+        raise OSError("injected system commit failure")
+
+    monkeypatch.setattr(ProfileRepository, "_write_system", fail_system_commit)
+    with pytest.raises(OSError, match="injected system commit failure"):
+        ProfileRepository(tmp_path)
+
+    after = {
+        path.relative_to(previous_default).as_posix(): path.read_bytes()
+        for path in previous_default.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert not (tmp_path / "system.json").exists()
+    assert not list((tmp_path / "profiles").glob(".*migration-staging*"))
+    assert not list((tmp_path / "profiles").glob(".*migration-backup*"))
+
+    monkeypatch.setattr(ProfileRepository, "_write_system", original_write_system)
+    repository = ProfileRepository(tmp_path)
+    assert repository.get_profile("default")["subscriptions"] == [{"id": "legacy"}]
+    assert (tmp_path / "system.json").exists()
 
 
 def test_atomic_profile_save_keeps_previous_file_when_replace_fails(tmp_path, monkeypatch):
@@ -91,10 +653,13 @@ def test_partial_system_metadata_save_keeps_other_fields(tmp_path):
     repository.save_profile("default", {"system_config": {"config_token": "token"}})
     repository.save_profile("default", {"system_config": {"server_domain": "http://configflow.test"}})
 
-    assert repository.get_system()["system_config"] == {
+    system_config = repository.get_system()["system_config"]
+    assert system_config["rule_proxy_token"]
+    assert {key: value for key, value in system_config.items() if key != "rule_proxy_token"} == {
         "server_domain": "http://configflow.test",
         "github_proxy_domain": "",
         "config_token": "token",
+        "retired_rule_proxy_tokens": [],
     }
 
 

--- a/backend/test_profile_api.py
+++ b/backend/test_profile_api.py
@@ -1,0 +1,317 @@
+import json
+
+from flask import Flask
+
+from backend.common.config_repository import ProfileRepository
+from backend.common import config as config_module
+from backend.routes import register_blueprints
+from backend.routes.auth import setup_before_request
+
+
+def make_app(repository, monkeypatch):
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    return app
+
+
+def test_profile_context_prefers_route_over_header_and_query(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.create_profile({"id": "beta", "name": "Beta"})
+    repository.save_profile("alpha", {"subscriptions": [{"id": "alpha"}]})
+    repository.save_profile("beta", {"subscriptions": [{"id": "beta"}]})
+    app = make_app(repository, monkeypatch)
+    client = app.test_client()
+
+    response = client.get(
+        "/api/profiles/beta/subscriptions?profile=alpha",
+        headers={"X-ConfigFlow-Profile": "alpha"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()[0]["id"] == "beta"
+
+
+def test_legacy_routes_use_active_profile_and_header_is_request_scoped(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("alpha", {"subscriptions": [{"id": "alpha"}]})
+    repository.activate_profile("alpha")
+    app = make_app(repository, monkeypatch)
+    client = app.test_client()
+
+    active_response = client.get("/api/subscriptions")
+    explicit_response = client.get("/api/subscriptions", headers={"X-ConfigFlow-Profile": "default"})
+
+    assert active_response.get_json()[0]["id"] == "alpha"
+    assert explicit_response.get_json() == []
+    assert repository.active_profile_id() == "alpha"
+
+
+def test_profile_crud_clone_import_export_and_delete_rules(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    app = make_app(repository, monkeypatch)
+    client = app.test_client()
+
+    created = client.post("/api/profiles", json={"id": "alpha", "name": "Alpha"})
+    assert created.status_code == 201
+    repository.save_profile("alpha", {"subscriptions": [{"id": "sub-alpha"}]})
+
+    cloned = client.post("/api/profiles/alpha/clone", json={"id": "beta", "name": "Beta"})
+    assert cloned.status_code == 201
+    assert repository.get_profile("beta")["subscriptions"] == [{"id": "sub-alpha"}]
+
+    exported = client.get("/api/profiles/beta/export")
+    assert exported.status_code == 200
+    assert exported.get_json()["subscriptions"] == [{"id": "sub-alpha"}]
+
+    imported = client.post(
+        "/api/profiles/beta/import",
+        json={"subscriptions": [{"id": "sub-imported"}]},
+    )
+    assert imported.status_code == 200
+    assert repository.get_profile("beta")["subscriptions"] == [{"id": "sub-imported"}]
+
+    assert client.delete("/api/profiles/default").status_code == 400
+    assert client.delete("/api/profiles/beta").status_code == 204
+    assert not (tmp_path / "profiles" / "beta").exists()
+
+
+def test_invalid_profile_context_returns_not_found(tmp_path, monkeypatch):
+    app = make_app(ProfileRepository(tmp_path), monkeypatch)
+
+    response = app.test_client().get(
+        "/api/subscriptions",
+        headers={"X-ConfigFlow-Profile": "../outside"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_stale_profile_header_does_not_block_auth_or_profile_management(tmp_path, monkeypatch):
+    app = make_app(ProfileRepository(tmp_path), monkeypatch)
+    client = app.test_client()
+    headers = {"X-ConfigFlow-Profile": "deleted-profile"}
+
+    assert client.get("/api/auth/status", headers=headers).status_code == 200
+    assert client.post(
+        "/api/auth/login",
+        headers=headers,
+        json={"username": "nobody", "password": "wrong"},
+    ).status_code != 404
+    profiles_response = client.get("/api/profiles", headers=headers)
+    assert profiles_response.status_code == 200
+    assert profiles_response.get_json()[0]["id"] == "default"
+
+
+def test_stale_profile_header_returns_clear_not_found_for_profile_resources(tmp_path, monkeypatch):
+    app = make_app(ProfileRepository(tmp_path), monkeypatch)
+
+    response = app.test_client().get(
+        "/api/subscriptions",
+        headers={"X-ConfigFlow-Profile": "deleted-profile"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Profile not found: deleted-profile"
+
+
+def test_profile_config_and_generate_aliases_are_explicit(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    monkeypatch.setattr(
+        "backend.routes.generate.generate_mihomo_config",
+        lambda data, base_url="": "alpha-config",
+    )
+
+    config_response = app.test_client().get("/api/config/alpha/mihomo")
+    generated_response = app.test_client().post("/api/profiles/alpha/generate/mihomo", json={})
+
+    assert config_response.status_code == 200
+    assert config_response.get_data(as_text=True)
+    assert generated_response.status_code == 200
+    assert (repository.generated_dir("alpha") / "config.yaml").read_text(encoding="utf-8") == "alpha-config"
+
+
+def test_profile_import_does_not_overwrite_system_or_agents(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile(
+        "default",
+        {
+            "system_config": {"server_domain": "http://stable.test"},
+        },
+    )
+    repository.update_system_transaction(
+        lambda system: system.update({
+            "agents": [{"id": "agent-1", "profile_id": "default"}],
+        })
+    )
+    app = make_app(repository, monkeypatch)
+
+    response = app.test_client().post(
+        "/api/profiles/alpha/import",
+        json={
+            "subscriptions": [{"id": "imported"}],
+            "system_config": {"server_domain": "http://attacker.test"},
+            "agents": [{"id": "attacker"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert repository.get_profile("alpha")["subscriptions"] == [{"id": "imported"}]
+    system = repository.get_system()
+    assert system["system_config"]["server_domain"] == "http://stable.test"
+    assert system["agents"] == [{"id": "agent-1", "profile_id": "default"}]
+
+
+def test_profile_config_url_is_public_when_config_token_is_valid(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("default", {"system_config": {"config_token": "secret"}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+
+    response = app.test_client().get("/api/config/alpha/mihomo?token=secret")
+
+    assert response.status_code == 200
+
+
+def test_legacy_config_export_reads_the_active_profile(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"subscriptions": [{"id": "exported"}]})
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+
+    response = app.test_client().get("/api/config/export")
+
+    assert response.status_code == 200
+    assert response.get_json()["subscriptions"] == [{"id": "exported"}]
+
+
+def test_legacy_config_url_defaults_to_default_profile(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("default", {"marker": "default"})
+    repository.save_profile("alpha", {"marker": "alpha"})
+    repository.activate_profile("alpha")
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    monkeypatch.setattr(
+        "backend.routes.config.generate_mihomo_config",
+        lambda data, base_url="": data["marker"],
+    )
+
+    response = app.test_client().get("/api/config/mihomo")
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "default"
+
+
+def test_load_config_uses_request_profile_context(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.create_profile({"id": "beta", "name": "Beta"})
+    repository.save_profile("alpha", {"marker": "alpha"})
+    repository.save_profile("beta", {"marker": "beta"})
+    repository.activate_profile("beta")
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        loaded = config_module.load_config()
+
+    assert loaded["marker"] == "alpha"
+
+
+def test_each_request_reads_latest_profile_config(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"subscriptions": [{"id": "before"}]})
+    app = make_app(repository, monkeypatch)
+    client = app.test_client()
+
+    assert client.get("/api/subscriptions").get_json()[0]["id"] == "before"
+
+    repository.save_profile("default", {"subscriptions": [{"id": "after"}]})
+
+    assert client.get("/api/subscriptions").get_json()[0]["id"] == "after"
+
+
+def test_incremental_config_transaction_uses_latest_disk_state(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    independent = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    config_module.get_config("default")  # Populate a deliberately stale compatibility snapshot.
+    independent.update_profile_transaction(
+        "default", lambda profile: profile["subscriptions"].append({"id": "independent"})
+    )
+
+    config_module.update_config_transaction(
+        lambda profile: profile["subscriptions"].append({"id": "route"}),
+        "default",
+    )
+
+    assert repository.get_profile("default")["subscriptions"] == [
+        {"id": "independent"},
+        {"id": "route"},
+    ]
+
+
+def test_profile_config_snapshot_is_cleared_after_request(tmp_path, monkeypatch):
+    app = make_app(ProfileRepository(tmp_path), monkeypatch)
+
+    app.test_client().get("/api/subscriptions")
+
+    assert config_module._CONFIG_CACHE.get() is None
+
+
+def test_desensitized_export_does_not_create_external_temp_file(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile(
+        "default",
+        {"subscriptions": [{"id": "sub-1", "url": "https://secret.example"}]},
+    )
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+
+    def fail_temp_file(*args, **kwargs):
+        raise AssertionError("export must stay in memory")
+
+    monkeypatch.setattr("tempfile.NamedTemporaryFile", fail_temp_file)
+    response = app.test_client().get("/api/config/export?desensitize=true")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data())['subscriptions'][0]['url'] == '***已脱敏***'
+
+
+def test_new_repository_keeps_existing_template_defaults(tmp_path, monkeypatch):
+    template = tmp_path / 'config_template.json'
+    template.write_text(
+        json.dumps({
+            'subscriptions': [{'id': 'template-sub'}],
+            'marker': 'template',
+            'system_config': {'server_domain': 'http://template.test'},
+        }),
+        encoding='utf-8',
+    )
+    data_dir = tmp_path / 'data'
+    monkeypatch.setattr(config_module, 'DATA_DIR', str(data_dir))
+    monkeypatch.setattr(config_module, 'get_backend_resource', lambda _: str(template))
+    monkeypatch.setattr(config_module, '_repository', None)
+
+    repository = config_module.get_repository()
+
+    assert repository.get_profile('default')['subscriptions'] == [{'id': 'template-sub'}]
+    assert repository.get_profile('default')['marker'] == 'template'
+    assert 'system_config' not in repository.get_profile('default')
+    assert repository.get_system()['system_config']['server_domain'] == 'http://template.test'

--- a/backend/test_profile_scoped_artifacts.py
+++ b/backend/test_profile_scoped_artifacts.py
@@ -1,5 +1,8 @@
+import json
 from flask import Flask
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
 
 from backend.common import config as config_module
 from backend.common.config_repository import ProfileRepository
@@ -96,13 +99,17 @@ def test_generated_provider_urls_include_the_selected_profile(tmp_path, monkeypa
     assert downloads[0]["url"] == "http://configflow.test/api/profiles/alpha/subscriptions/sub-1/proxies"
 
 
-def test_mosdns_rule_proxy_urls_include_url_encoded_config_token_for_profile_and_legacy():
+def test_mosdns_rule_proxy_urls_use_url_encoded_internal_token_for_profile_and_legacy():
     rule_set = {
         "id": "rules-1", "name": "Rules", "itemType": "ruleset",
         "url": "https://rules.test/list?a=1&b=2",
     }
     common = {
-        "system_config": {"server_domain": "https://config.test", "config_token": "token /&?"},
+        "system_config": {
+            "server_domain": "https://config.test",
+            "config_token": "legacy-public-token",
+            "rule_proxy_token": "internal /&?",
+        },
         "mosdns": {"direct_rulesets": ["rules-1"], "proxy_rulesets": []},
         "rule_configs": [rule_set],
     }
@@ -112,12 +119,64 @@ def test_mosdns_rule_proxy_urls_include_url_encoded_config_token_for_profile_and
 
     assert profile_url == (
         "https://config.test/api/profiles/alpha/mosdns/rule-proxy"
-        "?url=https%3A%2F%2Frules.test%2Flist%3Fa%3D1%26b%3D2&token=token%20%2F%26%3F"
+        "?url=https%3A%2F%2Frules.test%2Flist%3Fa%3D1%26b%3D2&token=internal%20%2F%26%3F"
     )
     assert legacy_url == (
         "https://config.test/api/mosdns/rule-proxy"
-        "?url=https%3A%2F%2Frules.test%2Flist%3Fa%3D1%26b%3D2&token=token%20%2F%26%3F"
+        "?url=https%3A%2F%2Frules.test%2Flist%3Fa%3D1%26b%3D2&token=internal%20%2F%26%3F"
     )
+
+
+def test_mosdns_refuses_to_generate_rule_proxy_url_without_internal_token():
+    config = {
+        "system_config": {"server_domain": "https://config.test", "config_token": ""},
+        "mosdns": {"direct_rulesets": ["rules-1"], "proxy_rulesets": []},
+        "rule_configs": [{
+            "id": "rules-1", "name": "Rules", "itemType": "ruleset",
+            "url": "https://rules.test/list",
+        }],
+    }
+
+    with pytest.raises(ValueError, match="rule proxy token"):
+        get_mosdns_ruleset_downloads(config)
+
+
+def _assert_generated_default_url_authenticates(repository, monkeypatch):
+    repository.save_profile("default", {
+        "system_config": {"server_domain": "https://config.test"},
+        "mosdns": {"direct_rulesets": ["rules-1"], "proxy_rulesets": []},
+        "rule_configs": [{
+            "id": "rules-1", "name": "Rules", "itemType": "ruleset",
+            "url": "https://rules.test/list",
+        }],
+    })
+    config_module.set_repository(repository)
+    token = repository.get_system()["system_config"]["rule_proxy_token"]
+    generated_url = get_mosdns_ruleset_downloads(repository.get_compat_config("default"))[0]["url"]
+    parsed = urlsplit(generated_url)
+    assert parse_qs(parsed.query)["token"] == [token]
+    monkeypatch.setattr("backend.routes.mosdns._fetch_remote_content", lambda url: "domain:example.com")
+    monkeypatch.setattr(
+        "backend.routes.mosdns.socket.getaddrinfo",
+        lambda *args, **kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+    app = Flask(__name__)
+    register_blueprints(app)
+    response = app.test_client().get(f"{parsed.path}?{parsed.query}")
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "domain:example.com"
+
+
+def test_empty_data_directory_generates_mosdns_url_accepted_by_rule_proxy(tmp_path, monkeypatch):
+    _assert_generated_default_url_authenticates(ProfileRepository(tmp_path), monkeypatch)
+
+
+def test_legacy_empty_token_generates_mosdns_url_accepted_by_rule_proxy(tmp_path, monkeypatch):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"system_config": {"config_token": ""}}),
+        encoding="utf-8",
+    )
+    _assert_generated_default_url_authenticates(ProfileRepository(tmp_path), monkeypatch)
 
 
 def test_generated_profile_rule_proxy_url_downloads_with_auth_enabled(tmp_path, monkeypatch):

--- a/backend/test_profile_scoped_artifacts.py
+++ b/backend/test_profile_scoped_artifacts.py
@@ -1,0 +1,328 @@
+from flask import Flask
+from urllib.parse import urlsplit
+
+from backend.common import config as config_module
+from backend.common.config_repository import ProfileRepository
+from backend.routes import register_blueprints
+from backend.routes.aggregations import generate_aggregation_provider
+from backend.converters.mihomo import get_mihomo_provider_downloads
+from backend.converters.mosdns import get_mosdns_ruleset_downloads
+from backend.routes.rules import get_ruleset_content, normalize_rule_config_url
+from backend.utils import subscription_cache
+from backend.utils.rule_utils import get_rules_dir
+
+
+def setup_repository(tmp_path, monkeypatch):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.create_profile({"id": "beta", "name": "Beta"})
+    config_module.set_repository(repository)
+    return repository
+
+
+def test_subscription_and_rule_caches_are_profile_scoped(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    app = Flask(__name__)
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        subscription_cache.save_subscription_nodes("same", [{"name": "alpha-node"}])
+        alpha_rules = get_rules_dir()
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "beta"}):
+        subscription_cache.save_subscription_nodes("same", [{"name": "beta-node"}])
+        beta_rules = get_rules_dir()
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        assert subscription_cache.load_subscription_cache("same")["nodes"][0]["name"] == "alpha-node"
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "beta"}):
+        assert subscription_cache.load_subscription_cache("same")["nodes"][0]["name"] == "beta-node"
+    assert alpha_rules == str(repository.rules_dir("alpha"))
+    assert beta_rules == str(repository.rules_dir("beta"))
+    assert alpha_rules != beta_rules
+
+
+def test_aggregation_provider_is_profile_scoped(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    app = Flask(__name__)
+    aggregation = {"id": "agg-same", "name": "Same", "subscriptions": [], "nodes": []}
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        alpha_path = generate_aggregation_provider(aggregation)["file_path"]
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "beta"}):
+        beta_path = generate_aggregation_provider(aggregation)["file_path"]
+
+    assert alpha_path == str(repository.providers_dir("alpha") / "agg-same.yaml")
+    assert beta_path == str(repository.providers_dir("beta") / "agg-same.yaml")
+    assert alpha_path != beta_path
+
+
+def test_generated_configuration_is_written_under_selected_profile(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    app = Flask(__name__)
+    register_blueprints(app)
+    monkeypatch.setattr("backend.routes.generate.generate_mihomo_config", lambda data, base_url="": "profile-config")
+
+    response = app.test_client().post(
+        "/api/generate/mihomo",
+        headers={"X-ConfigFlow-Profile": "alpha"},
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert (repository.generated_dir("alpha") / "config.yaml").read_text(encoding="utf-8") == "profile-config"
+    assert not (repository.generated_dir("beta") / "config.yaml").exists()
+
+
+def test_generated_provider_urls_include_the_selected_profile(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    config = repository.get_compat_config("alpha")
+    config["system_config"]["server_domain"] = "http://configflow.test"
+    config["subscriptions"] = [{
+        "id": "sub-1",
+        "name": "Primary",
+        "url": "https://example.test/sub",
+        "enabled": True,
+    }]
+    config["proxy_groups"] = [{
+        "id": "group-1",
+        "name": "Proxy",
+        "type": "select",
+        "enabled": True,
+        "subscriptions": ["sub-1"],
+    }]
+    config_module.set_repository(repository)
+
+    downloads = get_mihomo_provider_downloads(config, base_url="http://fallback.test")
+
+    assert downloads[0]["url"] == "http://configflow.test/api/profiles/alpha/subscriptions/sub-1/proxies"
+
+
+def test_mosdns_rule_proxy_urls_include_url_encoded_config_token_for_profile_and_legacy():
+    rule_set = {
+        "id": "rules-1", "name": "Rules", "itemType": "ruleset",
+        "url": "https://rules.test/list?a=1&b=2",
+    }
+    common = {
+        "system_config": {"server_domain": "https://config.test", "config_token": "token /&?"},
+        "mosdns": {"direct_rulesets": ["rules-1"], "proxy_rulesets": []},
+        "rule_configs": [rule_set],
+    }
+
+    profile_url = get_mosdns_ruleset_downloads({**common, "profile_id": "alpha"})[0]["url"]
+    legacy_url = get_mosdns_ruleset_downloads(common)[0]["url"]
+
+    assert profile_url == (
+        "https://config.test/api/profiles/alpha/mosdns/rule-proxy"
+        "?url=https%3A%2F%2Frules.test%2Flist%3Fa%3D1%26b%3D2&token=token%20%2F%26%3F"
+    )
+    assert legacy_url == (
+        "https://config.test/api/mosdns/rule-proxy"
+        "?url=https%3A%2F%2Frules.test%2Flist%3Fa%3D1%26b%3D2&token=token%20%2F%26%3F"
+    )
+
+
+def test_generated_profile_rule_proxy_url_downloads_with_auth_enabled(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {
+        "system_config": {"server_domain": "https://config.test", "config_token": "profile token"},
+        "mosdns": {"direct_rulesets": ["rules-1"], "proxy_rulesets": []},
+        "rule_configs": [{
+            "id": "rules-1", "name": "Rules", "itemType": "ruleset",
+            "url": "https://rules.test/list",
+        }],
+    })
+    config = repository.get_compat_config("alpha")
+    generated_url = get_mosdns_ruleset_downloads(config)[0]["url"]
+    parsed = urlsplit(generated_url)
+    fetched = []
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(
+        "backend.routes.mosdns._fetch_remote_content",
+        lambda url: fetched.append(url) or "domain:example.com",
+    )
+    monkeypatch.setattr(
+        "backend.routes.mosdns.socket.getaddrinfo",
+        lambda *args, **kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+    app = Flask(__name__)
+    register_blueprints(app)
+    from backend.routes.auth import setup_before_request
+    setup_before_request(app)
+
+    response = app.test_client().get(f"{parsed.path}?{parsed.query}")
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    assert response.get_data(as_text=True) == "domain:example.com"
+    assert fetched == ["https://rules.test/list"]
+
+
+def test_profile_resource_aliases_include_rule_library(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {
+        "rule_library": [{"id": "rule-1", "name": "Local", "source_type": "content", "content": "DOMAIN,example.test"}],
+    })
+    app = Flask(__name__)
+    register_blueprints(app)
+
+    response = app.test_client().get("/api/profiles/alpha/rule-library")
+
+    assert response.status_code == 200
+    assert response.get_json()[0]["id"] == "rule-1"
+
+
+def test_aggregation_workers_keep_the_selected_profile_context(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {
+        "subscriptions": [{
+            "id": "sub-1",
+            "name": "Primary",
+            "url": "https://example.test/sub",
+            "enabled": True,
+        }],
+    })
+    app = Flask(__name__)
+    seen_profiles = []
+    monkeypatch.setattr(
+        "backend.routes.aggregations.get_subscription_proxies_yaml",
+        lambda sub_id, url: ("ignored", "test"),
+    )
+    monkeypatch.setattr(
+        "backend.routes.aggregations.parse_proxies_from_yaml",
+        lambda text: [{"name": "node-1"}],
+    )
+    monkeypatch.setattr(
+        "backend.routes.aggregations.proxies_to_nodes",
+        lambda proxies: proxies,
+    )
+    monkeypatch.setattr(
+        "backend.routes.aggregations.save_subscription_nodes",
+        lambda sub_id, nodes, metadata=None, profile_id=None: seen_profiles.append(profile_id) or {"nodes": nodes},
+    )
+    monkeypatch.setattr(
+        "backend.routes.aggregations.load_subscription_cache",
+        lambda sub_id, profile_id=None: seen_profiles.append(profile_id) or None,
+    )
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        generate_aggregation_provider({
+            "id": "agg-1",
+            "name": "Aggregation",
+            "subscriptions": ["sub-1"],
+            "nodes": [],
+        })
+
+    assert seen_profiles == ["alpha"]
+
+
+def test_local_rule_refresh_uses_profile_repository_write(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {
+        "rule_library": [{
+            "id": "rule-1",
+            "name": "Remote",
+            "source_type": "url",
+            "url": "https://example.test/rules",
+        }],
+    })
+    app = Flask(__name__)
+    register_blueprints(app)
+    calls = []
+    original_write = repository.write_profile_text
+
+    def write_profile_text(profile_id, relative_path, content):
+        calls.append(profile_id)
+        return original_write(profile_id, relative_path, content)
+
+    monkeypatch.setattr(repository, "write_profile_text", write_profile_text)
+    monkeypatch.setattr(
+        "backend.routes.rules.requests.get",
+        lambda url, timeout: type("Response", (), {"status_code": 200, "text": "DOMAIN,remote.test"})(),
+    )
+
+    response = app.test_client().get(
+        "/api/profiles/alpha/rules/local/Remote",
+        headers={"X-ConfigFlow-Profile": "beta"},
+    )
+
+    assert response.status_code == 200
+    assert calls == ["alpha"]
+
+
+def test_rule_library_content_urls_include_the_selected_profile(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {
+        "rule_library": [{"id": "rule-1", "source_type": "content"}],
+    })
+    app = Flask(__name__)
+    config_module.set_repository(repository)
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        rule = {"library_rule_id": "rule-1"}
+        normalize_rule_config_url(rule)
+
+    assert rule["url"] == "/api/profiles/alpha/rule-library/content/rule-1"
+
+
+def test_rule_cache_workers_keep_the_selected_profile_context(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    repository.save_profile("alpha", {
+        "rule_library": [{
+            "id": "rule-1",
+            "name": "Remote",
+            "source_type": "url",
+            "url": "https://example.test/rules",
+        }],
+    })
+    app = Flask(__name__)
+    register_blueprints(app)
+    seen_profiles = []
+    monkeypatch.setattr(
+        "backend.utils.rule_utils.save_rule_to_local",
+        lambda rule, profile_id=None: seen_profiles.append(profile_id) or "cached.list",
+    )
+
+    response = app.test_client().post(
+        "/api/rule-library/cache",
+        headers={"X-ConfigFlow-Profile": "alpha"},
+        json={"rule_ids": ["rule-1"]},
+    )
+
+    assert response.status_code == 200
+    assert seen_profiles == ["alpha"]
+
+
+def test_ruleset_content_cache_uses_profile_repository_write(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    app = Flask(__name__)
+    calls = []
+    original_write = repository.write_profile_text
+
+    def write_profile_text(profile_id, relative_path, content):
+        calls.append(profile_id)
+        return original_write(profile_id, relative_path, content)
+
+    monkeypatch.setattr(repository, "write_profile_text", write_profile_text)
+    monkeypatch.setattr(
+        "backend.routes.rules.requests.get",
+        lambda url, timeout: type("Response", (), {"status_code": 200, "text": "DOMAIN,remote.test"})(),
+    )
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        content = get_ruleset_content(
+            {"name": "Remote"},
+            {"name": "Remote", "source_type": "url", "url": "https://example.test/rules"},
+        )
+
+    assert content == "DOMAIN,remote.test"
+    assert calls == ["alpha"]
+
+
+def test_corrupt_subscription_cache_is_ignored(tmp_path, monkeypatch):
+    repository = setup_repository(tmp_path, monkeypatch)
+    (repository.cache_dir("alpha") / "broken.json").write_text("{", encoding="utf-8")
+    app = Flask(__name__)
+
+    with app.test_request_context("/", headers={"X-ConfigFlow-Profile": "alpha"}):
+        cached = subscription_cache.load_subscription_cache("broken")
+
+    assert cached is None

--- a/backend/test_safe_url_queries.py
+++ b/backend/test_safe_url_queries.py
@@ -1,0 +1,104 @@
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+import yaml
+
+from backend.common import profile_context
+from backend.converters.mihomo import generate_mihomo_config, get_mihomo_provider_downloads
+from backend.converters.mosdns import get_mosdns_ruleset_downloads
+from backend.converters.surge import convert_proxy_group_to_surge, generate_surge_config
+
+
+SPECIAL_TOKEN = "token /&?"
+
+
+def _provider_config(profile_id=None):
+    config = {
+        "system_config": {
+            "server_domain": "https://config.test",
+            "config_token": SPECIAL_TOKEN,
+        },
+        "subscriptions": [{"id": "sub-1", "name": "Primary", "enabled": True}],
+        "subscription_aggregations": [{
+            "id": "agg-1",
+            "name": "Combined",
+            "enabled": True,
+            "subscriptions": [],
+        }],
+        "proxy_groups": [{
+            "id": "group-1",
+            "name": "Proxy",
+            "type": "select",
+            "enabled": True,
+            "subscriptions": ["sub-1"],
+            "aggregations": ["agg-1"],
+        }],
+        "nodes": [],
+        "rule_configs": [],
+    }
+    if profile_id:
+        config["profile_id"] = profile_id
+    return config
+
+
+def _assert_query(generated_url, **expected):
+    assert parse_qs(urlsplit(generated_url).query, keep_blank_values=True) == {
+        key: [value] for key, value in expected.items()
+    }
+
+
+def test_append_url_query_encodes_values_and_preserves_existing_query():
+    url = profile_context.append_url_query(
+        "https://config.test/path?existing=first%20value",
+        {"token": SPECIAL_TOKEN, "format": "surge"},
+    )
+
+    _assert_query(url, existing="first value", token=SPECIAL_TOKEN, format="surge")
+
+
+@pytest.mark.parametrize("profile_id", [None, "alpha"], ids=["legacy", "profile"])
+def test_mihomo_provider_and_aggregation_urls_round_trip_special_token(profile_id):
+    config = _provider_config(profile_id)
+
+    generated = yaml.safe_load(generate_mihomo_config(config))
+    generated_urls = [provider["url"] for provider in generated["proxy-providers"].values()]
+    download_urls = [item["url"] for item in get_mihomo_provider_downloads(config)]
+
+    assert len(generated_urls) == len(download_urls) == 2
+    for url in generated_urls + download_urls:
+        _assert_query(url, token=SPECIAL_TOKEN)
+
+
+@pytest.mark.parametrize("profile_id", [None, "alpha"], ids=["legacy", "profile"])
+def test_surge_managed_subscription_and_aggregation_urls_round_trip_special_token(profile_id):
+    config = _provider_config(profile_id)
+    group = config["proxy_groups"][0]
+
+    managed_url = generate_surge_config(config).splitlines()[0].split()[1]
+    group_line = convert_proxy_group_to_surge(group, config)
+    policy_urls = [
+        part.split(",", 1)[0]
+        for part in group_line.split("policy-path = ")[1:]
+    ]
+
+    _assert_query(managed_url, token=SPECIAL_TOKEN)
+    assert len(policy_urls) == 2
+    for url in policy_urls:
+        _assert_query(url, token=SPECIAL_TOKEN, format="surge")
+
+
+@pytest.mark.parametrize("profile_id", [None, "alpha"], ids=["legacy", "profile"])
+def test_mosdns_rule_proxy_url_round_trips_remote_url_and_special_token(profile_id):
+    config = _provider_config(profile_id)
+    remote_url = "https://rules.test/list?a=1&b=2"
+    config["mosdns"] = {"direct_rulesets": ["rules-1"], "proxy_rulesets": []}
+    config["rule_configs"] = [{
+        "id": "rules-1",
+        "name": "Rules",
+        "itemType": "ruleset",
+        "url": remote_url,
+    }]
+
+    generated_url = get_mosdns_ruleset_downloads(config)[0]["url"]
+
+    _assert_query(generated_url, url=remote_url, token=SPECIAL_TOKEN)

--- a/backend/test_safe_url_queries.py
+++ b/backend/test_safe_url_queries.py
@@ -17,6 +17,7 @@ def _provider_config(profile_id=None):
         "system_config": {
             "server_domain": "https://config.test",
             "config_token": SPECIAL_TOKEN,
+            "rule_proxy_token": "internal /&?",
         },
         "subscriptions": [{"id": "sub-1", "name": "Primary", "enabled": True}],
         "subscription_aggregations": [{
@@ -101,4 +102,4 @@ def test_mosdns_rule_proxy_url_round_trips_remote_url_and_special_token(profile_
 
     generated_url = get_mosdns_ruleset_downloads(config)[0]["url"]
 
-    _assert_query(generated_url, url=remote_url, token=SPECIAL_TOKEN)
+    _assert_query(generated_url, url=remote_url, token="internal /&?")

--- a/backend/test_security_regressions.py
+++ b/backend/test_security_regressions.py
@@ -1,0 +1,325 @@
+import json
+import socket
+
+import pytest
+from flask import Flask
+
+from backend.common import config as config_module
+from backend.common.auth import generate_token
+from backend.common.config_repository import ProfileRepository
+from backend.routes import register_blueprints
+from backend.routes.auth import setup_before_request
+from backend.routes import mosdns
+
+
+def auth_app(monkeypatch):
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    app = Flask(__name__)
+    setup_before_request(app)
+    return app
+
+
+def test_auth_public_paths_are_exact_and_stats_is_protected(monkeypatch):
+    app = auth_app(monkeypatch)
+    client = app.test_client()
+
+    assert client.get("/").status_code == 404  # public matching, route absent
+    assert client.get("/anything").status_code == 401
+    assert client.get("/api/auth/status-extra").status_code == 401
+    assert client.get("/api/stats/overview").status_code == 401
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {},
+        {"Authorization": "Bearer not-a-valid-jwt"},
+    ],
+    ids=["missing-jwt", "invalid-jwt"],
+)
+def test_profile_provider_rejects_anonymous_when_auth_enabled_and_config_token_empty(
+    monkeypatch, tmp_path, headers
+):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("default", {"system_config": {"config_token": ""}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+
+    response = app.test_client().get(
+        "/api/profiles/alpha/aggregations/missing/provider",
+        headers=headers,
+    )
+
+    assert response.status_code == 401
+
+
+def _config_endpoint_app(monkeypatch, tmp_path, *, auth_enabled, config_token=""):
+    repository = ProfileRepository(tmp_path)
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("default", {"system_config": {"config_token": config_token}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: auth_enabled)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: auth_enabled)
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+    return app
+
+
+@pytest.mark.parametrize("target", ["mihomo", "surge", "mosdns"])
+@pytest.mark.parametrize("path", ["/api/config/{target}", "/api/config/alpha/{target}"])
+@pytest.mark.parametrize(
+    "headers",
+    [{}, {"Authorization": "Bearer not-a-valid-jwt"}],
+    ids=["missing-jwt", "invalid-jwt"],
+)
+def test_public_config_endpoints_require_valid_jwt_when_auth_enabled_and_config_token_empty(
+    monkeypatch, tmp_path, target, path, headers
+):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True)
+
+    response = app.test_client().get(path.format(target=target), headers=headers)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("path", ["/api/config/mihomo", "/api/config/alpha/mihomo"])
+def test_public_config_endpoints_accept_valid_jwt_when_config_token_empty(monkeypatch, tmp_path, path):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True)
+
+    response = app.test_client().get(
+        path,
+        headers={"Authorization": f"Bearer {generate_token('admin')}"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("path", ["/api/config/mihomo", "/api/config/alpha/mihomo"])
+def test_public_config_endpoints_remain_anonymous_when_auth_disabled(monkeypatch, tmp_path, path):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=False)
+
+    assert app.test_client().get(path).status_code == 200
+
+
+@pytest.mark.parametrize("path", ["/api/config/mihomo", "/api/config/alpha/mihomo"])
+def test_public_config_endpoints_accept_encoded_query_token(monkeypatch, tmp_path, path):
+    token = "token /&?"
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True, config_token=token)
+
+    response = app.test_client().get(path, query_string={"token": token})
+
+    assert response.status_code == 200
+
+
+def test_rule_proxy_requires_auth_even_when_global_auth_is_disabled(monkeypatch, tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: False)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: False)
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+
+    response = app.test_client().get("/api/mosdns/rule-proxy?url=https://example.com/rules.txt")
+    assert response.status_code == 401
+
+
+def test_auth_enabled_rule_proxy_accepts_valid_config_token(monkeypatch, tmp_path):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": "valid /&?"}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "domain:example.com")
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+
+    response = app.test_client().get(
+        "/api/mosdns/rule-proxy",
+        query_string={"url": "https://example.com/rules.txt", "token": "valid /&?"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "domain:example.com"
+
+
+@pytest.mark.parametrize("token", [None, "wrong"], ids=["missing-token", "wrong-token"])
+def test_auth_enabled_rule_proxy_rejects_invalid_config_token(monkeypatch, tmp_path, token):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": "valid"}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "must-not-download")
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+    query = {"url": "https://example.com/rules.txt"}
+    if token is not None:
+        query["token"] = token
+
+    response = app.test_client().get("/api/mosdns/rule-proxy", query_string=query)
+
+    assert response.status_code == 401
+
+
+def test_rule_proxy_rejects_non_http_and_private_targets():
+    for url in (
+        "ftp://example.com/rules.txt",
+        "file:///etc/passwd",
+        "http://127.0.0.1/rules.txt",
+        "http://localhost/rules.txt",
+        "http://169.254.169.254/latest/meta-data/",
+    ):
+        with pytest.raises(ValueError):
+            mosdns._validate_remote_url(url)
+
+
+def test_rule_proxy_pins_validated_ip_and_preserves_https_identity(monkeypatch):
+    resolutions = iter([
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))],
+    ])
+    monkeypatch.setattr(mosdns.socket, "getaddrinfo", lambda *args, **kwargs: next(resolutions))
+    observed = {}
+
+    class Response:
+        status = 200
+        headers = {}
+
+        def stream(self, chunk_size):
+            yield b"domain:example.com"
+
+        def release_conn(self):
+            observed["released"] = True
+
+    class Pool:
+        def __init__(self, host, port, **kwargs):
+            observed.update(host=host, port=port, pool_kwargs=kwargs)
+
+        def urlopen(self, method, path, **kwargs):
+            observed.update(method=method, path=path, request_kwargs=kwargs)
+            return Response()
+
+        def close(self):
+            observed["closed"] = True
+
+    monkeypatch.setattr("urllib3.HTTPSConnectionPool", Pool)
+
+    assert mosdns._fetch_remote_content("https://rules.example/path/list?format=txt") == "domain:example.com"
+    assert observed["host"] == "93.184.216.34"
+    assert observed["port"] == 443
+    assert observed["pool_kwargs"]["assert_hostname"] == "rules.example"
+    assert observed["pool_kwargs"]["server_hostname"] == "rules.example"
+    assert observed["request_kwargs"]["headers"]["Host"] == "rules.example"
+    assert observed["path"] == "/path/list?format=txt"
+    assert observed["released"] and observed["closed"]
+
+
+def _install_fake_http_pool(monkeypatch, responses, observed=None):
+    observed = observed if observed is not None else []
+
+    class Pool:
+        def __init__(self, host, port, **kwargs):
+            self.host = host
+            observed.append((host, port, kwargs))
+
+        def urlopen(self, method, path, **kwargs):
+            response = responses.pop(0)
+            response.request_host = self.host
+            return response
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("urllib3.HTTPConnectionPool", Pool)
+    return observed
+
+
+class _FakePoolResponse:
+    def __init__(self, status=200, headers=None, chunks=()):
+        self.status = status
+        self.headers = headers or {}
+        self._chunks = chunks
+        self.released = False
+
+    def stream(self, chunk_size):
+        yield from self._chunks
+
+    def release_conn(self):
+        self.released = True
+
+
+def test_rule_proxy_revalidates_and_pins_each_redirect_hop(monkeypatch):
+    resolutions = iter([
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))],
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))],
+    ])
+    monkeypatch.setattr(mosdns.socket, "getaddrinfo", lambda *args, **kwargs: next(resolutions))
+    redirect = _FakePoolResponse(302, {"Location": "http://private.example/rules"})
+    observed = _install_fake_http_pool(monkeypatch, [redirect])
+
+    with pytest.raises(ValueError, match="Private network"):
+        mosdns._fetch_remote_content("http://public.example/rules")
+
+    assert [entry[0] for entry in observed] == ["93.184.216.34"]
+    assert redirect.released
+
+
+def test_rule_proxy_rejects_non_2xx_response(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))],
+    )
+    response = _FakePoolResponse(503)
+    _install_fake_http_pool(monkeypatch, [response])
+
+    with pytest.raises(requests.exceptions.HTTPError, match="503"):
+        mosdns._fetch_remote_content("http://public.example/rules")
+    assert response.released
+
+
+def test_rule_proxy_enforces_streamed_response_limit(monkeypatch):
+    monkeypatch.setattr(mosdns, "_MAX_RULE_PROXY_BYTES", 5)
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))],
+    )
+    response = _FakePoolResponse(200, chunks=[b"123", b"456"])
+    _install_fake_http_pool(monkeypatch, [response])
+
+    with pytest.raises(ValueError, match="size limit"):
+        mosdns._fetch_remote_content("http://public.example/rules")
+    assert response.released
+
+
+def test_repository_without_factory_uses_string_github_proxy_default(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    system = repository.get_system()
+    profile = repository.get_profile("default")
+
+    assert isinstance(system["system_config"]["github_proxy_domain"], str)
+    assert "github_proxy_domain" not in profile or isinstance(
+        profile["github_proxy_domain"], str
+    )
+
+
+def test_gitignore_does_not_hide_source_lock_or_backup_files():
+    gitignore = open(".gitignore", encoding="utf-8").read()
+    assert "*.lock" not in gitignore
+    assert "*.bak" not in gitignore
+    assert "*.tmp" not in gitignore
+    assert "/profiles/" in gitignore
+    assert "/cache/" in gitignore
+    assert "/generated/" in gitignore

--- a/backend/test_security_regressions.py
+++ b/backend/test_security_regressions.py
@@ -293,6 +293,13 @@ def test_auth_enabled_rule_proxy_accepts_valid_config_token(monkeypatch, tmp_pat
     config_module.set_repository(repository)
     monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
     monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ],
+    )
     monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "domain:example.com")
     app = Flask(__name__)
     register_blueprints(app)
@@ -329,6 +336,13 @@ def test_auth_enabled_rule_proxy_accepts_valid_jwt(monkeypatch, tmp_path):
     config_module.set_repository(repository)
     monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
     monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ],
+    )
     monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "domain:example.com")
     app = Flask(__name__)
     register_blueprints(app)
@@ -401,6 +415,88 @@ def test_rule_proxy_rejects_non_http_and_private_targets():
     ):
         with pytest.raises(ValueError):
             mosdns._validate_remote_url(url)
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "224.0.0.1",
+        "ff02::1",
+        "100.64.0.1",
+        "192.0.2.1",
+        "2001:db8::1",
+        "240.0.0.1",
+        "198.18.0.1",
+        "fd00::1",
+        "169.254.1.1",
+        "fe80::1",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+        "::",
+    ],
+    ids=[
+        "ipv4-multicast",
+        "ipv6-multicast",
+        "cgnat",
+        "ipv4-documentation",
+        "ipv6-documentation",
+        "reserved",
+        "benchmark",
+        "ula",
+        "ipv4-link-local",
+        "ipv6-link-local",
+        "ipv4-loopback",
+        "ipv6-loopback",
+        "ipv4-unspecified",
+        "ipv6-unspecified",
+    ],
+)
+def test_rule_proxy_rejects_every_non_global_dns_result(monkeypatch, address):
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(family, socket.SOCK_STREAM, 6, "", (address, 443))],
+    )
+
+    with pytest.raises(ValueError, match="Public network"):
+        mosdns._resolve_remote_url("https://rules.example/list")
+
+
+def test_rule_proxy_rejects_mixed_public_and_private_dns_results(monkeypatch):
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 443)),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Public network"):
+        mosdns._resolve_remote_url("https://rules.example/list")
+
+
+@pytest.mark.parametrize(
+    "address,family",
+    [
+        ("93.184.216.34", socket.AF_INET),
+        ("2606:4700:4700::1111", socket.AF_INET6),
+    ],
+    ids=["public-ipv4", "public-ipv6"],
+)
+def test_rule_proxy_accepts_public_ipv4_and_ipv6(monkeypatch, address, family):
+    monkeypatch.setattr(
+        mosdns.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(family, socket.SOCK_STREAM, 6, "", (address, 443))],
+    )
+
+    parsed, selected = mosdns._resolve_remote_url("https://rules.example/list")
+
+    assert parsed.hostname == "rules.example"
+    assert selected == address
 
 
 def test_rule_proxy_pins_validated_ip_and_preserves_https_identity(monkeypatch):
@@ -478,16 +574,24 @@ class _FakePoolResponse:
         self.released = True
 
 
-def test_rule_proxy_revalidates_and_pins_each_redirect_hop(monkeypatch):
+@pytest.mark.parametrize(
+    "redirect_address",
+    ["224.0.0.1", "ff02::1", "100.64.0.1", "fd00::1"],
+    ids=["ipv4-multicast", "ipv6-multicast", "cgnat", "ula"],
+)
+def test_rule_proxy_revalidates_and_rejects_forbidden_redirect_hop(
+    monkeypatch, redirect_address
+):
+    redirect_family = socket.AF_INET6 if ":" in redirect_address else socket.AF_INET
     resolutions = iter([
         [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))],
-        [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))],
+        [(redirect_family, socket.SOCK_STREAM, 6, "", (redirect_address, 80))],
     ])
     monkeypatch.setattr(mosdns.socket, "getaddrinfo", lambda *args, **kwargs: next(resolutions))
-    redirect = _FakePoolResponse(302, {"Location": "http://private.example/rules"})
+    redirect = _FakePoolResponse(302, {"Location": "http://forbidden.example/rules"})
     observed = _install_fake_http_pool(monkeypatch, [redirect])
 
-    with pytest.raises(ValueError, match="Private network"):
+    with pytest.raises(ValueError, match="Public network"):
         mosdns._fetch_remote_content("http://public.example/rules")
 
     assert [entry[0] for entry in observed] == ["93.184.216.34"]

--- a/backend/test_security_regressions.py
+++ b/backend/test_security_regressions.py
@@ -5,7 +5,7 @@ import pytest
 from flask import Flask
 
 from backend.common import config as config_module
-from backend.common.auth import generate_token
+from backend.common.auth import MAX_AUTH_TOKEN_LENGTH, generate_token
 from backend.common.config_repository import ProfileRepository
 from backend.routes import register_blueprints
 from backend.routes.auth import setup_before_request
@@ -58,14 +58,17 @@ def test_profile_provider_rejects_anonymous_when_auth_enabled_and_config_token_e
     assert response.status_code == 401
 
 
-def _config_endpoint_app(monkeypatch, tmp_path, *, auth_enabled, config_token=""):
+def _config_endpoint_app(monkeypatch, tmp_path, *, auth_enabled, config_token=None):
     repository = ProfileRepository(tmp_path)
     repository.create_profile({"id": "alpha", "name": "Alpha"})
-    repository.save_profile("default", {"system_config": {"config_token": config_token}})
+    if config_token is not None:
+        repository.save_profile("default", {"system_config": {"config_token": config_token}})
     config_module.set_repository(repository)
     monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: auth_enabled)
     monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: auth_enabled)
     app = Flask(__name__)
+    app.config["TEST_CONFIG_TOKEN"] = repository.get_system()["system_config"].get("config_token", "")
+    app.config["TEST_RULE_PROXY_TOKEN"] = repository.get_system()["system_config"]["rule_proxy_token"]
     register_blueprints(app)
     setup_before_request(app)
     return app
@@ -81,7 +84,7 @@ def _config_endpoint_app(monkeypatch, tmp_path, *, auth_enabled, config_token=""
 def test_public_config_endpoints_require_valid_jwt_when_auth_enabled_and_config_token_empty(
     monkeypatch, tmp_path, target, path, headers
 ):
-    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True)
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True, config_token="")
 
     response = app.test_client().get(path.format(target=target), headers=headers)
 
@@ -90,7 +93,7 @@ def test_public_config_endpoints_require_valid_jwt_when_auth_enabled_and_config_
 
 @pytest.mark.parametrize("path", ["/api/config/mihomo", "/api/config/alpha/mihomo"])
 def test_public_config_endpoints_accept_valid_jwt_when_config_token_empty(monkeypatch, tmp_path, path):
-    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True)
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True, config_token="")
 
     response = app.test_client().get(
         path,
@@ -100,11 +103,150 @@ def test_public_config_endpoints_accept_valid_jwt_when_config_token_empty(monkey
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        lambda token: f"Bearer {token} extra",
+        lambda token: f"Bearer  {token}",
+        lambda token: f"Bearer\t{token}",
+        lambda token: "Bearer café",
+        lambda token: f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=["trailing-field", "double-space", "tab", "unicode", "oversized"],
+)
+def test_public_config_endpoint_rejects_malformed_bearer(monkeypatch, tmp_path, authorization):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True, config_token="")
+    token = generate_token("admin")
+
+    response = app.test_client().get(
+        "/api/config/mihomo",
+        headers={"Authorization": authorization(token)},
+    )
+
+    assert response.status_code == 401
+
+
+def test_public_config_endpoint_rejects_oversized_query_token(monkeypatch, tmp_path):
+    token = "x" * (MAX_AUTH_TOKEN_LENGTH + 1)
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True, config_token=token)
+
+    response = app.test_client().get("/api/config/mihomo", query_string={"token": token})
+
+    assert response.status_code == 401
+
+
 @pytest.mark.parametrize("path", ["/api/config/mihomo", "/api/config/alpha/mihomo"])
 def test_public_config_endpoints_remain_anonymous_when_auth_disabled(monkeypatch, tmp_path, path):
     app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=False)
 
     assert app.test_client().get(path).status_code == 200
+
+
+def test_anonymous_config_token_response_does_not_expose_internal_rule_proxy_token(monkeypatch, tmp_path):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=False, config_token="")
+
+    response = app.test_client().get("/api/config-token")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"config_token": ""}
+    assert app.config["TEST_RULE_PROXY_TOKEN"] not in response.get_data(as_text=True)
+
+
+def test_config_token_post_rejects_internal_rule_proxy_token(monkeypatch, tmp_path):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=False, config_token="public-token")
+    repository = config_module.get_repository()
+    before = repository.get_system()["system_config"]
+    internal_token = app.config["TEST_RULE_PROXY_TOKEN"]
+
+    response = app.test_client().post("/api/config-token", json={"token": internal_token})
+
+    assert response.status_code == 400
+    assert response.get_json()["success"] is False
+    assert repository.get_system()["system_config"] == before
+
+
+@pytest.mark.parametrize("layers", [0, 1, 2, 8, 20])
+def test_config_token_post_rejects_embedded_encoded_current_or_retired_internal_token(
+    monkeypatch, tmp_path, layers
+):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=False, config_token="public-token")
+    repository = config_module.get_repository()
+    system = repository.get_system()
+    current = system["system_config"]["rule_proxy_token"]
+    retired = "retired-internal-token"
+    system["system_config"]["retired_rule_proxy_tokens"] = [retired]
+    repository._write_system(system)
+    before = repository.get_system()["system_config"]
+
+    for internal in (current, retired):
+        encoded = internal
+        for index in range(layers):
+            encoded = (
+                __import__("urllib.parse", fromlist=["quote"]).quote(encoded, safe="")
+                if index % 2 == 0
+                else __import__("urllib.parse", fromlist=["quote_plus"]).quote_plus(encoded, safe="")
+            )
+        response = app.test_client().post(
+            "/api/config-token", json={"token": f"managed::{encoded}::suffix"}
+        )
+        assert response.status_code == 400
+        assert repository.get_system()["system_config"] == before
+
+
+def test_config_token_get_scrubs_legacy_embedded_internal_token(monkeypatch, tmp_path):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=False, config_token="public-token")
+    repository = config_module.get_repository()
+    system = repository.get_system()
+    internal = system["system_config"]["rule_proxy_token"]
+    system["system_config"]["config_token"] = f"legacy::{internal}::embedded"
+    repository._write_system(system)
+
+    response = app.test_client().get("/api/config-token")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"config_token": "[REDACTED]"}
+    assert internal not in response.get_data(as_text=True)
+
+
+def test_retired_rule_proxy_token_never_authorizes_config_rule_proxy_or_mcp(monkeypatch, tmp_path):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": "public-token"}})
+    system = repository.get_system()
+    retired = "retired-internal-token"
+    system["system_config"]["retired_rule_proxy_tokens"] = [retired]
+    system["system_config"]["config_token"] = retired
+    repository._write_system(system)
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "must-not-fetch")
+    from backend.mcp_server import mcp_bp
+
+    app = Flask(__name__)
+    register_blueprints(app)
+    app.register_blueprint(mcp_bp)
+    setup_before_request(app)
+    client = app.test_client()
+
+    assert client.get("/api/config/mihomo", query_string={"token": retired}).status_code == 401
+    assert client.get(
+        "/api/mosdns/rule-proxy",
+        query_string={"url": "https://example.com/rules", "token": retired},
+    ).status_code == 401
+    monkeypatch.setattr(
+        "backend.common.auth.verify_token",
+        lambda token: {"username": "admin"} if token == retired else None,
+    )
+    assert client.get(
+        "/api/mosdns/rule-proxy",
+        query_string={"url": "https://example.com/rules"},
+        headers={"Authorization": f"Bearer {retired}"},
+    ).status_code == 401
+    assert client.post(
+        "/mcp",
+        headers={"Authorization": f"Bearer {retired}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    ).status_code == 401
 
 
 @pytest.mark.parametrize("path", ["/api/config/mihomo", "/api/config/alpha/mihomo"])
@@ -115,6 +257,21 @@ def test_public_config_endpoints_accept_encoded_query_token(monkeypatch, tmp_pat
     response = app.test_client().get(path, query_string={"token": token})
 
     assert response.status_code == 200
+
+
+def test_config_endpoint_rejects_rule_proxy_token_before_equal_config_token(monkeypatch, tmp_path):
+    app = _config_endpoint_app(monkeypatch, tmp_path, auth_enabled=True, config_token="public-token")
+    shared_token = app.config["TEST_RULE_PROXY_TOKEN"]
+    equal_config = config_module.get_repository().get_compat_config("default")
+    equal_config["system_config"]["config_token"] = shared_token
+    monkeypatch.setattr("backend.routes.config.get_config", lambda profile_id=None: equal_config)
+
+    response = app.test_client().get(
+        "/api/config/mihomo",
+        query_string={"token": shared_token},
+    )
+
+    assert response.status_code == 401
 
 
 def test_rule_proxy_requires_auth_even_when_global_auth_is_disabled(monkeypatch, tmp_path):
@@ -148,6 +305,70 @@ def test_auth_enabled_rule_proxy_accepts_valid_config_token(monkeypatch, tmp_pat
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == "domain:example.com"
+
+
+def test_rule_proxy_rejects_oversized_query_token(monkeypatch, tmp_path):
+    token = "x" * (MAX_AUTH_TOKEN_LENGTH + 1)
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"config_token": token}})
+    config_module.set_repository(repository)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "must-not-fetch")
+    app = Flask(__name__)
+    register_blueprints(app)
+
+    response = app.test_client().get(
+        "/api/mosdns/rule-proxy",
+        query_string={"url": "https://example.com/rules.txt", "token": token},
+    )
+
+    assert response.status_code == 401
+
+
+def test_auth_enabled_rule_proxy_accepts_valid_jwt(monkeypatch, tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    monkeypatch.setattr("backend.common.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr("backend.routes.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "domain:example.com")
+    app = Flask(__name__)
+    register_blueprints(app)
+    setup_before_request(app)
+
+    response = app.test_client().get(
+        "/api/mosdns/rule-proxy",
+        query_string={"url": "https://example.com/rules.txt"},
+        headers={"Authorization": f"Bearer {generate_token('admin')}"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        lambda token: f"Bearer {token} extra",
+        lambda token: f"Bearer  {token}",
+        lambda token: f"Bearer\t{token}",
+        lambda token: "Bearer café",
+        lambda token: f"Bearer {'x' * (MAX_AUTH_TOKEN_LENGTH + 1)}",
+    ],
+    ids=["trailing-field", "double-space", "tab", "unicode", "oversized"],
+)
+def test_rule_proxy_rejects_malformed_bearer(monkeypatch, tmp_path, authorization):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: "must-not-fetch")
+    app = Flask(__name__)
+    register_blueprints(app)
+    token = generate_token("admin")
+
+    response = app.test_client().get(
+        "/api/mosdns/rule-proxy",
+        query_string={"url": "https://example.com/rules.txt"},
+        headers={"Authorization": authorization(token)},
+    )
+
+    assert response.status_code == 401
 
 
 @pytest.mark.parametrize("token", [None, "wrong"], ids=["missing-token", "wrong-token"])

--- a/backend/test_sensitive_config_exports.py
+++ b/backend/test_sensitive_config_exports.py
@@ -1,0 +1,611 @@
+import copy
+import json
+import sys
+import time
+import types
+import urllib.parse
+
+import pytest
+from flask import Flask
+
+from backend.common import config as config_module
+from backend.common.config_export import sanitize_config_for_output, sanitize_external_payload
+from backend.common.config_repository import ProfileRepository
+from backend.mcp_server import mcp_bp
+from backend.routes import register_blueprints
+
+
+RULE_PROXY_SECRET = "rule proxy/&?=秘密"
+CONFIG_TOKEN = "managed-config-token-remains-visible"
+REDACTED = "[REDACTED]"
+
+
+def _nested_list(depth, leaf="leaf"):
+    value = leaf
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def _descend_singleton_lists(value, count):
+    for _ in range(count):
+        assert isinstance(value, list) and len(value) == 1
+        value = value[0]
+    return value
+
+
+def _secret_forms(token=RULE_PROXY_SECRET):
+    forms = {token}
+    frontier = {token}
+    for _ in range(4):
+        frontier = {
+            encoded
+            for value in frontier
+            for encoded in (
+                urllib.parse.quote(value, safe=""),
+                urllib.parse.quote_plus(value, safe=""),
+            )
+        }
+        forms.update(frontier)
+    forms.update(
+        value.replace("%2F", "%2f").replace("%26", "%26").replace("%3F", "%3f")
+        for value in tuple(forms)
+    )
+    return forms
+
+
+def _assert_all_secret_forms_absent(content):
+    text = content.decode() if isinstance(content, bytes) else content
+    for secret_form in _secret_forms():
+        assert secret_form not in text
+
+
+def test_sanitize_external_payload_uses_repository_token_and_scrubs_nested_encoded_forms(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile(
+        "default", {"system_config": {"rule_proxy_token": RULE_PROXY_SECRET}}
+    )
+    config_module.set_repository(repository)
+    encoded = urllib.parse.quote_plus(RULE_PROXY_SECRET, safe="")
+    repeated = urllib.parse.quote(encoded, safe="").replace("%2F", "%2f")
+    payload = {
+        "system_config": {"rule_proxy_token": "decoy"},
+        "nested": [
+            f"raw={RULE_PROXY_SECRET}",
+            {"url": f"https://example.test/?token={encoded}"},
+            (f"again={repeated}",),
+        ],
+        f"encoded-key-{encoded}": "value",
+        "rule_proxy_token": "another-decoy",
+    }
+
+    sanitized = sanitize_external_payload(payload, payload["system_config"])
+    serialized = json.dumps(sanitized, ensure_ascii=False)
+
+    assert "rule_proxy_token" not in serialized
+    _assert_all_secret_forms_absent(serialized)
+    assert RULE_PROXY_SECRET in repository.rule_proxy_tokens_for_sanitization()
+    assert repository.get_system()["system_config"]["rule_proxy_token"] == RULE_PROXY_SECRET
+
+
+def _encode_layers(value, layers, mode):
+    encoders = {
+        "quote": lambda item: urllib.parse.quote(item, safe=""),
+        "quote_plus": lambda item: urllib.parse.quote_plus(item, safe=""),
+    }
+    for layer in range(layers):
+        selected = mode if mode != "mixed" else ("quote", "quote_plus")[layer % 2]
+        value = encoders[selected](value)
+    return value
+
+
+@pytest.mark.parametrize("depth", [1100, 5000])
+def test_sanitize_external_payload_redacts_subtree_beyond_safe_depth_without_recursion(
+    tmp_path, depth
+):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    payload = {"deep": _nested_list(depth), "safe": "preserved"}
+
+    sanitized = sanitize_external_payload(payload)
+
+    assert sanitized["safe"] == "preserved"
+    assert _descend_singleton_lists(sanitized["deep"], 127) == REDACTED
+    assert _descend_singleton_lists(payload["deep"], depth) == "leaf"
+
+
+def test_sanitize_external_payload_redacts_only_cyclic_branch_and_does_not_mutate_input(
+    tmp_path
+):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    cyclic = {"safe": ["unchanged"]}
+    cyclic["inside"] = {"back": cyclic}
+    payload = {"cyclic": cyclic, "ordinary": {"value": 1}}
+
+    sanitized = sanitize_external_payload(payload)
+
+    assert sanitized == {
+        "cyclic": {"safe": ["unchanged"], "inside": {"back": REDACTED}},
+        "ordinary": {"value": 1},
+    }
+    assert cyclic["inside"]["back"] is cyclic
+    assert sanitized["cyclic"] is not cyclic
+    assert sanitized["cyclic"]["safe"] is not cyclic["safe"]
+
+
+def test_sanitize_external_payload_handles_wide_container_with_bounded_overhead(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    payload = {f"key-{index}": [index, "safe"] for index in range(20_000)}
+
+    started = time.perf_counter()
+    sanitized = sanitize_external_payload(payload)
+    elapsed = time.perf_counter() - started
+
+    assert sanitized == payload
+    assert sanitized is not payload
+    assert sanitized["key-19999"] is not payload["key-19999"]
+    assert elapsed < 5.0
+
+
+def test_after_request_returns_controlled_json_for_pathologically_deep_payload(
+    tmp_path, monkeypatch
+):
+    app, _ = _app_with_secrets(tmp_path)
+    deep_payload = {"deep": _nested_list(1100), "safe": True}
+    from flask.wrappers import Response
+
+    original_get_json = Response.get_json
+
+    def deep_get_json(self, *args, **kwargs):
+        if self.headers.get("X-Deep-Test") == "1":
+            return deep_payload
+        return original_get_json(self, *args, **kwargs)
+
+    monkeypatch.setattr(Response, "get_json", deep_get_json)
+
+    @app.get("/api/deep-json")
+    def deep_json():
+        return Response("{}", mimetype="application/json", headers={"X-Deep-Test": "1"})
+
+    response = app.test_client().get("/api/deep-json")
+    body = original_get_json(response)
+
+    assert response.status_code == 200
+    assert body["safe"] is True
+    assert _descend_singleton_lists(body["deep"], 127) == REDACTED
+
+
+def test_sanitize_config_for_output_does_not_deepcopy_pathological_input(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    config_module.set_repository(repository)
+    config = {"deep": _nested_list(1100), "system_config": {}}
+
+    sanitized = sanitize_config_for_output(config)
+
+    assert _descend_singleton_lists(sanitized["deep"], 127) == REDACTED
+    assert _descend_singleton_lists(config["deep"], 1100) == "leaf"
+
+
+def test_after_request_replaces_raw_json_that_exceeds_decoder_recursion_limit(tmp_path):
+    app, _ = _app_with_secrets(tmp_path)
+    from flask.wrappers import Response
+
+    raw_deep_json = "[" * 1100 + '"leaf"' + "]" * 1100
+
+    @app.get("/api/raw-deep-json")
+    def raw_deep_json_response():
+        return Response(raw_deep_json, mimetype="application/json")
+
+    response = app.test_client().get("/api/raw-deep-json")
+
+    assert response.status_code == 200
+    assert response.is_json
+    assert response.get_json() == REDACTED
+
+
+@pytest.mark.parametrize("layers", range(21))
+@pytest.mark.parametrize("mode", ["quote", "quote_plus", "mixed"])
+def test_sanitize_external_payload_redacts_entire_string_at_zero_to_twenty_encoding_layers(
+    tmp_path, layers, mode
+):
+    token = "令牌 +/%?=🔐"
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile("default", {"system_config": {"rule_proxy_token": token}})
+    config_module.set_repository(repository)
+    encoded = _encode_layers(token, layers, mode)
+
+    original = {
+        "rule_proxy_token": token,
+        "raw": f"prefix::{encoded}::suffix",
+        "safe": "unchanged",
+    }
+    sanitized = sanitize_external_payload(original)
+
+    assert sanitized == {"raw": REDACTED, "safe": "unchanged"}
+    assert original["raw"] == f"prefix::{encoded}::suffix"
+    assert repository.get_system()["system_config"]["rule_proxy_token"] == token
+
+
+def _app_with_secrets(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    encoded = urllib.parse.quote_plus(RULE_PROXY_SECRET, safe="")
+    repeated = urllib.parse.quote(encoded, safe="")
+    repository.save_profile(
+        "default",
+        {
+            "system_config": {
+                "rule_proxy_token": RULE_PROXY_SECRET,
+                "config_token": CONFIG_TOKEN,
+                "server_domain": f"https://config.test/{RULE_PROXY_SECRET}",
+                "sub_store_url": f"https://store.test/?token={encoded}",
+            },
+            "subscriptions": [
+                {"id": "sub-1", "url": f"https://secret.test/sub?token={repeated}"}
+            ],
+            "nodes": [
+                {"id": "node-1", "proxy_string": f"ss://secret#{RULE_PROXY_SECRET}"}
+            ],
+            "rule_configs": [
+                {
+                    "id": "rules-1",
+                    "name": "Rules",
+                    "itemType": "ruleset",
+                    "url": "https://rules.test/list",
+                }
+            ],
+            "mosdns": {"direct_rulesets": ["rules-1"], "proxy_rulesets": []},
+        },
+    )
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    app.register_blueprint(mcp_bp)
+    return app, repository
+
+
+def _assert_rule_proxy_secret_absent(response):
+    assert response.status_code == 200
+    assert b"rule_proxy_token" not in response.get_data()
+    _assert_all_secret_forms_absent(response.get_data())
+
+
+@pytest.mark.parametrize("desensitize", [False, True], ids=["full", "desensitized"])
+def test_config_exports_strip_internal_rule_proxy_token_but_preserve_managed_config_token(
+    tmp_path, desensitize
+):
+    app, repository = _app_with_secrets(tmp_path)
+
+    response = app.test_client().get(
+        "/api/config/export", query_string={"desensitize": str(desensitize).lower()}
+    )
+
+    _assert_rule_proxy_secret_absent(response)
+    exported = json.loads(response.get_data())
+    assert "rule_proxy_token" not in exported["system_config"]
+    assert exported["system_config"]["config_token"] == CONFIG_TOKEN
+    assert RULE_PROXY_SECRET in repository.rule_proxy_tokens_for_sanitization()
+    assert repository.get_system()["system_config"]["rule_proxy_token"] == RULE_PROXY_SECRET
+
+
+def test_profile_export_and_explicit_settings_responses_do_not_leak_rule_proxy_token(tmp_path):
+    app, _ = _app_with_secrets(tmp_path)
+    client = app.test_client()
+
+    responses = [
+        client.get("/api/profiles/default/export"),
+        client.get("/api/server-domain"),
+        client.get("/api/config-token"),
+        client.get("/api/backup/config"),
+        client.get("/api/settings/sub-store-url"),
+        client.get("/api/settings/subscription-aggregation"),
+    ]
+
+    for response in responses:
+        _assert_rule_proxy_secret_absent(response)
+    assert responses[2].get_json() == {"config_token": CONFIG_TOKEN}
+
+
+def test_all_ordinary_json_api_responses_scrub_embedded_repository_token(tmp_path):
+    app, _ = _app_with_secrets(tmp_path)
+
+    @app.get("/api/synthetic-json")
+    def synthetic_json():
+        from flask import jsonify
+
+        return jsonify(
+            {
+                "rule_proxy_token": RULE_PROXY_SECRET,
+                "arbitrary": urllib.parse.quote_plus(RULE_PROXY_SECRET, safe=""),
+            }
+        )
+
+    client = app.test_client()
+    responses = [
+        client.get("/api/server-domain"),
+        client.get("/api/settings/sub-store-url"),
+        client.get("/api/subscriptions"),
+        client.get("/api/nodes"),
+        client.get("/api/profiles/default/export"),
+        client.get("/api/synthetic-json"),
+    ]
+
+    for response in responses:
+        _assert_rule_proxy_secret_absent(response)
+
+
+def test_config_token_management_scrubs_legacy_value_embedding_internal_token(tmp_path):
+    app, repository = _app_with_secrets(tmp_path)
+    managed_value = f"managed::{RULE_PROXY_SECRET}"
+    repository.save_profile("default", {"system_config": {"config_token": managed_value}})
+
+    response = app.test_client().get("/api/config-token")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"config_token": REDACTED}
+    assert RULE_PROXY_SECRET not in response.get_data(as_text=True)
+
+
+def test_agent_tokens_are_centrally_scrubbed_from_api_profile_export_and_mcp(tmp_path, monkeypatch):
+    app, repository = _app_with_secrets(tmp_path)
+    from backend.common.agent_manager import init_agent_manager
+
+    registered = init_agent_manager().register_agent(
+        {"name": "central-secret", "host": "10.0.0.30"}
+    )
+    agent_token = registered["token"]
+    encoded = _encode_layers(agent_token, 10, "mixed")
+    monkeypatch.setattr("backend.mcp_server.server.has_tool", lambda name: True)
+    monkeypatch.setattr(
+        "backend.mcp_server.server.call_tool",
+        lambda name, arguments: {
+            "agent": registered["agent"],
+            f"key::{encoded}": f"value::{encoded}",
+        },
+    )
+
+    responses = [
+        app.test_client().get("/api/agents"),
+        app.test_client().get(f"/api/agents/{registered['id']}"),
+        app.test_client().get("/api/config/export"),
+        app.test_client().get("/api/profiles/default/export"),
+        _mcp_call(app.test_client(), "synthetic_agent_payload"),
+    ]
+    for response in responses:
+        assert response.status_code == 200
+        assert agent_token not in response.get_data(as_text=True)
+        assert encoded not in response.get_data(as_text=True)
+    assert repository.get_system()["agents"][0]["token"] == agent_token
+
+
+def test_retired_internal_token_is_scrubbed_from_keys_and_values_after_multiple_restarts(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    system = repository.get_system()
+    system["system_config"]["retired_rule_proxy_tokens"] = [RULE_PROXY_SECRET]
+    repository._write_system(system)
+
+    for restart in range(3):
+        repository = ProfileRepository(tmp_path)
+        config_module.set_repository(repository)
+        encoded = _encode_layers(RULE_PROXY_SECRET, 12, "mixed")
+        payload = {
+            f"field::{encoded}": f"value::{encoded}",
+            "retired_rule_proxy_tokens": [RULE_PROXY_SECRET],
+            "safe": restart,
+        }
+        serialized = json.dumps(sanitize_external_payload(payload), ensure_ascii=False)
+        _assert_all_secret_forms_absent(serialized)
+        assert "retired_rule_proxy_tokens" not in serialized
+        assert json.loads(serialized)["safe"] == restart
+
+
+def test_webdav_backup_export_strips_rule_proxy_token(tmp_path, monkeypatch):
+    app, _ = _app_with_secrets(tmp_path)
+    uploaded = {}
+
+    class FakeClient:
+        def __init__(self, options):
+            self.options = options
+
+        def check(self, path):
+            return True
+
+        def upload_sync(self, *, remote_path, local_path):
+            uploaded["remote_path"] = remote_path
+            with open(local_path, "rb") as handle:
+                uploaded["content"] = handle.read()
+
+    package = types.ModuleType("webdav3")
+    client_module = types.ModuleType("webdav3.client")
+    client_module.Client = FakeClient
+    monkeypatch.setitem(sys.modules, "webdav3", package)
+    monkeypatch.setitem(sys.modules, "webdav3.client", client_module)
+
+    response = app.test_client().post(
+        "/api/backup/now",
+        json={
+            "webdav_url": "https://dav.test",
+            "webdav_username": "user",
+            "webdav_password": "password",
+            "webdav_path": "/backups/",
+        },
+    )
+
+    assert response.status_code == 200
+    _assert_all_secret_forms_absent(uploaded["content"])
+    assert b"rule_proxy_token" not in uploaded["content"]
+    assert json.loads(uploaded["content"])["system_config"]["config_token"] == CONFIG_TOKEN
+
+
+def test_rule_proxy_authentication_still_uses_migrated_internal_token(tmp_path, monkeypatch):
+    app, repository = _app_with_secrets(tmp_path)
+    current_token = repository.get_system()["system_config"]["rule_proxy_token"]
+    monkeypatch.setattr(
+        "backend.routes.mosdns._fetch_remote_content",
+        lambda url: "domain:internal-path-still-works",
+    )
+
+    response = app.test_client().get(
+        "/api/mosdns/rule-proxy",
+        query_string={
+            "url": "https://example.com/rules.txt",
+            "token": current_token,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "domain:internal-path-still-works"
+
+
+def test_legacy_unicode_token_survives_restarts_and_stays_private_across_api_webdav_and_mcp(
+    tmp_path, monkeypatch
+):
+    token = "旧令牌 +/&?=秘密🔐"
+    encoded = _encode_layers(token, 20, "mixed")
+    legacy = {
+        "system_config": {
+            "rule_proxy_token": token,
+            "config_token": CONFIG_TOKEN,
+            "server_domain": f"https://config.test/{encoded}",
+        },
+        "subscriptions": [],
+        "nodes": [],
+    }
+    (tmp_path / "config.json").write_text(
+        json.dumps(legacy, ensure_ascii=False), encoding="utf-8"
+    )
+    uploads = []
+
+    class FakeClient:
+        def __init__(self, options):
+            self.options = options
+
+        def check(self, path):
+            return True
+
+        def upload_sync(self, *, remote_path, local_path):
+            with open(local_path, "rb") as handle:
+                uploads.append(handle.read())
+
+    package = types.ModuleType("webdav3")
+    client_module = types.ModuleType("webdav3.client")
+    client_module.Client = FakeClient
+    monkeypatch.setitem(sys.modules, "webdav3", package)
+    monkeypatch.setitem(sys.modules, "webdav3.client", client_module)
+    monkeypatch.setattr("backend.mcp_server.server.has_tool", lambda name: True)
+    monkeypatch.setattr(
+        "backend.mcp_server.server.call_tool",
+        lambda name, arguments: {
+            "rule_proxy_token": token,
+            "result": f"prefix::{encoded}::suffix",
+        },
+    )
+    monkeypatch.setattr(
+        "backend.routes.mosdns._fetch_remote_content", lambda url: "domain:restart-ok"
+    )
+
+    for restart in range(3):
+        repository = ProfileRepository(tmp_path)
+        config_module.set_repository(repository)
+        before = copy.deepcopy(repository.get_system())
+        assert before["system_config"]["rule_proxy_token"] == token
+
+        app = Flask(__name__)
+        register_blueprints(app)
+        app.register_blueprint(mcp_bp)
+
+        @app.get(f"/api/restart-{restart}")
+        def synthetic_restart_payload(encoded_value=encoded):
+            from flask import jsonify
+
+            return jsonify(
+                {
+                    "rule_proxy_token": token,
+                    "result": f"prefix::{encoded_value}::suffix",
+                }
+            )
+
+        client = app.test_client()
+        api_response = client.get(f"/api/restart-{restart}")
+        assert api_response.get_json() == {"result": REDACTED}
+
+        mcp_response = _mcp_call(client, "synthetic_restart_payload")
+        _assert_rule_proxy_secret_absent(mcp_response)
+        assert token.encode() not in mcp_response.get_data()
+        assert REDACTED.encode() in mcp_response.get_data()
+
+        backup_response = client.post(
+            "/api/backup/now",
+            json={
+                "webdav_url": "https://dav.test",
+                "webdav_username": "user",
+                "webdav_password": "password",
+                "webdav_path": "/backups/",
+            },
+        )
+        assert backup_response.status_code == 200
+        assert token.encode() not in uploads[-1]
+        assert REDACTED.encode() in uploads[-1]
+
+        auth_response = client.get(
+            "/api/mosdns/rule-proxy",
+            query_string={"url": "https://example.com/rules", "token": token},
+        )
+        assert auth_response.status_code == 200
+        assert auth_response.get_data(as_text=True) == "domain:restart-ok"
+        assert repository.get_system() == before
+
+
+def _mcp_call(client, name, arguments=None):
+    response = client.post(
+        "/mcp",
+        headers={"Authorization": f"Bearer {CONFIG_TOKEN}"},
+        json={
+            "jsonrpc": "2.0",
+            "id": name,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        },
+    )
+    assert response.status_code == 200
+    return response
+
+
+def test_mcp_globally_redacts_rule_proxy_token_from_nested_tool_payload(tmp_path, monkeypatch):
+    app, _ = _app_with_secrets(tmp_path)
+    monkeypatch.setattr("backend.mcp_server.server.has_tool", lambda name: True)
+    monkeypatch.setattr(
+        "backend.mcp_server.server.call_tool",
+        lambda name, arguments: {
+            "rule_proxy_token": RULE_PROXY_SECRET,
+            "nested": [f"https://config.test/rules?token={RULE_PROXY_SECRET}"],
+            "config_token": CONFIG_TOKEN,
+        },
+    )
+
+    response = _mcp_call(app.test_client(), "synthetic_secret_payload")
+
+    _assert_rule_proxy_secret_absent(response)
+    assert CONFIG_TOKEN.encode() in response.get_data()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("manage_config_backup", {"action": "export", "desensitize": False}),
+        ("manage_config_backup", {"action": "export", "desensitize": True}),
+        ("get_settings", {}),
+        ("preview_config", {"target": "mosdns", "base_url": "https://config.test"}),
+    ],
+)
+def test_mcp_config_and_settings_responses_do_not_leak_rule_proxy_token(
+    tmp_path, tool_name, arguments
+):
+    app, _ = _app_with_secrets(tmp_path)
+
+    response = _mcp_call(app.test_client(), tool_name, arguments)
+
+    _assert_rule_proxy_secret_absent(response)
+    if tool_name != "preview_config":
+        assert CONFIG_TOKEN.encode() in response.get_data()

--- a/backend/test_sensitive_config_exports.py
+++ b/backend/test_sensitive_config_exports.py
@@ -442,6 +442,10 @@ def test_rule_proxy_authentication_still_uses_migrated_internal_token(tmp_path, 
     app, repository = _app_with_secrets(tmp_path)
     current_token = repository.get_system()["system_config"]["rule_proxy_token"]
     monkeypatch.setattr(
+        "backend.routes.mosdns.socket.getaddrinfo",
+        lambda *args, **kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(
         "backend.routes.mosdns._fetch_remote_content",
         lambda url: "domain:internal-path-still-works",
     )
@@ -503,6 +507,10 @@ def test_legacy_unicode_token_survives_restarts_and_stays_private_across_api_web
     )
     monkeypatch.setattr(
         "backend.routes.mosdns._fetch_remote_content", lambda url: "domain:restart-ok"
+    )
+    monkeypatch.setattr(
+        "backend.routes.mosdns.socket.getaddrinfo",
+        lambda *args, **kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
     )
 
     for restart in range(3):

--- a/backend/test_shell_agent_security.py
+++ b/backend/test_shell_agent_security.py
@@ -1,0 +1,213 @@
+import json
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+from flask import Flask
+from werkzeug.serving import make_server
+
+from backend.common import config as config_module
+from backend.common.agent_manager import init_agent_manager
+from backend.common.config_repository import ProfileRepository
+from backend.routes import register_blueprints
+
+
+SCRIPT = Path(__file__).parent / "agents" / "scripts" / "agent.sh"
+GO_CLIENT = Path(__file__).parent / "agents" / "go-agent" / "client.go"
+
+
+def test_shell_agent_heartbeat_sends_real_token_but_only_logs_redacted_token(tmp_path):
+    source = SCRIPT.read_text(encoding="utf-8")
+    functions = source.split("# 备份配置", 1)[0]
+    log_file = tmp_path / "agent.log"
+    functions = functions.replace('LOG_FILE="/var/log/configflow-agent.log"', f'LOG_FILE="{log_file.as_posix()}"')
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    curl_args = tmp_path / "curl-args.txt"
+    (fake_bin / "systemctl").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (fake_bin / "curl").write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$CURL_ARGS_FILE"\nprintf "{}\\n200"\n',
+        encoding="utf-8",
+    )
+    os.chmod(fake_bin / "systemctl", 0o755)
+    os.chmod(fake_bin / "curl", 0o755)
+
+    token = "real-token-$[]-with-specials"
+    harness = tmp_path / "heartbeat-probe.sh"
+    harness.write_text(
+        functions
+        + f"\nSERVER_URL='https://config.test'\nAGENT_ID='agent-1'\nTOKEN='{token}'\nSERVICE_NAME='mosdns'\nsend_heartbeat\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["CURL_ARGS_FILE"] = str(curl_args)
+    result = subprocess.run(["sh", str(harness)], env=env, text=True, capture_output=True)
+
+    assert result.returncode == 0, result.stderr
+    recorded_args = curl_args.read_text(encoding="utf-8")
+    assert token in recorded_args
+    assert ("*" * 3) not in recorded_args
+    logs = log_file.read_text(encoding="utf-8")
+    assert ("*" * 3) in logs
+    assert token not in logs
+    assert token[:10] not in logs
+    assert "bad substitution" not in result.stderr.lower()
+
+
+def test_shell_agent_reregistration_sends_bearer_and_preserves_token_when_response_omits_it(tmp_path):
+    source = SCRIPT.read_text(encoding="utf-8")
+    functions = source.split("# 备份配置", 1)[0]
+    log_file = tmp_path / "agent.log"
+    config_file = tmp_path / "config.json"
+    functions = functions.replace('LOG_FILE="/var/log/configflow-agent.log"', f'LOG_FILE="{log_file.as_posix()}"')
+    functions = functions.replace('CONFIG_FILE="/opt/configflow-agent/config.json"', f'CONFIG_FILE="{config_file.as_posix()}"')
+    token = "existing-registration-token"
+    config_file.write_text(
+        '{\n  "agent_id": "agent-1",\n  "token": "existing-registration-token"\n}\n',
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    curl_args = tmp_path / "curl-args.txt"
+    (fake_bin / "curl").write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$CURL_ARGS_FILE"\nprintf \'{"success":true,"id":"agent-1","status":"online","is_new":false}\\n200\'\n',
+        encoding="utf-8",
+    )
+    os.chmod(fake_bin / "curl", 0o755)
+    harness = tmp_path / "register-probe.sh"
+    harness.write_text(
+        functions
+        + "\nSERVER_URL='https://config.test'\nAGENT_NAME='probe'\nAGENT_IP='10.0.0.8'\nAGENT_PORT=8080\nSERVICE_TYPE='mihomo'\n"
+        + f"AGENT_ID='agent-1'\nTOKEN='{token}'\nregister_to_server\nprintf '%s' \"$TOKEN\" > '{(tmp_path / 'token-after.txt').as_posix()}'\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["CURL_ARGS_FILE"] = str(curl_args)
+
+    result = subprocess.run(["sh", str(harness)], env=env, text=True, capture_output=True)
+
+    assert result.returncode == 0, result.stderr
+    recorded_args = curl_args.read_text(encoding="utf-8")
+    assert f"Authorization: Bearer {token}" in recorded_args
+    assert (tmp_path / "token-after.txt").read_text(encoding="utf-8") == token
+    assert token in config_file.read_text(encoding="utf-8")
+    logs = log_file.read_text(encoding="utf-8")
+    assert token not in logs
+    assert "Authorization: Bearer ***" in logs
+
+
+def test_shell_agent_first_registration_saves_returned_token_without_logging_it(tmp_path):
+    source = SCRIPT.read_text(encoding="utf-8")
+    functions = source.split("# 备份配置", 1)[0]
+    log_file = tmp_path / "agent.log"
+    config_file = tmp_path / "config.json"
+    functions = functions.replace('LOG_FILE="/var/log/configflow-agent.log"', f'LOG_FILE="{log_file.as_posix()}"')
+    functions = functions.replace('CONFIG_FILE="/opt/configflow-agent/config.json"', f'CONFIG_FILE="{config_file.as_posix()}"')
+    config_file.write_text('{\n  "agent_name": "probe"\n}\n', encoding="utf-8")
+    issued_token = "newly-issued-shell-token"
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    curl_args = tmp_path / "curl-args.txt"
+    (fake_bin / "curl").write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "$@" > "$CURL_ARGS_FILE"\nprintf \'{{"success":true,"id":"agent-new","token":"{issued_token}"}}\\n200\'\n',
+        encoding="utf-8",
+    )
+    os.chmod(fake_bin / "curl", 0o755)
+    harness = tmp_path / "first-register-probe.sh"
+    harness.write_text(
+        functions
+        + "\nSERVER_URL='https://config.test'\nAGENT_NAME='probe'\nAGENT_IP='10.0.0.9'\nAGENT_PORT=8080\nSERVICE_TYPE='mihomo'\nAGENT_ID=''\nTOKEN=''\n"
+        + f"register_to_server\nprintf '%s' \"$TOKEN\" > '{(tmp_path / 'token-after.txt').as_posix()}'\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["CURL_ARGS_FILE"] = str(curl_args)
+
+    result = subprocess.run(["sh", str(harness)], env=env, text=True, capture_output=True)
+
+    assert result.returncode == 0, result.stderr
+    recorded_args = curl_args.read_text(encoding="utf-8")
+    assert "Authorization:" not in recorded_args
+    assert (tmp_path / "token-after.txt").read_text(encoding="utf-8") == issued_token
+    assert issued_token in config_file.read_text(encoding="utf-8")
+    assert issued_token not in log_file.read_text(encoding="utf-8")
+
+
+def test_shell_registers_against_real_flask_and_heartbeats_with_persisted_token(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_REGISTRATION_KEY", raising=False)
+    repository = ProfileRepository(tmp_path / "repository")
+    config_module.set_repository(repository)
+    init_agent_manager()
+    app = Flask(__name__)
+    register_blueprints(app)
+    server = make_server("127.0.0.1", 0, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    source = SCRIPT.read_text(encoding="utf-8")
+    functions = source.split("# 备份配置", 1)[0]
+    log_file = tmp_path / "agent.log"
+    config_file = tmp_path / "config.json"
+    functions = functions.replace('LOG_FILE="/var/log/configflow-agent.log"', f'LOG_FILE="{log_file.as_posix()}"')
+    functions = functions.replace('CONFIG_FILE="/opt/configflow-agent/config.json"', f'CONFIG_FILE="{config_file.as_posix()}"')
+    config_file.write_text(
+        json.dumps(
+            {
+                "server_url": f"http://127.0.0.1:{server.server_port}",
+                "agent_name": "real-shell-agent",
+                "agent_host": "127.0.0.1",
+                "agent_port": 8080,
+                "agent_ip": "10.0.0.77",
+                "service_type": "mihomo",
+                "service_name": "definitely-not-running",
+                "config_path": str(tmp_path / "service.yaml"),
+                "restart_command": "true",
+                "heartbeat_interval": 30,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    harness = tmp_path / "real-flask-probe.sh"
+    harness.write_text(
+        functions + "\nload_config\nregister_to_server\nsend_heartbeat\n",
+        encoding="utf-8",
+    )
+
+    try:
+        first = subprocess.run(["sh", str(harness)], text=True, capture_output=True)
+        assert first.returncode == 0, first.stderr
+        first_config = json.loads(config_file.read_text(encoding="utf-8"))
+        issued_token = first_config["token"]
+        assert issued_token and issued_token != "[REDACTED]"
+        assert repository.get_system()["agents"][0]["token"] == issued_token
+
+        second = subprocess.run(["sh", str(harness)], text=True, capture_output=True)
+        assert second.returncode == 0, second.stderr
+        second_config = json.loads(config_file.read_text(encoding="utf-8"))
+        assert second_config["token"] == issued_token
+        persisted = repository.get_system()["agents"][0]
+        assert persisted["token"] == issued_token
+        assert persisted["status"] == "online"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_shell_agent_has_portable_syntax():
+    result = subprocess.run(["sh", "-n", str(SCRIPT)], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_go_agent_heartbeat_sends_configured_bearer_token():
+    source = GO_CLIENT.read_text(encoding="utf-8")
+    assert 'req.Header.Set("Authorization", "Bearer "+c.Token)' in source

--- a/backend/utils/rule_utils.py
+++ b/backend/utils/rule_utils.py
@@ -8,17 +8,17 @@
 import os
 import re
 from typing import Dict, Any
-from backend.common.config import DATA_DIR
+from backend.common.config import get_repository
+from backend.common.profile_context import resolve_profile_id
 
 
-def get_rules_dir() -> str:
+def get_rules_dir(profile_id: str = None) -> str:
     """获取规则缓存目录路径
 
     Returns:
         规则目录的绝对路径
     """
-    rules_dir = os.path.join(DATA_DIR, 'rules')
-    return rules_dir
+    return str(get_repository().rules_dir(resolve_profile_id(profile_id)))
 
 
 def sanitize_rule_name(name: str) -> str:
@@ -41,8 +41,8 @@ def sanitize_rule_name(name: str) -> str:
     return safe_name[:200] if safe_name else 'unnamed'
 
 
-def save_rule_to_local(rule: Dict[str, Any]) -> str:
-    """将规则内容保存到本地文件 {DATA_DIR}/rules/{rule_name}.list
+def save_rule_to_local(rule: Dict[str, Any], profile_id: str = None) -> str:
+    """将规则内容保存到当前 profile 的 rules/{rule_name}.list
 
     Args:
         rule: 规则字典
@@ -57,7 +57,8 @@ def save_rule_to_local(rule: Dict[str, Any]) -> str:
 
     rule_name = rule.get('name', 'unnamed')
     filename = f"{sanitize_rule_name(rule_name)}.list"
-    rules_dir = get_rules_dir()
+    resolved_profile_id = resolve_profile_id(profile_id)
+    rules_dir = get_rules_dir(resolved_profile_id)
     filepath = os.path.join(rules_dir, filename)
 
     # 确保目录存在
@@ -68,8 +69,11 @@ def save_rule_to_local(rule: Dict[str, Any]) -> str:
     if source_type == 'content':
         # 直接保存内容
         content = rule.get('content', '')
-        with open(filepath, 'w', encoding='utf-8') as f:
-            f.write(content)
+        get_repository().write_profile_text(
+            resolved_profile_id,
+            os.path.join('rules', filename),
+            content,
+        )
         logger.info(f"Saved rule content to {filepath}")
 
     elif source_type == 'url':
@@ -84,8 +88,11 @@ def save_rule_to_local(rule: Dict[str, Any]) -> str:
             response = requests.get(url, timeout=10)
             response.raise_for_status()
 
-            with open(filepath, 'w', encoding='utf-8') as f:
-                f.write(response.text)
+            get_repository().write_profile_text(
+                resolved_profile_id,
+                os.path.join('rules', filename),
+                response.text,
+            )
 
             logger.info(f"Downloaded and saved rule from {url} to {filepath}")
 

--- a/backend/utils/subscription_cache.py
+++ b/backend/utils/subscription_cache.py
@@ -4,7 +4,9 @@ import os
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from backend.common.config import DATA_DIR
+from backend.common.config import DATA_DIR, get_repository
+from backend.common.config_repository import ProfileRepositoryError
+from backend.common.profile_context import resolve_profile_id
 from backend.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -12,25 +14,31 @@ logger = get_logger(__name__)
 SUBSCRIPTION_CACHE_DIR = os.path.join(DATA_DIR, 'subscribes')
 
 
-def _ensure_cache_dir() -> str:
+def _ensure_cache_dir(profile_id: Optional[str] = None) -> str:
     """确保缓存目录存在"""
     try:
-        os.makedirs(SUBSCRIPTION_CACHE_DIR, exist_ok=True)
+        os.makedirs(get_repository().cache_dir(resolve_profile_id(profile_id)), exist_ok=True)
     except OSError as exc:
         logger.warning("创建订阅缓存目录失败: %s", exc)
-    return SUBSCRIPTION_CACHE_DIR
+    return str(get_repository().cache_dir(resolve_profile_id(profile_id)))
 
 
-def _get_cache_path(sub_id: str) -> str:
+def _get_cache_path(sub_id: str, profile_id: Optional[str] = None) -> str:
     """获取缓存文件路径"""
-    cache_dir = _ensure_cache_dir()
-    safe_id = sub_id.replace('/', '_')
+    cache_dir = _ensure_cache_dir(profile_id)
+    safe_id = sub_id.replace('/', '_').replace('\\', '_')
     return os.path.join(cache_dir, f'{safe_id}.json')
 
 
-def save_subscription_nodes(sub_id: str, nodes: Any, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def save_subscription_nodes(
+    sub_id: str,
+    nodes: Any,
+    metadata: Optional[Dict[str, Any]] = None,
+    profile_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """保存订阅节点到本地缓存"""
-    cache_path = _get_cache_path(sub_id)
+    resolved_profile_id = resolve_profile_id(profile_id)
+    cache_path = _get_cache_path(sub_id, resolved_profile_id)
     payload: Dict[str, Any] = {
         'subscription_id': sub_id,
         'updated_at': datetime.now().isoformat() + 'Z',
@@ -40,26 +48,32 @@ def save_subscription_nodes(sub_id: str, nodes: Any, metadata: Optional[Dict[str
     if metadata:
         payload['metadata'] = metadata
     try:
-        with open(cache_path, 'w', encoding='utf-8') as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
+        get_repository().write_profile_json(
+            resolved_profile_id,
+            os.path.join('subscribes', os.path.basename(cache_path)),
+            payload,
+        )
     except OSError as exc:
         logger.error("写入订阅缓存失败 (%s): %s", sub_id, exc)
     return payload
 
 
-def load_subscription_cache(sub_id: str) -> Optional[Dict[str, Any]]:
+def load_subscription_cache(sub_id: str, profile_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """加载订阅缓存，如果不存在则返回 None"""
-    cache_path = _get_cache_path(sub_id)
+    resolved_profile_id = resolve_profile_id(profile_id)
+    cache_path = _get_cache_path(sub_id, resolved_profile_id)
     if not os.path.exists(cache_path):
         return None
 
     try:
-        with open(cache_path, 'r', encoding='utf-8') as f:
-            data = json.load(f)
+        data = get_repository().read_profile_json(
+            resolved_profile_id,
+            os.path.join('subscribes', os.path.basename(cache_path)),
+        )
         # 兼容旧数据，确保 count 存在
         if 'count' not in data and isinstance(data.get('nodes'), list):
             data['count'] = len(data['nodes'])
         return data
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, ProfileRepositoryError, json.JSONDecodeError) as exc:
         logger.warning("读取订阅缓存失败 (%s): %s", sub_id, exc)
         return None

--- a/doc/design/multi-config-management.md
+++ b/doc/design/multi-config-management.md
@@ -1,0 +1,647 @@
+# ConfigFlow 多配置管理可行性分析
+
+> 仓库：`thsrite/configflow`
+> 分析提交：`875d67c8fb32aa66710e918c899380ae16f4520e`
+> 目标：在一个 ConfigFlow 实例中管理多套相互隔离的 Mihomo / MosDNS / Surge 配置，并将不同配置绑定到不同 Agent。
+
+## 1. 结论
+
+**可行，建议实现。**
+
+但不能只在前端增加“配置下拉框”。当前系统把配置、缓存、生成产物和 Agent 注册全部放在单一全局作用域：
+
+- 单一配置文件：`/data/config.json`
+- 单一进程全局对象：`backend.common.config.config_data`
+- 单一订阅缓存目录：`/data/subscribes`
+- 单一规则/Provider 目录：`/data/rules`、`/data/providers`
+- 单一生成产物：`/data/config.yaml`、`/data/config.conf`
+- Agent 注册信息也存于同一个 `config_data['agents']`
+
+代码规模约 28,952 行，后端约 8,031 行 Python。约 20 个 Python 文件、450 处引用直接依赖 `config_data`，另有 66 处 `save_config()` 调用。因此多配置属于**中等规模架构改造**，不是小功能。
+
+推荐引入一等公民的 `Profile`（配置空间），把“系统级数据”和“配置级数据”拆开，并让每个 Agent 显式绑定一个 Profile。
+
+## 2. 当前架构与耦合点
+
+### 2.1 配置存储
+
+核心文件：`backend/common/config.py`
+
+当前：
+
+```python
+DATA_DIR = os.environ.get('DATA_DIR', '/data')
+CONFIG_FILE = os.path.join(DATA_DIR, 'config.json')
+config_data = get_default_config()
+```
+
+`get_config()` 永远返回同一个全局字典；`save_config()` 永远覆盖同一个 `config.json`。
+
+主要问题：
+
+1. 无法同时加载两套配置；
+2. 并发请求切换全局 `config_data` 会串配置；
+3. `AgentManager` 持有同一个字典引用；
+4. 生成器、路由、MCP 内部调用都默认使用全局配置；
+5. 当前写文件不是原子替换，也没有按 Profile 加锁。
+
+另外，`backend/models/config.py` 中的 dataclass 与实际存储模型已经脱节：模型使用 `rules` / `rule_sets`，实际配置使用统一的 `rule_configs`；路由也全部直接操作 `dict/list`。因此不能只在 dataclass 上增加 `profile_id`，需要以 ConfigRepository 为真实数据入口。
+
+### 2.2 缓存和生成产物
+
+- `backend/utils/subscription_cache.py` 固定使用 `/data/subscribes/<sub_id>.json`
+- `backend/common/config.py` 固定使用 `/data/providers`
+- `backend/utils/rule_utils.py` 使用全局规则目录
+- `backend/routes/generate.py` 固定保存 `/data/config.yaml` 和 `/data/config.conf`
+
+即使只给 `config.json` 增加多配置数组，缓存和生成文件仍会互相覆盖。
+
+### 2.3 REST API
+
+现有 API 都没有配置上下文：
+
+```text
+/api/subscriptions
+/api/rules
+/api/proxy-groups
+/api/generate/mihomo
+/api/config/mihomo
+/api/agents/<id>/push-config
+```
+
+所有路由内部直接 `get_config()` 或直接引用 `config_data`。
+
+### 2.4 Agent 推送
+
+核心：`backend/routes/agents.py::push_config_to_agent()`
+
+当前根据 Agent 的 `service_type` 生成配置，但生成源永远是全局 `config_data`：
+
+```python
+generate_mihomo_config(config_data, ...)
+generate_mosdns_config(config_data, ...)
+```
+
+因此目前不可能安全地让 `.28` 使用 `100.127.0.0/17`，同时让 `.29` 使用 `100.126.0.0/17` 并都由同一 ConfigFlow 管理。
+
+### 2.5 MCP
+
+MCP 工具通过 `backend/mcp_server/invoker.py` 进程内调用现有 REST API，这是好的设计，可继续复用。
+
+问题是 MCP 当前无状态；工具没有 `profile_id` 参数，因此所有调用都落到唯一全局配置。
+
+### 2.6 前端
+
+前端没有集中式配置状态库，每个页面直接调用现有 API。`frontend/src/api/index.ts` 的 Axios 拦截器当前只注入 Authorization。
+
+这反而使改造相对容易：可以在 Axios 请求拦截器中统一注入 Profile 上下文，并通过顶栏选择器切换。
+
+## 3. 推荐领域模型
+
+### 3.1 系统级数据
+
+不属于任何 Profile：
+
+```json
+{
+  "schema_version": 2,
+  "active_profile_id": "default",
+  "profiles": [
+    {
+      "id": "main-28",
+      "name": "主代理 .28",
+      "description": "Mihomo/MosDNS 主实例",
+      "created_at": "...",
+      "updated_at": "..."
+    }
+  ],
+  "agents": [],
+  "system_config": {
+    "server_domain": "...",
+    "github_proxy_domain": {},
+    "config_token": "..."
+  },
+  "backup": {}
+}
+```
+
+建议全局保存：
+
+- Profile 索引；
+- Agent 注册、心跳和监控元数据；
+- 登录/认证相关系统设置；
+- ConfigFlow 服务地址；
+- 全局备份配置。
+
+### 3.2 Profile 级数据
+
+每个 Profile 独立保存：
+
+```json
+{
+  "subscriptions": [],
+  "nodes": [],
+  "subscription_aggregations": [],
+  "rule_configs": [],
+  "rule_library": [],
+  "proxy_groups": [],
+  "mihomo": {},
+  "mosdns": {},
+  "surge": {}
+}
+```
+
+### 3.3 Agent 绑定
+
+为 Agent 增加：
+
+```json
+{
+  "profile_id": "main-28",
+  "service_type": "mihomo"
+}
+```
+
+同一个 Profile 可绑定多个 Agent；一个 Agent 默认只绑定一个 Profile。
+
+你的实际场景：
+
+```text
+main-28
+  ├─ ros-mihomo
+  └─ ros-mosdns
+
+backup-29
+  ├─ ros-mihomo29
+  └─ ros-mosdns29
+
+nas-aio
+  ├─ aio-mihomo
+  └─ aio-mosdns
+```
+
+`.28/.29` 可分别配置：
+
+```text
+main-28 fake-IP   = 100.127.0.0/17
+backup-29 fake-IP = 100.126.0.0/17
+```
+
+这样 ConfigFlow 才能安全推送，不会把 `.28` 配置覆盖到 `.29`。
+
+## 4. 推荐磁盘布局
+
+```text
+/data/
+├─ system.json
+├─ profiles/
+│  ├─ main-28/
+│  │  ├─ config.json
+│  │  ├─ subscribes/
+│  │  ├─ providers/
+│  │  ├─ rules/
+│  │  └─ generated/
+│  │     ├─ config.yaml
+│  │     └─ config.conf
+│  ├─ backup-29/
+│  │  └─ ...
+│  └─ nas-aio/
+│     └─ ...
+├─ logs/
+└─ app.log
+```
+
+不要让不同 Profile 共享：
+
+- subscription cache；
+- provider 文件；
+- 本地规则缓存；
+- 生成文件；
+- MosDNS 自定义文件。
+
+即使两个 Profile 的 subscription ID 相同，也不能覆盖彼此。
+
+## 5. 后端实现方案
+
+### 5.1 引入 ConfigRepository
+
+新增：
+
+```text
+backend/common/config_repository.py
+backend/common/profile_context.py
+```
+
+建议接口：
+
+```python
+class ConfigRepository:
+    def list_profiles(self): ...
+    def create_profile(self, metadata, clone_from=None): ...
+    def get_profile(self, profile_id): ...
+    def save_profile(self, profile_id, data): ...
+    def delete_profile(self, profile_id): ...
+    def export_profile(self, profile_id): ...
+    def import_profile(self, profile_id, data): ...
+    def profile_dir(self, profile_id): ...
+```
+
+写入要求：
+
+1. 每个 Profile 独立锁；
+2. 写入临时文件；
+3. `fsync` 后 `os.replace()` 原子替换；
+4. 保留最近一次有效副本；
+5. 校验 profile ID，防止路径穿越。
+
+### 5.2 请求级 ProfileContext
+
+建议用 Flask `g` 或 `contextvars.ContextVar`，不要在请求开始时替换全局 `config_data`。
+
+解析优先级：
+
+```text
+显式 URL profile_id
+→ X-ConfigFlow-Profile 请求头
+→ query 参数 profile
+→ system.active_profile_id
+→ default
+```
+
+推荐显式 URL 用于外部配置和危险操作；Header 用于前端普通 CRUD。
+
+Profile 上下文最好同时进入请求日志，便于审计一次规则修改、生成或推送究竟作用于哪套配置。
+
+### 5.3 兼容现有路由
+
+生产级推荐两层兼容：
+
+```text
+旧：/api/rules
+新：/api/profiles/<profile_id>/rules
+```
+
+旧路由解析到 `active_profile_id`，保证升级后旧客户端继续工作。
+
+外部订阅 URL：
+
+```text
+/api/config/<profile_id>/mihomo?token=...
+/api/config/<profile_id>/surge?token=...
+/api/config/<profile_id>/mosdns?token=...
+```
+
+旧 URL：
+
+```text
+/api/config/mihomo
+```
+
+继续指向默认 Profile。
+
+### 5.4 降低改造面
+
+短期兼容可以保留 `get_config()`，改为：
+
+```python
+def get_config(profile_id=None):
+    return repository.get_profile(resolve_profile_id(profile_id))
+```
+
+但应逐步消除模块级 `from ... import config_data`。全局代理对象虽然能减少代码改动，但在并发 Web/MCP/后台任务中容易串 Profile，不建议作为最终方案。
+
+所有生成器本身已经接收 `config_data` 参数，因此生成器核心无需重写；只需在调用点传入正确 Profile 数据。
+
+## 6. REST API 设计
+
+### Profile 管理
+
+```text
+GET    /api/profiles
+POST   /api/profiles
+GET    /api/profiles/<id>
+PUT    /api/profiles/<id>
+DELETE /api/profiles/<id>
+POST   /api/profiles/<id>/clone
+POST   /api/profiles/<id>/activate
+GET    /api/profiles/<id>/export
+POST   /api/profiles/<id>/import
+```
+
+删除限制：
+
+- 默认 Profile 不可删除；
+- 被 Agent 绑定的 Profile 不可直接删除；
+- 删除前必须确认生成产物和缓存范围；
+- 不允许静默把 Agent 迁移到默认 Profile。
+
+### Profile 内资源
+
+推荐显式路径：
+
+```text
+/api/profiles/<id>/subscriptions
+/api/profiles/<id>/nodes
+/api/profiles/<id>/rules
+/api/profiles/<id>/rule-library
+/api/profiles/<id>/proxy-groups
+/api/profiles/<id>/generate/mihomo
+```
+
+为了减少一次性改动，也可先让旧资源 API 接受：
+
+```text
+X-ConfigFlow-Profile: main-28
+```
+
+然后分阶段迁移到显式路径。
+
+## 7. Agent 推送设计
+
+修改 `push_config_to_agent()`：
+
+```python
+profile_id = agent['profile_id']
+config_data = repository.get_profile(profile_id)
+```
+
+推送前响应/日志必须包含：
+
+```text
+Agent 名称
+Agent 地址
+Profile 名称和 ID
+配置类型
+配置版本/hash
+是否重启
+```
+
+建议 Agent 增加：
+
+```json
+{
+  "profile_id": "backup-29",
+  "config_revision": "sha256:..."
+}
+```
+
+推送安全检查：
+
+- 未绑定 Profile 时禁止推送；
+- 检测 fake-IP CIDR 与目标预期不一致时警告/阻止；
+- 推送前 preview；
+- 配置 hash 未变化时跳过；
+- 保留 Agent 端上一版配置以回滚。
+
+`backend/common/agent_manager.py` 当前是持有全局 `config_data` 引用的单例，必须拆成“全局 Agent 注册仓库 + 显式 Profile 配置仓库”，不能为每个请求重新绑定一个可变全局字典。
+
+同一个 Agent 的配置更新应加互斥锁或任务队列：当 Web、MCP 或后台任务同时向同一 Agent 推送时，只允许一个更新任务执行；后续任务按配置 revision 去重或排队。Go Agent 回报的 `config_version` 应与目标 Profile revision 对应，服务端在推送完成后进行确认。
+
+## 8. MCP 设计
+
+MCP 目前无状态，因此不能依赖“上一次选择了哪个配置”。
+
+### 新增工具
+
+```text
+list_profiles
+get_profile
+manage_profile
+clone_profile
+bind_agent_profile
+```
+
+### 现有工具参数
+
+所有配置相关工具增加可选：
+
+```json
+{
+  "profile_id": "main-28"
+}
+```
+
+兼容逻辑：
+
+- 未传 `profile_id` → 默认 Profile；
+- 涉及写入或 Agent 推送时，结果中必须回显 Profile ID；
+- 危险工具不可依赖一个全局“当前 Profile”会话状态。
+
+MCP 内部调用：
+
+```python
+call_api(..., headers={'X-ConfigFlow-Profile': profile_id})
+```
+
+需扩展 `backend/mcp_server/invoker.py::call_api()` 支持额外 headers 或显式 Profile 路径。
+
+## 9. 前端实现
+
+### 9.1 Profile Store
+
+新增轻量 store（可用 Pinia，或先用 `provide/inject`）：
+
+```text
+frontend/src/stores/profile.ts
+frontend/src/components/ProfileSwitcher.vue
+frontend/src/views/Profiles.vue
+```
+
+状态：
+
+```ts
+activeProfileId
+profiles
+loading
+switchProfile(id)
+refreshProfiles()
+```
+
+### 9.2 Axios 注入
+
+`frontend/src/api/index.ts` 请求拦截器中增加：
+
+```ts
+config.headers['X-ConfigFlow-Profile'] = activeProfileId
+```
+
+配置生成和订阅 URL 使用显式 profile path，不能只靠 Header。
+
+### 9.3 页面刷新
+
+Profile 切换后：
+
+- 清空当前页面缓存；
+- 取消旧 Profile 未完成请求；
+- 使用 `router-view :key="activeProfileId"` 重新挂载页面；
+- 页面标题/危险操作对话框显示 Profile 名称；
+- 在 Agent 页面显示绑定 Profile。
+
+Profile 选择不应只保存在全局 `localStorage`。若用户同时打开两个标签页分别编辑 `.28` 和 `.29`，共享 localStorage 会让一个标签页的切换影响另一个标签页。推荐：
+
+- Profile ID 放入 URL（例如 `/profiles/main-28/rules`），或
+- 使用 `sessionStorage` 保存每个标签页的活动 Profile；
+- Axios 请求仍显式携带 Profile ID；
+- 服务器不依赖浏览器“当前配置”状态。
+
+### 9.4 UX
+
+顶栏显示：
+
+```text
+当前配置：[主代理 .28 ▼]
+```
+
+切换时明确提示未保存编辑。克隆 Profile 是重要入口：
+
+```text
+从“主代理 .28”克隆 → “备用代理 .29”
+```
+
+然后只调整 fake-IP、DNS、节点策略和 Agent 绑定。
+
+## 10. 迁移方案
+
+### 首次启动迁移
+
+检测到旧 `/data/config.json` 且不存在 `/data/system.json`：
+
+1. 完整复制为 `/data/migrations/<timestamp>/config.json`；
+2. 建立 `default` Profile；
+3. 把配置级字段迁到 `/data/profiles/default/config.json`；
+4. 把 `agents`、`system_config`、`backup` 移入 `/data/system.json`；
+5. 把旧缓存目录移动到 default Profile；
+6. 写入 `schema_version=2`；
+7. 验证数量和引用一致后再提交迁移标记。
+
+迁移必须幂等；中途失败时继续使用旧配置，不能写出空配置。
+
+### 兼容策略
+
+- 默认 Profile ID 固定为 `default`；
+- 老 API/订阅链接默认指向 `default`；
+- 老 MCP 调用不传 profile 时仍工作；
+- 配置导入默认导入到当前 Profile，不覆盖系统/Agent 数据；
+- 增加“导出单个 Profile”和“导出完整系统”两种模式。
+
+## 11. 两种实现档位
+
+### 方案 A：多配置存储 + 全局活动配置
+
+特点：一次只能有一个 active Profile，所有 Agent 仍使用活动配置。
+
+优点：改动小。
+缺点：不能安全同时管理 `.28/.29`；切换期间并发请求和 Agent 推送风险高。
+
+**不建议作为最终实现。** 最多作为短期 MVP UI。
+
+### 方案 B：请求级 Profile + Agent 显式绑定
+
+特点：多个 Profile 可并存、并发生成、分别推送。
+
+优点：真正解决主备、多设备、多环境。
+缺点：需要改造配置仓库、缓存路径、REST、Agent、MCP、前端和迁移。
+
+**推荐方案。**
+
+## 12. 实施阶段
+
+### Phase 0：测试与基线（1–2 天）
+
+- 为配置加载/保存/导入补测试；
+- 为生成器建立固定快照测试；
+- 为 Agent 推送建立 fake Agent 测试；
+- 记录现有 REST/MCP 兼容行为。
+
+### Phase 1：ConfigRepository + 迁移（2–3 天）
+
+- system/profile 存储；
+- 原子写入和锁；
+- 旧配置迁移；
+- Profile CRUD；
+- 缓存目录隔离。
+
+### Phase 2：请求上下文和 REST（2–3 天）
+
+- ProfileContext；
+- 现有 API 兼容；
+- 显式 Profile API；
+- 配置生成/订阅 URL 多 Profile 化。
+
+### Phase 3：前端（2–3 天）
+
+- ProfileSwitcher；
+- Profile 管理页；
+- Axios 上下文；
+- 切换刷新和危险操作提示。
+
+### Phase 4：Agent + MCP（2–3 天）
+
+- Agent profile_id；
+- 按绑定配置推送；
+- MCP profile_id 参数；
+- MCP Profile 工具；
+- 配置 hash 和误推送防护。
+
+### Phase 5：回归和部署（2 天）
+
+- default 兼容；
+- `.28/.29` 并行验证；
+- 导入导出、备份恢复；
+- 并发请求测试；
+- 回滚测试。
+
+完整生产级实现预计约 **9–14 个开发日**。只做“可保存多份并手动切换”的 MVP 约 **3–5 天**，但不满足 `.28/.29` 同时管理的核心需求。
+
+## 13. 关键风险
+
+1. **全局字典并发串配置**：必须使用请求级上下文/显式传参；
+2. **缓存文件串 Profile**：所有派生文件必须命名空间隔离；
+3. **Agent 误推送**：必须绑定 Profile，并在推送确认中展示目标；
+4. **配置令牌权限**：多 Profile URL 必须明确授权模型；
+5. **备份语义变化**：区分单 Profile 与全系统备份；
+6. **ID 冲突**：克隆时可保留内部 ID（独立命名空间）或统一重映射，必须保持引用完整；
+7. **配置迁移写空**：迁移应先写新目录、验证后原子切换；
+8. **后台任务上下文**：订阅刷新、Agent 心跳、MCP 调用不能依赖可变全局 active Profile；
+9. **生成文件 URL**：规则和 Provider URL 必须携带 Profile；
+10. **删除 Profile**：有 Agent 绑定或活动订阅链接时必须阻止。
+
+## 14. 推荐落地路径
+
+推荐先从现有配置克隆三套 Profile：
+
+```text
+main-28    → ros-mihomo + ros-mosdns
+backup-29  → ros-mihomo29 + ros-mosdns29
+nas-aio    → aio-mihomo + aio-mosdns
+```
+
+第一版完成后至少验收：
+
+- 三个 Profile 的规则/订阅/策略组独立；
+- 同时 preview 三套配置不串数据；
+- `.28/.29` fake-IP 分别保持 `100.127/17` 与 `100.126/17`；
+- Agent 推送严格按绑定 Profile；
+- MCP 读写指定 Profile；
+- 老 `/api/config/mihomo` 和老 MCP 调用仍指向 default；
+- 删除/切换 Profile 不影响其他配置。
+
+## 15. 最终建议
+
+采用 **方案 B：请求级 Profile + Agent 显式绑定**。
+
+不要通过“切换全局 config_data 后复用全部 API”的方式实现，因为 Web、MCP、Agent 心跳和后台任务可以并发，会有把 `.28` 配置推给 `.29` 的真实风险。
+
+最佳技术路线是：
+
+```text
+ConfigRepository
++ ProfileContext
++ profile-scoped storage
++ explicit Agent binding
++ MCP profile_id
++ frontend ProfileSwitcher
++ backward-compatible default profile
+```
+
+生成器已经是接收 `config_data` 的纯函数风格，核心转换逻辑可复用；真正需要重构的是配置取得、持久化、缓存命名空间和调用上下文。整体工程可控，具备较高实施可行性。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,7 @@
             <h2 class="logo-text">ConfigFlow</h2>
           </div>
           <div class="header-actions">
+            <ProfileSwitcher v-if="!isLoginPage" />
             <div class="version-github-group">
               <el-tag class="version-tag" effect="plain">{{ versionInfo }}</el-tag>
               <el-button
@@ -59,6 +60,10 @@
             <el-menu-item index="/dashboard" class="menu-item">
               <el-icon><DataAnalysis /></el-icon>
               <span>数据统计</span>
+            </el-menu-item>
+            <el-menu-item index="/profiles" class="menu-item">
+              <el-icon><Setting /></el-icon>
+              <span>Profile 管理</span>
             </el-menu-item>
             <el-menu-item index="/subscriptions" class="menu-item">
               <el-icon><Link /></el-icon>
@@ -117,6 +122,10 @@
               <el-icon><DataAnalysis /></el-icon>
               <span>数据统计</span>
             </el-menu-item>
+            <el-menu-item index="/profiles">
+              <el-icon><Setting /></el-icon>
+              <span>Profile 管理</span>
+            </el-menu-item>
             <el-menu-item index="/subscriptions">
               <el-icon><Link /></el-icon>
               <span>订阅管理</span>
@@ -157,7 +166,7 @@
         </el-drawer>
 
         <el-main class="modern-main">
-          <router-view />
+          <router-view :key="activeProfileId" />
         </el-main>
       </el-container>
     </el-container>
@@ -170,9 +179,13 @@ import { useRoute, useRouter } from 'vue-router'
 import { systemApi, statsApi } from './api'
 import api from './api'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import ProfileSwitcher from './components/ProfileSwitcher.vue'
+import { useProfileStore } from './stores/profile'
 
 const route = useRoute()
 const router = useRouter()
+const profileStore = useProfileStore()
+const { activeProfileId } = profileStore
 const activeMenu = ref(route.path)
 const drawerVisible = ref(false)
 const versionInfo = ref('v1.0')
@@ -285,6 +298,7 @@ const handleCommand = async (command: string) => {
 onMounted(async () => {
   loadVersion()
   checkAuthStatus()
+  profileStore.refreshProfiles().catch(() => undefined)
 
   // 加载订阅聚合配置
   loadSubscriptionAggregationSetting()

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,11 +1,27 @@
 import axios from 'axios'
 import { ElMessage } from 'element-plus'
 import router from '@/router'
+import { clearActiveProfileId, getActiveProfileId } from '@/profileContext'
 
 const api = axios.create({
   baseURL: '/api',
   timeout: 30000
 })
+
+let profileRecovery: Promise<void> | null = null
+
+const recoverFromMissingProfile = (): Promise<void> => {
+  if (!profileRecovery) {
+    clearActiveProfileId()
+    profileRecovery = import('@/stores/profile')
+      .then(({ useProfileStore }) => useProfileStore().refreshProfiles())
+      .then(() => undefined)
+      .finally(() => {
+        profileRecovery = null
+      })
+  }
+  return profileRecovery
+}
 
 // 请求拦截器 - 添加 token
 api.interceptors.request.use(
@@ -14,6 +30,7 @@ api.interceptors.request.use(
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
+    config.headers['X-ConfigFlow-Profile'] = getActiveProfileId()
     return config
   },
   (error) => {
@@ -27,7 +44,10 @@ api.interceptors.response.use(
     return response
   },
   (error) => {
-    if (error.response?.status === 401) {
+    const message = error.response?.data?.message
+    if (error.response?.status === 404 && typeof message === 'string' && message.startsWith('Profile not found:')) {
+      void recoverFromMissingProfile().catch(() => undefined)
+    } else if (error.response?.status === 401) {
       // token 无效或过期
       localStorage.removeItem('token')
       localStorage.removeItem('username')
@@ -87,14 +107,29 @@ const getBaseUrl = () => {
   return localStorage.getItem('serverDomain') || window.location.origin
 }
 
+const profilePath = (profileId: string, path: string = '') =>
+  `/profiles/${encodeURIComponent(profileId)}${path}`
+
+export const profileApi = {
+  list: () => api.get('/profiles'),
+  get: (id: string) => api.get(profilePath(id)),
+  create: (data: any) => api.post('/profiles', data),
+  update: (id: string, data: any) => api.put(profilePath(id), data),
+  delete: (id: string) => api.delete(profilePath(id)),
+  clone: (id: string, data: any) => api.post(profilePath(id, '/clone'), data),
+  activate: (id: string) => api.post(profilePath(id, '/activate')),
+  export: (id: string) => api.get(profilePath(id, '/export'), { responseType: 'blob' }),
+  import: (id: string, data: any) => api.post(profilePath(id, '/import'), data),
+}
+
 // 配置生成
 export const generateApi = {
-  mihomo: () => api.post('/generate/mihomo', { base_url: getBaseUrl() }, { responseType: 'blob' }),
-  surge: () => api.post('/generate/surge', { base_url: getBaseUrl() }, { responseType: 'blob' }),
-  mosdns: () => api.post('/generate/mosdns', { base_url: getBaseUrl() }, { responseType: 'blob' }),
-  previewMihomo: () => api.post('/generate/mihomo/preview', { base_url: getBaseUrl() }),
-  previewSurge: () => api.post('/generate/surge/preview', { base_url: getBaseUrl() }),
-  previewMosdns: () => api.post('/generate/mosdns/preview', { base_url: getBaseUrl() })
+  mihomo: () => api.post(profilePath(getActiveProfileId(), '/generate/mihomo'), { base_url: getBaseUrl() }, { responseType: 'blob' }),
+  surge: () => api.post(profilePath(getActiveProfileId(), '/generate/surge'), { base_url: getBaseUrl() }, { responseType: 'blob' }),
+  mosdns: () => api.post(profilePath(getActiveProfileId(), '/generate/mosdns'), { base_url: getBaseUrl() }, { responseType: 'blob' }),
+  previewMihomo: () => api.post(profilePath(getActiveProfileId(), '/generate/mihomo/preview'), { base_url: getBaseUrl() }),
+  previewSurge: () => api.post(profilePath(getActiveProfileId(), '/generate/surge/preview'), { base_url: getBaseUrl() }),
+  previewMosdns: () => api.post(profilePath(getActiveProfileId(), '/generate/mosdns/preview'), { base_url: getBaseUrl() })
 }
 
 // 配置导入导出
@@ -119,6 +154,7 @@ export const agentApi = {
   getAll: () => api.get('/agents'),
   create: (data: any) => api.post('/agents', data),
   update: (id: string, data: any = {}) => api.post(`/agents/${id}/update`, data),
+  bindProfile: (id: string, profileId: string) => api.put(`/agents/${id}`, { profile_id: profileId }),
   delete: (id: string) => api.delete(`/agents/${id}`),
   restart: (id: string) => api.post(`/agents/${id}/restart`),
   getStatus: (id: string) => api.get(`/agents/${id}/status`),

--- a/frontend/src/components/ProfileSwitcher.vue
+++ b/frontend/src/components/ProfileSwitcher.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="profile-switcher">
+    <el-icon class="profile-icon"><Collection /></el-icon>
+    <el-select
+      v-model="selectedProfileId"
+      size="small"
+      class="profile-select"
+      :loading="loading"
+      aria-label="当前配置 Profile"
+      @change="handleChange"
+    >
+      <el-option
+        v-for="profile in profiles"
+        :key="profile.id"
+        :label="profile.name"
+        :value="profile.id"
+      >
+        <span>{{ profile.name }}</span>
+        <small>{{ profile.id }}</small>
+      </el-option>
+    </el-select>
+    <el-button
+      text
+      class="profile-manager-button"
+      title="管理配置 Profile"
+      aria-label="管理配置 Profile"
+      @click="router.push('/profiles')"
+    >
+      <el-icon><Setting /></el-icon>
+    </el-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import { ElMessageBox } from 'element-plus'
+import { useRouter } from 'vue-router'
+import { useProfileStore } from '@/stores/profile'
+
+const router = useRouter()
+const profileStore = useProfileStore()
+const { profiles, loading, activeProfileId, refreshProfiles, switchProfile } = profileStore
+const selectedProfileId = ref(activeProfileId.value)
+
+watch(activeProfileId, value => {
+  selectedProfileId.value = value
+})
+
+const handleChange = async (profileId: string) => {
+  if (profileId === activeProfileId.value) return
+  try {
+    await ElMessageBox.confirm(
+      '切换后当前页面将重新加载，未保存的编辑内容会丢失。继续吗？',
+      '切换配置 Profile',
+      { confirmButtonText: '切换', cancelButtonText: '取消', type: 'warning' }
+    )
+    switchProfile(profileId)
+    window.location.reload()
+  } catch {
+    selectedProfileId.value = activeProfileId.value
+  }
+}
+
+onMounted(() => {
+  refreshProfiles().catch(() => undefined)
+})
+</script>
+
+<style scoped>
+.profile-switcher {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.profile-icon {
+  color: #5b67d8;
+}
+
+.profile-select {
+  width: 158px;
+}
+
+.profile-manager-button {
+  color: #5b67d8;
+}
+
+.profile-select small {
+  margin-left: 8px;
+  color: #909399;
+}
+
+@media (max-width: 700px) {
+  .profile-icon {
+    display: none;
+  }
+
+  .profile-select {
+    width: 128px;
+  }
+}
+</style>

--- a/frontend/src/profileContext.ts
+++ b/frontend/src/profileContext.ts
@@ -1,0 +1,34 @@
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'configflow.activeProfile'
+
+const readStoredProfile = (): string => {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY) || 'default'
+  } catch {
+    return 'default'
+  }
+}
+
+export const activeProfileId = ref(readStoredProfile())
+
+export const setActiveProfileId = (profileId: string): void => {
+  if (!profileId) return
+  activeProfileId.value = profileId
+  try {
+    sessionStorage.setItem(STORAGE_KEY, profileId)
+  } catch {
+    // Private browsing can disable sessionStorage; the in-memory context still works.
+  }
+}
+
+export const clearActiveProfileId = (): void => {
+  activeProfileId.value = 'default'
+  try {
+    sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Keep the in-memory fallback when storage is unavailable.
+  }
+}
+
+export const getActiveProfileId = (): string => activeProfileId.value

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -26,6 +26,11 @@ const routes = [
     component: () => import('@/views/Dashboard.vue')
   },
   {
+    path: '/profiles',
+    name: 'Profiles',
+    component: () => import('@/views/Profiles.vue')
+  },
+  {
     path: '/subscriptions',
     name: 'Subscriptions',
     component: () => import('@/views/Subscriptions.vue')

--- a/frontend/src/stores/profile.ts
+++ b/frontend/src/stores/profile.ts
@@ -1,0 +1,52 @@
+import { computed, ref } from 'vue'
+import { profileApi } from '@/api'
+import { activeProfileId, setActiveProfileId } from '@/profileContext'
+
+export interface Profile {
+  id: string
+  name: string
+  description?: string
+  created_at?: string
+  updated_at?: string
+}
+
+const profiles = ref<Profile[]>([])
+const loading = ref(false)
+
+const refreshProfiles = async (): Promise<Profile[]> => {
+  loading.value = true
+  try {
+    const { data } = await profileApi.list()
+    profiles.value = Array.isArray(data) ? data : data?.profiles || []
+    if (!profiles.value.some(profile => profile.id === activeProfileId.value)) {
+      setActiveProfileId(profiles.value[0]?.id || 'default')
+    }
+    return profiles.value
+  } finally {
+    loading.value = false
+  }
+}
+
+const switchProfile = (profileId: string): void => {
+  if (profiles.value.some(profile => profile.id === profileId)) {
+    setActiveProfileId(profileId)
+  }
+}
+
+const activeProfile = computed(() =>
+  profiles.value.find(profile => profile.id === activeProfileId.value)
+)
+
+const profileName = (profileId: string): string => {
+  return profiles.value.find(profile => profile.id === profileId)?.name || profileId
+}
+
+export const useProfileStore = () => ({
+  profiles,
+  loading,
+  activeProfileId,
+  activeProfile,
+  refreshProfiles,
+  switchProfile,
+  profileName,
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -78,6 +78,7 @@ export interface Agent {
   version: string
   config_version: string
   enabled: boolean
+  profile_id?: string
   has_update?: boolean
   created_at?: string
   updated_at?: string

--- a/frontend/src/views/Agents.vue
+++ b/frontend/src/views/Agents.vue
@@ -121,6 +121,27 @@
           <div class="section-value">{{ agent.version || 'N/A' }}</div>
         </div>
 
+        <div class="card-section profile-binding">
+          <div class="section-label">
+            <el-icon><Setting /></el-icon>
+            配置 Profile
+          </div>
+          <el-select
+            :model-value="agent.profile_id || 'default'"
+            size="small"
+            :teleported="false"
+            :disabled="bindingAgentId === agent.id"
+            @change="bindAgentProfile(agent, $event)"
+          >
+            <el-option
+              v-for="profile in profileStore.profiles"
+              :key="profile.id"
+              :label="profile.name"
+              :value="profile.id"
+            />
+          </el-select>
+        </div>
+
         <!-- 系统监控指标 -->
         <div v-if="agent.system_metrics" class="metrics-section">
           <div class="metrics-header">
@@ -862,10 +883,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { ElMessage, ElMessageBox, ElLoading } from 'element-plus'
-import { Document, Refresh, Monitor, SuccessFilled, WarningFilled, DocumentCopy, QuestionFilled, Connection, Clock, InfoFilled, Upload, RefreshRight, View, Delete, Close, Download, TrendCharts } from '@element-plus/icons-vue'
+import { Document, Refresh, Monitor, SuccessFilled, WarningFilled, DocumentCopy, QuestionFilled, Connection, Clock, InfoFilled, Upload, RefreshRight, View, Delete, Close, Download, TrendCharts, Setting } from '@element-plus/icons-vue'
 import { agentApi } from '@/api'
 import api from '@/api'
 import type { Agent } from '@/types'
+import { useProfileStore } from '@/stores/profile'
 import { use } from 'echarts/core'
 import { LineChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent, LegendComponent, TitleComponent } from 'echarts/components'
@@ -876,6 +898,8 @@ import VChart from 'vue-echarts'
 use([LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer])
 
 const agents = ref<Agent[]>([])
+const profileStore = useProfileStore()
+const bindingAgentId = ref<string | null>(null)
 const scriptDialogVisible = ref(false)
 const logsDialogVisible = ref(false)
 const metricsDialogVisible = ref(false)
@@ -1306,6 +1330,21 @@ const loadAgents = async () => {
     agents.value = data
   } catch (error) {
     ElMessage.error('加载 Agent 列表失败')
+  }
+}
+
+const bindAgentProfile = async (agent: Agent, profileId: string) => {
+  const previousProfileId = agent.profile_id || 'default'
+  if (profileId === previousProfileId) return
+  bindingAgentId.value = agent.id
+  try {
+    await agentApi.bindProfile(agent.id, profileId)
+    agent.profile_id = profileId
+    ElMessage.success('Agent 配置 Profile 已更新')
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || 'Agent 配置 Profile 更新失败')
+  } finally {
+    bindingAgentId.value = null
   }
 }
 
@@ -2096,6 +2135,7 @@ const stopAutoRefresh = () => {
 
 onMounted(() => {
   loadAgents()
+  profileStore.refreshProfiles().catch(() => undefined)
   startAutoRefresh()
 })
 

--- a/frontend/src/views/Generate.vue
+++ b/frontend/src/views/Generate.vue
@@ -1278,6 +1278,7 @@ import { generateApi, configApi, customConfigApi, subscriptionApi, nodeApi, rule
 import YamlEditor from '@/components/YamlEditor.vue'
 import api from '@/api'
 import type { RuleSet } from '@/types'
+import { activeProfileId } from '@/profileContext'
 import * as yaml from 'js-yaml'
 import Sortable from 'sortablejs'
 
@@ -1874,15 +1875,15 @@ const baseUrl = computed(() => {
 })
 
 const mihomoUrl = computed(() => {
-  const url = `${baseUrl.value}/api/config/mihomo`
+  const url = `${baseUrl.value}/api/config/${encodeURIComponent(activeProfileId.value)}/mihomo`
   return configToken.value ? `${url}?token=${configToken.value}` : url
 })
 const surgeUrl = computed(() => {
-  const url = `${baseUrl.value}/api/config/surge`
+  const url = `${baseUrl.value}/api/config/${encodeURIComponent(activeProfileId.value)}/surge`
   return configToken.value ? `${url}?token=${configToken.value}` : url
 })
 const mosdnsUrl = computed(() => {
-  const url = `${baseUrl.value}/api/config/mosdns`
+  const url = `${baseUrl.value}/api/config/${encodeURIComponent(activeProfileId.value)}/mosdns`
   return configToken.value ? `${url}?token=${configToken.value}` : url
 })
 

--- a/frontend/src/views/Profiles.vue
+++ b/frontend/src/views/Profiles.vue
@@ -1,0 +1,238 @@
+<template>
+  <div class="profiles-page">
+    <div class="page-header">
+      <div class="title-block">
+        <h2>配置 Profile</h2>
+        <p>管理隔离的订阅、节点、规则和生成配置</p>
+      </div>
+      <div class="header-actions">
+        <el-button @click="pickImportFile">
+          <el-icon><Upload /></el-icon>
+          导入到当前 Profile
+        </el-button>
+        <el-button type="primary" @click="openCreate">
+          <el-icon><Plus /></el-icon>
+          新建 Profile
+        </el-button>
+        <input ref="importInput" type="file" accept="application/json" hidden @change="importProfile" />
+      </div>
+    </div>
+
+    <el-table v-loading="loading" :data="profiles" row-key="id" class="profiles-table">
+      <el-table-column prop="name" label="名称" min-width="180" />
+      <el-table-column prop="id" label="ID" min-width="150" />
+      <el-table-column prop="description" label="说明" min-width="220" show-overflow-tooltip />
+      <el-table-column label="状态" width="110">
+        <template #default="{ row }">
+          <el-tag v-if="row.id === activeProfileId" type="success">当前</el-tag>
+          <span v-else class="muted">未使用</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="330" fixed="right">
+        <template #default="{ row }">
+          <el-button
+            v-if="row.id !== activeProfileId"
+            text
+            type="primary"
+            :disabled="row.id === 'default' && activeProfileId === row.id"
+            @click="activate(row.id)"
+          >
+            <el-icon><CircleCheck /></el-icon>
+            使用
+          </el-button>
+          <el-button text @click="openEdit(row)">
+            <el-icon><Edit /></el-icon>
+            编辑
+          </el-button>
+          <el-button text @click="clone(row)">
+            <el-icon><CopyDocument /></el-icon>
+            克隆
+          </el-button>
+          <el-button text @click="exportProfile(row.id)">
+            <el-icon><Download /></el-icon>
+            导出
+          </el-button>
+          <el-button v-if="row.id !== 'default'" text type="danger" @click="remove(row)">
+            <el-icon><Delete /></el-icon>
+            删除
+          </el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialogVisible" :title="editingId ? '编辑 Profile' : '新建 Profile'" width="460px">
+      <el-form label-width="82px" @submit.prevent="submit">
+        <el-form-item label="Profile ID">
+          <el-input v-model="form.id" :disabled="Boolean(editingId)" maxlength="64" />
+        </el-form-item>
+        <el-form-item label="名称">
+          <el-input v-model="form.name" maxlength="120" />
+        </el-form-item>
+        <el-form-item label="说明">
+          <el-input v-model="form.description" type="textarea" :rows="3" maxlength="500" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="submit">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { CircleCheck, CopyDocument, Delete, Download, Edit, Plus, Upload } from '@element-plus/icons-vue'
+import { profileApi } from '@/api'
+import { useProfileStore, type Profile } from '@/stores/profile'
+
+const profileStore = useProfileStore()
+const { profiles, loading, activeProfileId, refreshProfiles, switchProfile } = profileStore
+const dialogVisible = ref(false)
+const saving = ref(false)
+const editingId = ref('')
+const importInput = ref<HTMLInputElement>()
+const form = reactive({ id: '', name: '', description: '' })
+
+const openCreate = () => {
+  editingId.value = ''
+  Object.assign(form, { id: '', name: '', description: '' })
+  dialogVisible.value = true
+}
+
+const openEdit = (profile: Profile) => {
+  editingId.value = profile.id
+  Object.assign(form, {
+    id: profile.id,
+    name: profile.name,
+    description: profile.description || '',
+  })
+  dialogVisible.value = true
+}
+
+const submit = async () => {
+  if (!form.name.trim() || (!editingId.value && !form.id.trim())) {
+    ElMessage.warning('请填写 Profile ID 和名称')
+    return
+  }
+  saving.value = true
+  try {
+    if (editingId.value) {
+      await profileApi.update(editingId.value, { name: form.name, description: form.description })
+    } else {
+      await profileApi.create({ id: form.id.trim(), name: form.name, description: form.description })
+    }
+    await refreshProfiles()
+    dialogVisible.value = false
+    ElMessage.success('Profile 已保存')
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || 'Profile 保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const activate = async (profileId: string) => {
+  try {
+    await profileApi.activate(profileId)
+    switchProfile(profileId)
+    window.location.reload()
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || '切换 Profile 失败')
+  }
+}
+
+const clone = async (profile: Profile) => {
+  try {
+    const { value } = await ElMessageBox.prompt('输入新 Profile ID', `克隆 ${profile.name}`, {
+      confirmButtonText: '克隆',
+      cancelButtonText: '取消',
+      inputValue: `${profile.id}-copy`,
+      inputPattern: /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/,
+      inputErrorMessage: 'ID 只能包含字母、数字、下划线和短横线',
+    })
+    await profileApi.clone(profile.id, { id: value, name: `${profile.name} 副本` })
+    await refreshProfiles()
+    ElMessage.success('Profile 已克隆')
+  } catch (error: any) {
+    if (error !== 'cancel') ElMessage.error(error.response?.data?.message || 'Profile 克隆失败')
+  }
+}
+
+const remove = async (profile: Profile) => {
+  try {
+    await ElMessageBox.confirm(`确定删除 Profile「${profile.name}」及其缓存和生成文件吗？`, '删除 Profile', {
+      confirmButtonText: '删除',
+      cancelButtonText: '取消',
+      type: 'warning',
+    })
+    await profileApi.delete(profile.id)
+    await refreshProfiles()
+    ElMessage.success('Profile 已删除')
+  } catch (error: any) {
+    if (error !== 'cancel') ElMessage.error(error.response?.data?.message || 'Profile 删除失败')
+  }
+}
+
+const exportProfile = async (profileId: string) => {
+  try {
+    const response = await profileApi.export(profileId)
+    const url = URL.createObjectURL(new Blob([response.data], { type: 'application/json' }))
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${profileId}.json`
+    link.click()
+    URL.revokeObjectURL(url)
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || 'Profile 导出失败')
+  }
+}
+
+const pickImportFile = () => importInput.value?.click()
+
+const importProfile = async (event: Event) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  try {
+    const data = JSON.parse(await file.text())
+    await profileApi.import(activeProfileId.value, data)
+    await refreshProfiles()
+    ElMessage.success('配置已导入当前 Profile')
+  } catch (error: any) {
+    ElMessage.error(error.response?.data?.message || 'Profile 导入失败')
+  } finally {
+    input.value = ''
+  }
+}
+
+onMounted(() => {
+  refreshProfiles().catch(() => ElMessage.error('加载 Profile 失败'))
+})
+</script>
+
+<style scoped>
+.profiles-page {
+  min-height: 100%;
+}
+
+.profiles-table {
+  width: 100%;
+}
+
+.muted {
+  color: #909399;
+  font-size: 13px;
+}
+
+@media (max-width: 720px) {
+  .header-actions {
+    flex-wrap: wrap;
+  }
+
+  .profiles-table :deep(.el-table__fixed-right) {
+    display: none;
+  }
+}
+</style>

--- a/frontend/src/views/RuleLibrary.vue
+++ b/frontend/src/views/RuleLibrary.vue
@@ -455,6 +455,7 @@ import {
   CopyDocument
 } from '@element-plus/icons-vue'
 import api from '@/api'
+import { activeProfileId } from '@/profileContext'
 import Sortable from 'sortablejs'
 
 interface RuleLibraryItem {
@@ -1244,7 +1245,7 @@ const handleSaveProxyDomains = async () => {
 const getRuleDownloadUrl = (rule: RuleLibraryItem): string => {
   if (rule.source_type === 'content') {
     const baseUrl = `${window.location.protocol}//${window.location.host}`
-    return `${baseUrl}/api/rule-library/content/${rule.id}`
+    return `${baseUrl}/api/profiles/${encodeURIComponent(activeProfileId.value)}/rule-library/content/${rule.id}`
   }
   return rule.url || ''
 }

--- a/frontend/src/views/Rules.vue
+++ b/frontend/src/views/Rules.vue
@@ -661,6 +661,7 @@ import { ElMessage } from 'element-plus'
 import { DCaret, Edit, Delete, FolderOpened, ArrowUp, ArrowDown, Search, Plus, View, Hide, InfoFilled, List, Grid, ChatLineSquare, CopyDocument, Loading } from '@element-plus/icons-vue'
 import { ruleApi, ruleSetApi, proxyGroupApi } from '@/api'
 import type { Rule, RuleSet, ProxyGroup } from '@/types'
+import { activeProfileId } from '@/profileContext'
 import Sortable from 'sortablejs'
 import api from '@/api'
 
@@ -1052,7 +1053,7 @@ const onLibraryRuleSelect = (libraryRuleId: string) => {
     if (selectedRule.source_type === 'content') {
       // 规则内容类型，使用内容接口
       const baseUrl = `${window.location.protocol}//${window.location.host}`
-      ruleSetForm.value.url = `${baseUrl}/api/rule-library/content/${libraryRuleId}`
+      ruleSetForm.value.url = `${baseUrl}/api/profiles/${encodeURIComponent(activeProfileId.value)}/rule-library/content/${libraryRuleId}`
     } else {
       // URL 类型，使用原始 URL
       ruleSetForm.value.url = selectedRule.url


### PR DESCRIPTION
## Summary

This PR adds first-class multi-profile configuration management to ConfigFlow, allowing one instance to safely manage isolated Mihomo, MosDNS, and Surge configurations for multiple devices/environments.

### Multi-profile management

- Adds durable profile storage under `DATA_DIR/profiles/<profile_id>`.
- Adds profile CRUD, clone, activate, import, and export APIs.
- Adds request-scoped profile selection through explicit routes, headers, and query parameters without mutable global switching.
- Keeps legacy API and MCP behavior compatible through the default profile.
- Isolates subscriptions, rules, providers, caches, and generated artifacts by profile.
- Adds frontend profile selection and management UI.
- Adds `profile_id` binding for Agents and profile-aware MCP tools.

### Migration and concurrency safety

- Migrates legacy `config.json` into the default profile.
- Uses atomic writes, per-profile locks, system locks, rollback/compensation, and cross-process initialization locking.
- Uses staging directories for legacy migration and recoverable profile create/delete operations.
- Protects against stale snapshots and concurrent lost updates.

### Security hardening included

- Strict Bearer parsing across Python and Go Agent endpoints.
- Authenticated Agent heartbeat and authenticated duplicate registration.
- Agent capability tokens are returned only on first registration and removed from normal API/export/MCP responses.
- Internal `rule_proxy_token` is separated from `config_token`, never authorizes MCP, and is scrubbed from external output.
- Recursive/deep output sanitization handles nested and repeatedly URL-encoded secrets.
- Rule-proxy SSRF protection fixes DNS rebinding by connecting to validated IPs and revalidating each redirect.
- Rule-proxy targets must resolve exclusively to globally routable addresses; private, loopback, link-local, multicast, CGNAT, ULA, reserved, documentation, and benchmark ranges are rejected.
- Heartbeat body size and metrics schema are bounded.
- Shell and Go Agent logs no longer expose capability tokens or response bodies.

## Compatibility

- Existing API calls without a profile continue to use the default profile.
- Existing Agents without `profile_id` are migrated to `default`.
- Existing non-empty `config_token` values are preserved.
- Existing config-token/JWT rule-proxy URLs remain supported.

## Validation

- Python: **351 passed, 1 skipped** (the skipped test is POSIX-specific when run on Windows).
- Go Agent: `go test ./...`, `go vet ./...`, and `go build ./...` passed with Go 1.21.13.
- Frontend production build passed.
- Python `compileall` passed.
- Shell syntax checks passed.
- Multiple independent security/code-review rounds completed.
- Final SSRF adversarial matrix passed, including IPv4/IPv6 multicast, CGNAT, ULA, mixed DNS, redirect chains, alternate IP notation, and DNS rebinding scenarios.
- Tested in an isolated NAS container with separate port and data volume; production containers were not modified.

## Notes

- Frontend build still emits the existing large-chunk and mixed static/dynamic import warnings; these are non-blocking and unrelated to correctness.
