### PR TITLE
fix: redact credentials from URLs and agent logs

### DIFF
--- a/backend/agents/go-agent/client.go
+++ b/backend/agents/go-agent/client.go
@@ -51,11 +51,11 @@ func (c *Config) sendRegisterRequest(reqBody RegisterRequest) (*RegisterResponse
 	log.Printf("Register request prepared (body length: %d)", len(jsonData))
 
 	registerURL := fmt.Sprintf("%s/api/agents/register", c.ServerURL)
-	log.Printf("Sending register request to: %s", registerURL)
+	log.Printf("Sending register request to: %s", redactURLForLog(registerURL))
 	req, err := http.NewRequest(http.MethodPost, registerURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		log.Printf("Failed to create register request: %v", err)
-		return nil, fmt.Errorf("failed to create register request: %w", err)
+		log.Printf("Failed to create register request for %s", redactURLForLog(registerURL))
+		return nil, safeURLFailure("failed to create register request for", registerURL, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.Token != "" {
@@ -63,8 +63,8 @@ func (c *Config) sendRegisterRequest(reqBody RegisterRequest) (*RegisterResponse
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Printf("Failed to send register request: %v", err)
-		return nil, fmt.Errorf("failed to send register request: %w", err)
+		log.Printf("Failed to send register request to %s", redactURLForLog(registerURL))
+		return nil, safeURLFailure("failed to send register request to", registerURL, err)
 	}
 	defer resp.Body.Close()
 
@@ -202,25 +202,27 @@ func (c *Config) createHeartbeatRequest() ([]byte, error) {
 	return jsonData, nil
 }
 
+var heartbeatHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 // sendHeartbeatRequest 发送心跳请求到服务器
 func (c *Config) sendHeartbeatRequest(jsonData []byte) error {
 	heartbeatURL := fmt.Sprintf("%s/api/agents/%s/heartbeat", c.ServerURL, c.AgentID)
-	logDebugf("Sending heartbeat to: %s", heartbeatURL)
+	logDebugf("Sending heartbeat to: %s", redactURLForLog(heartbeatURL))
 
 	req, err := http.NewRequest("POST", heartbeatURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		log.Printf("Error: Failed to create heartbeat request: %v", err)
-		return err
+		log.Printf("Error: Failed to create heartbeat request for %s", redactURLForLog(heartbeatURL))
+		return safeURLFailure("failed to create heartbeat request for", heartbeatURL, err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := heartbeatHTTPClient
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("Error: Failed to send heartbeat: %v", err)
-		return err
+		log.Printf("Error: Failed to send heartbeat to %s", redactURLForLog(heartbeatURL))
+		return safeURLFailure("failed to send heartbeat to", heartbeatURL, err)
 	}
 	defer resp.Body.Close()
 

--- a/backend/agents/go-agent/client_test.go
+++ b/backend/agents/go-agent/client_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +85,95 @@ func TestHandleRegisterResponseStoresTokenForFirstRegistration(t *testing.T) {
 	}
 	assertSavedToken(t, path, "issued-token")
 }
+
+func TestRedactURLForLogRemovesCredentialsAndTokenFragments(t *testing.T) {
+	const token = "main-agent-secret-token"
+	raw := "https://user:password@example.test/api?config_token=" + token + "&ok=visible"
+
+	got := redactURLForLog(raw)
+
+	for _, secret := range []string{"user", "password", token, token[:8]} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("redacted URL leaked %q: %s", secret, got)
+		}
+	}
+	if !strings.Contains(got, "config_token=[REDACTED]") || !strings.Contains(got, "ok=visible") {
+		t.Fatalf("unexpected redacted URL: %s", got)
+	}
+}
+
+func TestRedactURLForLogDropsEncodedAndNestedFragments(t *testing.T) {
+	for _, raw := range []string{
+		"https://example.test/path#token=plain-fragment-secret",
+		"https://example.test/path#token=encoded%2Dfragment%2Dsecret",
+		"https://example.test/path#outer=https%253A%252F%252Fexample.test%252F%253Ftoken%253Dnested-secret",
+		"https://example.test/path#safe=ok&api_key=mixed-fragment-secret",
+	} {
+		got := redactURLForLog(raw)
+		if strings.Contains(got, "#") || strings.Contains(got, "fragment-secret") || strings.Contains(got, "nested-secret") {
+			t.Fatalf("fragment credential leaked: raw=%q got=%q", raw, got)
+		}
+	}
+}
+
+func TestRedactURLForLogRedactsActualReviewNestedCredentials(t *testing.T) {
+	for _, raw := range []string{
+		"https://example.test/p?next=https%253A%252F%252Fnested.test%252Fp%253Ftoken%253Dnested-url-secret",
+		"https://example.test/p?next=token%253Dnested-expression-secret",
+		"https://example.test/p?next=api%252Bkey%253Dplus-layer-secret",
+	} {
+		got := redactURLForLog(raw)
+		if !strings.Contains(got, "next=[REDACTED]") {
+			t.Fatalf("nested credential value was not redacted: raw=%q got=%q", raw, got)
+		}
+		for _, secret := range []string{"nested-url-secret", "nested-expression-secret", "plus-layer-secret"} {
+			if strings.Contains(got, secret) {
+				t.Fatalf("nested credential leaked %q: raw=%q got=%q", secret, raw, got)
+			}
+		}
+	}
+}
+
+func TestRedactURLForLogFailsClosedWhenDecodingRevealsC0(t *testing.T) {
+	for _, encodedControl := range []string{"%250d%250a", "%2500", "%251f", "%257f"} {
+		raw := "https://example.test/p?next=ok" + encodedControl + "token=secret"
+		if got := redactURLForLog(raw); got != "[INVALID URL REDACTED]" {
+			t.Fatalf("decoded control did not fail closed: raw=%q got=%q", raw, got)
+		}
+	}
+}
+
+func TestRegisterTransportErrorPreservesIdentityWithoutLeakingError(t *testing.T) {
+	want := errors.New("register transport secret")
+	old := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, want })
+	t.Cleanup(func() { http.DefaultTransport = old })
+
+	_, err := (&Config{ServerURL: "https://example.test", Token: "token"}).sendRegisterRequest(RegisterRequest{Name: "probe"})
+	if !errors.Is(err, want) {
+		t.Fatalf("errors.Is(err, want) = false: %v", err)
+	}
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Fatalf("errors.As(err, *url.Error) = false: %v", err)
+	}
+}
+
+func TestHeartbeatTransportErrorPreservesIdentityWithoutLeakingError(t *testing.T) {
+	want := errors.New("heartbeat transport secret")
+	old := heartbeatHTTPClient
+	heartbeatHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, want })}
+	t.Cleanup(func() { heartbeatHTTPClient = old })
+
+	err := (&Config{ServerURL: "https://example.test", AgentID: "agent", Token: "secret"}).sendHeartbeatRequest([]byte(`{}`))
+	if !errors.Is(err, want) {
+		t.Fatalf("errors.Is(err, want) = false: %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func assertSavedToken(t *testing.T, path, expected string) {
 	t.Helper()

--- a/backend/agents/go-agent/routes/config.go
+++ b/backend/agents/go-agent/routes/config.go
@@ -55,22 +55,22 @@ type CustomFileItem struct {
 
 // Config 结构体定义
 type Config struct {
-	ServerURL          string `json:"server_url"`
-	AgentName          string `json:"agent_name"`
-	AgentHost          string `json:"agent_host"`
-	AgentPort          int    `json:"agent_port"`
-	AgentIP            string `json:"agent_ip,omitempty"`
-	ServiceType        string `json:"service_type"`
-	ServiceName        string `json:"service_name"`
-	ConfigPath         string `json:"config_path"`
-	RestartCommand     string `json:"restart_command"`
-	HeartbeatInterval  int    `json:"heartbeat_interval"`
-	AgentID            string `json:"agent_id,omitempty"`
-	Token              string `json:"token,omitempty"`
+	ServerURL         string `json:"server_url"`
+	AgentName         string `json:"agent_name"`
+	AgentHost         string `json:"agent_host"`
+	AgentPort         int    `json:"agent_port"`
+	AgentIP           string `json:"agent_ip,omitempty"`
+	ServiceType       string `json:"service_type"`
+	ServiceName       string `json:"service_name"`
+	ConfigPath        string `json:"config_path"`
+	RestartCommand    string `json:"restart_command"`
+	HeartbeatInterval int    `json:"heartbeat_interval"`
+	AgentID           string `json:"agent_id,omitempty"`
+	Token             string `json:"token,omitempty"`
 
 	// MosDNS 特殊功能字段
-	Directories       []string              `json:"directories,omitempty"`
-	RulesetDownloads  []RulesetDownloadItem `json:"ruleset_downloads,omitempty"`
+	Directories      []string              `json:"directories,omitempty"`
+	RulesetDownloads []RulesetDownloadItem `json:"ruleset_downloads,omitempty"`
 
 	filePath string
 }
@@ -297,7 +297,8 @@ func downloadRuleset(configDir string, item RulesetDownloadItem) error {
 	}
 
 	// 否则从 URL 下载（向后兼容）
-	log.Printf("Downloading ruleset: %s from %s to %s (base: %s)", item.Name, item.URL, localPath, configDir)
+	safeURL := redactURLForLog(item.URL)
+	log.Printf("Downloading ruleset: %s from %s to %s (base: %s)", item.Name, safeURL, localPath, configDir)
 
 	// 创建目标目录
 	dir := filepath.Dir(localPath)
@@ -342,25 +343,25 @@ func downloadRuleset(configDir string, item RulesetDownloadItem) error {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", item.URL, nil)
 	if err != nil {
-		log.Printf("Failed to create request for %s: %v", item.URL, err)
-		return fmt.Errorf("failed to create request for %s: %w", item.URL, err)
+		log.Printf("Failed to create request for %s", safeURL)
+		return fmt.Errorf("failed to create request for %s", safeURL)
 	}
 
 	// 设置一个标准的 User-Agent，以避免被某些服务器拒绝
 	req.Header.Set("User-Agent", "configflow-agent/1.0")
 
 	// 下载文件
-	log.Printf("Starting download from: %s", item.URL)
+	log.Printf("Starting download from: %s", safeURL)
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("Failed to download %s: %v", item.URL, err)
-		return fmt.Errorf("failed to download %s: %w", item.URL, err)
+		log.Printf("Failed to download %s", safeURL)
+		return fmt.Errorf("failed to download %s", safeURL)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("Failed to download %s: status code %d", item.URL, resp.StatusCode)
-		return fmt.Errorf("failed to download %s: status code %d", item.URL, resp.StatusCode)
+		log.Printf("Failed to download %s: status code %d", safeURL, resp.StatusCode)
+		return fmt.Errorf("failed to download %s: status code %d", safeURL, resp.StatusCode)
 	}
 
 	// 保存文件
@@ -378,7 +379,7 @@ func downloadRuleset(configDir string, item RulesetDownloadItem) error {
 		return fmt.Errorf("failed to save file %s: %w", localPath, err)
 	}
 
-	log.Printf("Successfully downloaded ruleset: %s -> %s", item.URL, localPath)
+	log.Printf("Successfully downloaded ruleset: %s -> %s", safeURL, localPath)
 	return nil
 }
 
@@ -445,7 +446,8 @@ func downloadProvider(configDir string, item ProviderDownloadItem) error {
 	}
 
 	// 否则从 URL 下载（向后兼容）
-	log.Printf("Downloading provider: %s from %s to %s (base: %s)", item.Name, item.URL, localPath, configDir)
+	safeURL := redactURLForLog(item.URL)
+	log.Printf("Downloading provider: %s from %s to %s (base: %s)", item.Name, safeURL, localPath, configDir)
 
 	// 创建目标目录
 	dir := filepath.Dir(localPath)
@@ -491,24 +493,24 @@ func downloadProvider(configDir string, item ProviderDownloadItem) error {
 	// 创建请求
 	req, err := http.NewRequestWithContext(ctx, "GET", item.URL, nil)
 	if err != nil {
-		log.Printf("Failed to create request for %s: %v", item.URL, err)
-		return fmt.Errorf("failed to create request for %s: %w", item.URL, err)
+		log.Printf("Failed to create request for %s", safeURL)
+		return fmt.Errorf("failed to create request for %s", safeURL)
 	}
 
 	// 下载文件
-	log.Printf("Sending HTTP request to: %s", item.URL)
+	log.Printf("Sending HTTP request to: %s", safeURL)
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("Failed to download %s: %v", item.URL, err)
-		return fmt.Errorf("failed to download %s: %w", item.URL, err)
+		log.Printf("Failed to download %s", safeURL)
+		return fmt.Errorf("failed to download %s", safeURL)
 	}
 	defer resp.Body.Close()
 
 	// 检查状态码
-	log.Printf("HTTP response status for %s: %d", item.URL, resp.StatusCode)
+	log.Printf("HTTP response status for %s: %d", safeURL, resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("Failed to download %s: status code %d", item.URL, resp.StatusCode)
-		return fmt.Errorf("failed to download %s: status code %d", item.URL, resp.StatusCode)
+		log.Printf("Failed to download %s: status code %d", safeURL, resp.StatusCode)
+		return fmt.Errorf("failed to download %s: status code %d", safeURL, resp.StatusCode)
 	}
 
 	// 保存文件
@@ -526,7 +528,7 @@ func downloadProvider(configDir string, item ProviderDownloadItem) error {
 		return fmt.Errorf("failed to save file %s: %w", localPath, err)
 	}
 
-	log.Printf("Successfully downloaded provider: %s -> %s", item.URL, localPath)
+	log.Printf("Successfully downloaded provider: %s -> %s", safeURL, localPath)
 	return nil
 }
 
@@ -845,8 +847,8 @@ func handleConfigUpdateAsync(cfg *Config, req UpdateRequest) {
 	// 服务读到不完整（甚至缺失）的配置而启动失败
 	if req.RestartAfterUpdate {
 		log.Printf("RestartAfterUpdate is set, restarting service...")
-		if output, err := RestartService(cfg); err != nil {
-			log.Printf("Restart after config update failed: %v\nOutput: %s", err, string(output))
+		if _, err := RestartService(cfg); err != nil {
+			log.Print("Restart after config update failed")
 		} else {
 			log.Printf("Service restarted successfully after config update.")
 		}

--- a/backend/agents/go-agent/routes/config_test.go
+++ b/backend/agents/go-agent/routes/config_test.go
@@ -1,6 +1,14 @@
 package routes
 
-import "testing"
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestMosdnsCacheDumpFile(t *testing.T) {
 	tests := []struct {
@@ -50,5 +58,45 @@ func TestMosdnsCacheDumpFile(t *testing.T) {
 				t.Fatalf("mosdnsCacheDumpFile() = %q, want %q", actual, test.expected)
 			}
 		})
+	}
+}
+
+func TestProviderAndRulesetDownloadLogsRedactURLCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+
+	const rawToken = "raw-secret-token"
+	const encodedToken = "encoded%2520secret%252Ftoken"
+	downloadURL := strings.Replace(server.URL, "://", "://user:password@", 1) +
+		"/download?config_token=" + rawToken + "&authorization=" + encodedToken
+
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
+
+	dir := t.TempDir()
+	if err := downloadProvider(dir, ProviderDownloadItem{
+		Name: "provider", URL: downloadURL, LocalPath: filepath.Join("providers", "one.yaml"),
+	}); err != nil {
+		t.Fatalf("downloadProvider returned error: %v", err)
+	}
+	if err := downloadRuleset(dir, RulesetDownloadItem{
+		Name: "ruleset", URL: downloadURL, LocalPath: filepath.Join("ruleset", "one.yaml"),
+	}); err != nil {
+		t.Fatalf("downloadRuleset returned error: %v", err)
+	}
+
+	got := logs.String()
+	for _, secret := range []string{rawToken, encodedToken, "user", "password", rawToken[:8]} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("download logs leaked URL credential %q: %s", secret, got)
+		}
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("download logs do not show redaction marker: %s", got)
 	}
 }

--- a/backend/agents/go-agent/routes/restart.go
+++ b/backend/agents/go-agent/routes/restart.go
@@ -9,64 +9,59 @@ import (
 	"strings"
 )
 
-// RestartService 执行服务重启命令，返回命令输出。
+// RestartService 执行服务重启命令，返回成功命令的输出。
 // supervisorctl 场景下补全配置文件路径；restart 失败时回退为 start。
 func RestartService(cfg *Config) ([]byte, error) {
 	restartCommand := cfg.RestartCommand
 	if strings.Contains(restartCommand, "supervisorctl") && !strings.Contains(restartCommand, "-c") {
 		restartCommand = strings.Replace(restartCommand, "supervisorctl", "supervisorctl -c /etc/supervisor/supervisord.conf", 1)
-		log.Printf("Modified supervisorctl command: %s", restartCommand)
+		log.Print("Prepared supervisorctl restart command")
 	}
 
-	log.Printf("Executing restart command: %s", restartCommand)
+	log.Print("Executing restart command")
 	output, err := executeURLCommand(restartCommand)
 	if err == nil {
 		return output, nil
 	}
 
-	log.Printf("Restart command failed: %v\nOutput: %s", err, string(output))
+	log.Print("Restart command failed")
 
-	// supervisorctl restart 失败时，服务可能未在运行，改用 start
 	if strings.Contains(restartCommand, "supervisorctl") && strings.Contains(restartCommand, "restart") {
 		startCommand := strings.Replace(restartCommand, "restart", "start", 1)
-		log.Printf("Attempting to start service instead: %s", startCommand)
+		log.Print("Attempting to start service instead")
 		return executeURLCommand(startCommand)
 	}
 
-	return output, err
+	return nil, err
 }
 
 // RestartHandler 处理服务重启请求
 func RestartHandler(cfg *Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Received restart request.")
-		log.Printf("Executing restart command: %s", cfg.RestartCommand)
+		log.Print("Executing restart command")
 
-		// 特殊处理 supervisorctl 命令，确保使用正确的配置文件路径
 		restartCommand := cfg.RestartCommand
 		if strings.Contains(restartCommand, "supervisorctl") && !strings.Contains(restartCommand, "-c") {
 			restartCommand = strings.Replace(restartCommand, "supervisorctl", "supervisorctl -c /etc/supervisor/supervisord.conf", 1)
-			log.Printf("Modified supervisorctl command: %s", restartCommand)
+			log.Print("Prepared supervisorctl restart command")
 		}
 
-		output, err := executeURLCommand(restartCommand)
+		_, err := executeURLCommand(restartCommand)
 		if err != nil {
-			log.Printf("Restart command failed: %v\nOutput: %s", err, string(output))
+			log.Print("Restart command failed")
 
-			// 如果是 supervisorctl restart 命令失败，尝试用 start 命令
 			if strings.Contains(restartCommand, "supervisorctl") && strings.Contains(restartCommand, "restart") {
-				log.Printf("Attempting to start service instead of restart...")
+				log.Print("Attempting to start service instead of restart")
 				startCommand := strings.Replace(restartCommand, "restart", "start", 1)
-				log.Printf("Executing start command: %s", startCommand)
+				log.Print("Executing start command")
 
-				startOutput, startErr := executeURLCommand(startCommand)
+				_, startErr := executeURLCommand(startCommand)
 				if startErr != nil {
-					log.Printf("Start command also failed: %v\nOutput: %s", startErr, string(startOutput))
+					log.Print("Start command also failed")
 					JsonResponse(w, http.StatusInternalServerError, map[string]interface{}{
-						"success":        false,
-						"message":        "Restart and start both failed",
-						"restart_output": string(output),
-						"start_output":   string(startOutput),
+						"success": false,
+						"message": "Restart and start both failed",
 					})
 					return
 				}
@@ -76,7 +71,7 @@ func RestartHandler(cfg *Config) http.HandlerFunc {
 				return
 			}
 
-			JsonResponse(w, http.StatusInternalServerError, map[string]interface{}{"success": false, "message": "Restart failed", "output": string(output)})
+			JsonResponse(w, http.StatusInternalServerError, map[string]interface{}{"success": false, "message": "Restart failed"})
 			return
 		}
 
@@ -85,52 +80,46 @@ func RestartHandler(cfg *Config) http.HandlerFunc {
 	}
 }
 
-// executeURLCommand 执行URL格式的命令
+// executeURLCommand 执行URL或shell格式的命令。
 func executeURLCommand(command string) ([]byte, error) {
-	log.Printf("Executing command: %s", command)
+	log.Print("Executing configured command")
 
-	// 检查是否为URL格式的命令
 	if strings.HasPrefix(command, "http://") || strings.HasPrefix(command, "https://") {
-		log.Printf("Executing URL command: %s", command)
-		// 发送HTTP请求
+		log.Print("Executing URL command")
 		resp, err := http.Post(command, "application/json", nil)
 		if err != nil {
-			log.Printf("Failed to execute URL command: %v", err)
-			return nil, fmt.Errorf("failed to execute URL command: %w", err)
+			log.Print("Failed to execute URL command")
+			return nil, &safeWrappedError{message: "failed to execute URL command", cause: err}
 		}
 		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Printf("Failed to read response: %v", err)
-			return nil, fmt.Errorf("failed to read response: %w", err)
+			log.Print("Failed to read URL command response")
+			return nil, &safeWrappedError{message: "failed to read URL command response", cause: err}
 		}
 
 		if resp.StatusCode >= 400 {
 			log.Printf("URL command failed with status %d", resp.StatusCode)
-			return body, fmt.Errorf("URL command failed with status %d", resp.StatusCode)
+			return nil, fmt.Errorf("URL command failed with status %d", resp.StatusCode)
 		}
 
-		log.Printf("URL command executed successfully")
+		log.Print("URL command executed successfully")
 		return body, nil
 	}
 
-	// 否则执行普通的shell命令
-	log.Printf("Executing shell command: %s", command)
-
-	// 特殊处理 supervisorctl 命令，确保使用正确的配置文件路径
+	log.Print("Executing shell command")
 	if strings.Contains(command, "supervisorctl") && !strings.Contains(command, "-c") {
-		// 在命令中添加配置文件路径
 		command = strings.Replace(command, "supervisorctl", "supervisorctl -c /etc/supervisor/supervisord.conf", 1)
-		log.Printf("Modified supervisorctl command: %s", command)
+		log.Print("Prepared supervisorctl shell command")
 	}
 
 	cmd := exec.Command("sh", "-c", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("Shell command failed: %v, output: %s", err, string(output))
-		return output, err
+		log.Print("Shell command failed")
+		return nil, &safeWrappedError{message: "shell command failed", cause: err}
 	}
-	log.Printf("Shell command executed successfully")
+	log.Print("Shell command executed successfully")
 	return output, nil
 }

--- a/backend/agents/go-agent/routes/restart_test.go
+++ b/backend/agents/go-agent/routes/restart_test.go
@@ -1,0 +1,70 @@
+package routes
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCommandForLogAlwaysRedactsNonURLCommand(t *testing.T) {
+	if got := commandForLog("printf command-text-secret; false"); got != "[COMMAND REDACTED]" {
+		t.Fatalf("commandForLog() = %q", got)
+	}
+}
+
+func TestFailedSecretCommandDoesNotLeakLogsOutputOrError(t *testing.T) {
+	const commandSecret = "command-text-secret"
+	const outputSecret = "output-stream-secret"
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
+
+	output, err := executeURLCommand("printf " + outputSecret + "; false # " + commandSecret)
+	if err == nil {
+		t.Fatal("executeURLCommand unexpectedly succeeded")
+	}
+	if len(output) != 0 {
+		t.Fatalf("failed command returned output: %q", output)
+	}
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) {
+		t.Fatalf("errors.As(err, *exec.ExitError) = false: %v", err)
+	}
+	if !errors.Is(err, exitError) {
+		t.Fatalf("errors.Is(err, exitError) = false: %v", err)
+	}
+	for _, secret := range []string{commandSecret, outputSecret} {
+		if strings.Contains(logs.String(), secret) || strings.Contains(err.Error(), secret) {
+			t.Fatalf("failed command leaked %q: logs=%q err=%q", secret, logs.String(), err.Error())
+		}
+	}
+}
+
+func TestRestartHandlerDoesNotReturnFailedCommandOutput(t *testing.T) {
+	const commandSecret = "handler-command-secret"
+	const outputSecret = "handler-output-secret"
+	cfg := &Config{RestartCommand: "printf " + outputSecret + "; false # " + commandSecret}
+	request := httptest.NewRequest(http.MethodPost, "/restart", nil)
+	recorder := httptest.NewRecorder()
+
+	RestartHandler(cfg).ServeHTTP(recorder, request)
+
+	body := recorder.Body.String()
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body=%s", recorder.Code, body)
+	}
+	for _, secret := range []string{commandSecret, outputSecret} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("restart response leaked %q: %s", secret, body)
+		}
+	}
+	if strings.Contains(body, "output") {
+		t.Fatalf("restart response exposed output field: %s", body)
+	}
+}

--- a/backend/agents/go-agent/routes/update.go
+++ b/backend/agents/go-agent/routes/update.go
@@ -88,7 +88,7 @@ func performUpdate(req AgentUpdateRequest, cfg *Config) {
 	}
 
 	downloadURL := fmt.Sprintf("%s/api/agents/download/configflow-agent-%s", serverURL, arch)
-	log.Printf("构造下载 URL: %s", downloadURL)
+	log.Printf("构造下载 URL: %s", redactURLForLog(downloadURL))
 
 	// 4. 创建备份目录
 	backupDir := "/opt/configflow-agent/backup"
@@ -175,7 +175,7 @@ func downloadFile(filepath string, url string) error {
 
 	resp, err := client.Get(url)
 	if err != nil {
-		return fmt.Errorf("下载失败: %w", err)
+		return safeURLFailure("从以下地址下载失败:", url, err)
 	}
 	defer resp.Body.Close()
 

--- a/backend/agents/go-agent/routes/update_test.go
+++ b/backend/agents/go-agent/routes/update_test.go
@@ -1,0 +1,35 @@
+package routes
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDownloadTransportErrorPreservesIdentityWithoutLeakingURLCredential(t *testing.T) {
+	want := errors.New("download transport failure")
+	old := http.DefaultTransport
+	http.DefaultTransport = updateRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, want
+	})
+	t.Cleanup(func() { http.DefaultTransport = old })
+
+	err := downloadFile(filepath.Join(t.TempDir(), "agent"), "https://example.test/?token=download-secret")
+	if !errors.Is(err, want) {
+		t.Fatalf("errors.Is(err, want) = false: %v", err)
+	}
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Fatalf("errors.As(err, *url.Error) = false: %v", err)
+	}
+	if got := err.Error(); strings.Contains(got, "download-secret") || strings.Contains(got, "token=download-secret") {
+		t.Fatalf("download URL credential leaked in error: %s", got)
+	}
+}
+
+type updateRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f updateRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/backend/agents/go-agent/routes/url_log_test.go
+++ b/backend/agents/go-agent/routes/url_log_test.go
@@ -1,0 +1,33 @@
+package routes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRoutesRedactURLForLogRedactsActualReviewNestedCredentials(t *testing.T) {
+	for _, raw := range []string{
+		"https://example.test/p?next=https%253A%252F%252Fnested.test%252Fp%253Ftoken%253Dnested-url-secret",
+		"https://example.test/p?next=token%253Dnested-expression-secret",
+		"https://example.test/p?next=api%252Bkey%253Dplus-layer-secret",
+	} {
+		got := redactURLForLog(raw)
+		if !strings.Contains(got, "next=[REDACTED]") {
+			t.Fatalf("nested credential value was not redacted: raw=%q got=%q", raw, got)
+		}
+		for _, secret := range []string{"nested-url-secret", "nested-expression-secret", "plus-layer-secret"} {
+			if strings.Contains(got, secret) {
+				t.Fatalf("nested credential leaked %q: raw=%q got=%q", secret, raw, got)
+			}
+		}
+	}
+}
+
+func TestRoutesRedactURLForLogFailsClosedWhenDecodingRevealsC0(t *testing.T) {
+	for _, encodedControl := range []string{"%250d%250a", "%2500", "%251f", "%257f"} {
+		raw := "https://example.test/p?next=ok" + encodedControl + "token=secret"
+		if got := redactURLForLog(raw); got != "[INVALID URL REDACTED]" {
+			t.Fatalf("decoded control did not fail closed: raw=%q got=%q", raw, got)
+		}
+	}
+}

--- a/backend/agents/go-agent/url_log.go
+++ b/backend/agents/go-agent/url_log.go
@@ -1,19 +1,16 @@
-package routes
+package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 )
 
-var nonAlphaNumeric = regexp.MustCompile(`[^a-z0-9]`)
+var urlLogNonAlphaNumeric = regexp.MustCompile(`[^a-z0-9]`)
 
 func sensitiveURLQueryKey(key string) bool {
-	normalized := nonAlphaNumeric.ReplaceAllString(strings.ToLower(key), "")
+	normalized := urlLogNonAlphaNumeric.ReplaceAllString(strings.ToLower(key), "")
 	for _, part := range []string{"token", "authorization", "auth", "key", "secret", "password", "passwd", "credential"} {
 		if strings.Contains(normalized, part) {
 			return true
@@ -108,26 +105,7 @@ func (e *safeWrappedError) Unwrap() error { return e.cause }
 
 func safeURLFailure(action, rawURL string, cause error) error {
 	return &safeWrappedError{
-		message: action + " " + redactURLForLog(rawURL),
+		message: fmt.Sprintf("%s %s", action, redactURLForLog(rawURL)),
 		cause:   cause,
-	}
-}
-
-func commandForLog(command string) string {
-	if strings.HasPrefix(command, "http://") || strings.HasPrefix(command, "https://") {
-		return redactURLForLog(command)
-	}
-	return "[COMMAND REDACTED]"
-}
-
-// JsonResponse 是一个辅助函数，用于统一返回JSON响应
-func JsonResponse(w http.ResponseWriter, statusCode int, data interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	if data != nil {
-		if statusCode >= 400 {
-			log.Printf("Returning error response: %d", statusCode)
-		}
-		json.NewEncoder(w).Encode(data)
 	}
 }

--- a/backend/agents/go_install_script.py
+++ b/backend/agents/go_install_script.py
@@ -155,7 +155,7 @@ fi
 # 下载 Go Agent 二进制
 BINARY_URL="{binary_download_url}/configflow-agent-$AGENT_ARCH"
 printf "%b\\n" "${{YELLOW}}下载 Go Agent 二进制...${{NC}}"
-printf "%b\\n" "${{BLUE}}URL: $BINARY_URL${{NC}}"
+printf "%b\\n" "${{BLUE}}准备下载二进制文件${{NC}}"
 
 if command -v wget >/dev/null 2>&1; then
     wget -O /tmp/configflow-agent "$BINARY_URL" || {{

--- a/backend/agents/scripts/agent.sh
+++ b/backend/agents/scripts/agent.sh
@@ -176,7 +176,7 @@ register_to_server() {
     fi
 
     local register_url="${SERVER_URL}/api/agents/register"
-    log "注册URL: $register_url"
+    log "准备发送注册请求"
 
     # 构建 JSON 数据
     local json_data="{\"name\":\"$AGENT_NAME\",\"host\":\"$local_ip\",\"port\":$AGENT_PORT,\"service_type\":\"$SERVICE_TYPE\",\"version\":\"$AGENT_VERSION\"}"
@@ -271,7 +271,7 @@ send_heartbeat() {
     local json_data="{\"version\":\"$AGENT_VERSION\",\"service_status\":\"$service_status\"}"
 
     # 打印脱敏后的心跳命令（不得泄露任何令牌片段）
-    log "发送心跳: curl -X POST '$heartbeat_url' -H 'Authorization: Bearer ***' -H 'Content-Type: application/json' -d '$json_data'"
+    log "发送心跳请求 (Authorization: Bearer ***)"
 
     # 发送心跳并只记录非敏感结果
     local heartbeat_auth_header="Authorization: Bearer $TOKEN"
@@ -313,7 +313,7 @@ backup_config() {
 
 # 重启服务
 restart_service() {
-    log "执行重启命令: $RESTART_CMD"
+    log "执行服务重启操作"
 
     # 判断是 URL 还是命令
     if echo "$RESTART_CMD" | grep -qE '^https?://'; then
@@ -335,8 +335,8 @@ restart_service() {
     else
         # 命令方式：直接执行命令
         log "检测到命令，直接执行"
-        # 将输出直接写入日志文件，避免污染 HTTP 响应
-        if eval "$RESTART_CMD" >> "$LOG_FILE" 2>&1; then
+        # 丢弃命令输出，日志只保留固定描述，避免命令输出泄露敏感信息
+        if eval "$RESTART_CMD" >/dev/null 2>&1; then
             log "服务重启成功 (命令方式)"
             return 0
         else
@@ -409,7 +409,7 @@ handle_http_request() {
     local path=$(echo "$request_line" | awk '{print $2}')
 
     # 记录收到的请求
-    log "收到HTTP请求: $method $path"
+    log "收到HTTP请求: $method"
 
     # 跳过 HTTP 头（改用更兼容的方式）
     local auth_token=""""
@@ -582,10 +582,10 @@ handle_http_request() {
                                         log "规则集下载成功: $full_path"
                                         download_count=$((download_count + 1))
                                     else
-                                        log_error "规则集下载失败: $item_url"
+                                        log_error "规则集下载失败: $item_name"
                                     fi
                                 else
-                                    log_error "规则集信息不完整: name=$item_name, url=$item_url, path=$item_path"
+                                    log_error "规则集信息不完整: name=$item_name, path=$item_path"
                                 fi
 
                                 i=$((i + 1))

--- a/backend/agents/scripts/install-go.sh
+++ b/backend/agents/scripts/install-go.sh
@@ -152,7 +152,6 @@ fi
 # 下载 Go Agent 二进制
 BINARY_URL="{binary_download_url}/configflow-agent-$AGENT_ARCH"
 printf "%b\n" "${{YELLOW}}下载 Go Agent 二进制...${{NC}}"
-printf "%b\n" "${{BLUE}}URL: $BINARY_URL${{NC}}"
 
 if command -v wget >/dev/null 2>&1; then
     wget -O /tmp/configflow-agent "$BINARY_URL" || {{

--- a/backend/converters/mihomo.py
+++ b/backend/converters/mihomo.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, List, Optional
 from backend.utils.logger import get_logger
 from backend.utils.proxy_utils import fix_proxy_fields
 from backend.common.profile_context import append_url_query, profile_api_path
+from backend.utils.url_utils import safe_url_for_log
 
 # 获取当前模块的日志记录器
 logger = get_logger(__name__)
@@ -438,7 +439,7 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
     # 使用本地接口而不是原始订阅 URL
     proxy_providers = {}
     logger.info(f"开始生成订阅 proxy-providers，使用本地接口")
-    logger.info(f"Server domain: {effective_base_url}")
+    logger.info(f"Server domain: {safe_url_for_log(effective_base_url)}")
     logger.info(f"Config token: {'已配置' if config_token else '未配置'}")
 
     for sub in config_data.get('subscriptions', []):
@@ -451,7 +452,7 @@ def generate_mihomo_config(config_data: Dict[str, Any], base_url: str = '',
             if config_token:
                 sub_url = append_url_query(sub_url, {'token': config_token})
 
-            logger.info(f"订阅 '{sub['name']}' 使用本地接口: {sub_url}")
+            logger.info(f"订阅 '{sub['name']}' 使用本地接口: {safe_url_for_log(sub_url)}")
 
             proxy_providers[sub['name']] = {
                 'type': 'http',

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -25,6 +25,7 @@ from backend.common.config_repository import ProfileRepositoryError
 from backend.common.agent_manager import get_agent_manager
 from backend.common.utils import str_to_bool
 from backend.utils.logger import get_logger
+from backend.utils.url_utils import safe_url_for_log
 
 logger = get_logger(__name__)
 
@@ -690,9 +691,9 @@ def _prefetch_download_contents(downloads, base_url):
             resp = requests.get(fetch_url, timeout=30)
             resp.raise_for_status()
             item['content'] = resp.text
-            logger.info(f"预获取成功: {item.get('name', url)} ({len(resp.text)} 字符)")
+            logger.info(f"预获取成功: {item.get('name') or safe_url_for_log(url)} ({len(resp.text)} 字符)")
         except Exception as e:
-            logger.warning(f"预获取失败: {item.get('name', url)}, 错误: {e}, Agent 将 fallback 到 URL 下载")
+            logger.warning(f"预获取失败: {item.get('name') or safe_url_for_log(url)}, Agent 将 fallback 到 URL 下载")
             item['content'] = ''
 
     with ThreadPoolExecutor(max_workers=8) as executor:
@@ -724,7 +725,7 @@ def push_config_to_agent(agent_id):
             host = request.headers.get('X-Forwarded-Host', request.host)
             base_url = f"{scheme}://{host}"
 
-        logger.info(f"Agent: {agent.get('name')}, Service Type: {agent.get('service_type')}, Base URL: {base_url}")
+        logger.info(f"Agent: {agent.get('name')}, Service Type: {agent.get('service_type')}, Base URL: {safe_url_for_log(base_url)}")
 
         profile_id = agent.get('profile_id', 'default')
         try:

--- a/backend/routes/aggregations.py
+++ b/backend/routes/aggregations.py
@@ -32,6 +32,7 @@ from backend.utils.sub_store_client import (
     proxies_to_nodes,
 )
 from backend.utils.logger import get_logger
+from backend.utils.url_utils import safe_exception_details
 
 logger = get_logger(__name__)
 
@@ -127,7 +128,7 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
             except Exception as e:
                 proxies = None
                 nodes_list = None
-                logger.warning(f"通过 Sub-Store 获取订阅 '{sub['name']}' 失败: {e}, 尝试读取本地缓存")
+                logger.warning("通过 Sub-Store 获取订阅 '%s' 失败, 尝试读取本地缓存: %s", sub['name'], safe_exception_details(e))
 
             # 如果从 Sub-Store 获取失败，从本地缓存读取
             if not nodes_list:
@@ -164,7 +165,7 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
                         results[fetched_id] = (proxies, nodes_list)
                     except Exception as e:
                         # 兜底：单个订阅的任何未预期异常都不影响其他订阅
-                        logger.error(f"订阅拉取任务异常: {e}")
+                        logger.error("订阅拉取任务异常: %s", safe_exception_details(e))
 
         # 按聚合中配置的订阅顺序汇总，保证输出稳定
         for sub_id, _sub in pending:
@@ -201,7 +202,7 @@ def generate_aggregation_provider(aggregation: Dict[str, Any]) -> Dict[str, Any]
             regex = re.compile(regex_filter)
             all_nodes = [node for node in all_nodes if regex.search(node.get('name', ''))]
         except re.error as e:
-            logger.error(f"聚合 '{agg_name}' 的正则表达式无效: {e}")
+            logger.error("聚合 '%s' 的正则表达式无效: %s", agg_name, safe_exception_details(e))
 
     # 4. 转换为 mihomo 格式
     # 构建 sub-store proxies 按名称索引（用于快速查找）
@@ -383,7 +384,8 @@ def handle_subscription_aggregation_item(agg_id):
 
             return jsonify({'success': False, 'message': 'Aggregation not found'}), 404
         except Exception as e:
-            return jsonify({'success': False, 'message': str(e)}), 500
+            logger.error("聚合操作失败: %s", safe_exception_details(e))
+            return jsonify({'success': False, 'message': '聚合操作失败'}), 500
 
     elif request.method == 'DELETE':
         # 删除聚合
@@ -433,8 +435,8 @@ def get_aggregation_node_count(agg_id):
         })
 
     except Exception as e:
-        logger.error(f"获取聚合节点数量失败: {str(e)}")
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("获取聚合节点数量失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '获取聚合节点数量失败'}), 500
 
 
 @bp.route('/<agg_id>/preview', methods=['GET'])
@@ -471,7 +473,8 @@ def preview_aggregation_nodes(agg_id):
         })
 
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("聚合操作失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '聚合操作失败'}), 500
 
 
 @bp.route('/<agg_id>/provider', methods=['GET'])
@@ -531,4 +534,5 @@ def get_aggregation_provider(agg_id):
         )
 
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("聚合操作失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '聚合操作失败'}), 500

--- a/backend/routes/mosdns.py
+++ b/backend/routes/mosdns.py
@@ -12,6 +12,7 @@ from backend.routes import mosdns_bp as bp
 from backend.common.auth import require_auth
 from backend.common.config import config_data, save_config
 from backend.utils.rule_utils import get_rules_dir, sanitize_rule_name
+from backend.utils.url_utils import safe_exception_details, safe_url_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -562,10 +563,14 @@ def mosdns_rule_proxy():
             original_content = _fetch_remote_content(fetch_url)
 
         except requests.exceptions.RequestException as e:
-            logger.warning(f"远程拉取规则失败，尝试使用本地缓存兜底: {original_url}, 错误: {e}")
+            logger.warning(
+                "远程拉取规则失败，尝试使用本地缓存兜底: %s %s",
+                safe_url_for_log(original_url),
+                safe_exception_details(e),
+            )
             original_content = _load_cached_rule_content_for_url(original_url)
             if not original_content:
-                return jsonify({'success': False, 'message': f'Failed to fetch original URL: {str(e)}'}), 500
+                return jsonify({'success': False, 'message': 'Failed to fetch original URL'}), 500
 
         # 检测内容格式
         # 如果内容已经是 mosdns 格式，则直接返回
@@ -690,6 +695,8 @@ def mosdns_rule_proxy():
         return converted_content, 200, {'Content-Type': 'text/plain; charset=utf-8'}
 
     except ValueError as e:
-        return jsonify({'success': False, 'message': str(e)}), 400
+        logger.warning("MosDNS rule-proxy rejected request: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': 'Invalid remote URL'}), 400
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("MosDNS rule-proxy request failed: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': 'Failed to process rule proxy request'}), 500

--- a/backend/routes/rules.py
+++ b/backend/routes/rules.py
@@ -17,6 +17,7 @@ from backend.common.profile_context import profile_api_path, resolve_profile_id
 from backend.utils.rule_matcher import parse_rule_line, match_query, is_valid_domain, is_valid_ip
 from backend.utils.rule_utils import get_rules_dir, sanitize_rule_name
 from backend.utils.logger import get_logger
+from backend.utils.url_utils import safe_exception_details, safe_url_for_log
 
 logger = get_logger(__name__)
 
@@ -173,8 +174,8 @@ def reorder_rules():
         logger.info(f"Successfully reordered {len(rule_configs)} rules")
         return jsonify({'success': True})
     except Exception as e:
-        logger.error(f"Error reordering rules: {e}", exc_info=True)
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("Error reordering rules: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': 'Error reordering rules'}), 500
 
 
 @bp.route('/batch', methods=['POST'])
@@ -265,7 +266,7 @@ def get_local_rule(name):
         if rule.get('source_type') == 'url':
             import requests
             url = rule.get('url', '')
-            logger.info(f"Rule '{name}' is URL type, attempting to fetch from: {url}")
+            logger.info(f"Rule '{name}' is URL type, attempting to fetch from: {safe_url_for_log(url)}")
 
             try:
                 # 尝试在 2 秒内拉取最新数据
@@ -289,7 +290,7 @@ def get_local_rule(name):
             except requests.Timeout:
                 logger.warning(f"Timeout fetching rule '{name}', falling back to cache")
             except Exception as e:
-                logger.error(f"Error fetching rule '{name}': {e}, falling back to cache")
+                logger.error("Error fetching rule '%s', falling back to cache: %s", name, safe_exception_details(e))
 
         # 如果是 content 类型或拉取失败，使用本地缓存
         if os.path.exists(filepath):
@@ -327,8 +328,8 @@ def get_local_rule(name):
                 }), 500
 
     except Exception as e:
-        logger.error(f"Error getting local rule '{name}': {str(e)}")
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("Error getting local rule '%s': %s", name, safe_exception_details(e))
+        return jsonify({'success': False, 'message': 'Error getting local rule'}), 500
 
 
 # ==================== /api/rule-sets 路由（向后兼容）====================
@@ -396,7 +397,8 @@ def reorder_rule_sets():
             'message': 'This endpoint is deprecated. Please use /api/rules/reorder instead.'
         }), 410
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        logger.error("Deprecated rule endpoint failed: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': 'Deprecated rule endpoint failed'}), 500
 
 
 def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
@@ -435,7 +437,7 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
             logger.info(f"Loaded rule content from cache: {filepath}")
             return rule_content
         except Exception as e:
-            logger.warning(f"Failed to read cached rule file {filepath}: {e}")
+            logger.warning("Failed to read cached rule file %s: %s", filepath, safe_exception_details(e))
 
     # 2. 如果缓存不存在或读取失败，从规则仓库获取内容
     if library_rule and not rule_content:
@@ -453,7 +455,7 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
                     response = requests.get(url, timeout=30)
                     if response.status_code == 200:
                         rule_content = response.text
-                        logger.info(f"Fetched rule content from library URL: {url}")
+                        logger.info(f"Fetched rule content from library URL: {safe_url_for_log(url)}")
 
                         # 保存到本地缓存
                         if filepath:
@@ -469,7 +471,7 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
 
                         return rule_content
                 except Exception as e:
-                    logger.warning(f"Failed to fetch rule from library URL {url}: {e}")
+                    logger.warning("Failed to fetch rule from library URL %s: %s", safe_url_for_log(url), safe_exception_details(e))
 
     # 3. 如果规则仓库没有，尝试从规则集的 url 字段获取
     if not rule_content:
@@ -485,7 +487,7 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
                 response = requests.get(url, timeout=30)
                 if response.status_code == 200:
                     rule_content = response.text
-                    logger.info(f"Fetched rule content from item URL: {url}")
+                    logger.info(f"Fetched rule content from item URL: {safe_url_for_log(url)}")
 
                     # 保存到本地缓存
                     if filepath:
@@ -501,7 +503,7 @@ def get_ruleset_content(rule_item: dict, library_rule: dict = None) -> str:
 
                     return rule_content
             except Exception as e:
-                logger.warning(f"Failed to fetch rule from item URL {url}: {e}")
+                logger.warning("Failed to fetch rule from item URL %s: %s", safe_url_for_log(url), safe_exception_details(e))
 
     return rule_content
 
@@ -610,7 +612,7 @@ def match_test_rule():
 
                 except Exception as e:
                     # 规则集处理失败，记录错误并跳过该规则集
-                    logger.error(f'Error processing ruleset "{rule_set_name}": {e}')
+                    logger.error('Error processing ruleset "%s": %s', rule_set_name, safe_exception_details(e))
                     continue
 
         # 没有匹配到任何规则
@@ -623,8 +625,8 @@ def match_test_rule():
         })
 
     except Exception as e:
-        logger.error(f'Rule match test failed: {e}')
-        return jsonify({'success': False, 'message': f'查询失败: {str(e)}'}), 500
+        logger.error('Rule match test failed: %s', safe_exception_details(e))
+        return jsonify({'success': False, 'message': '查询失败'}), 500
 
 
 @bp.route('/find-duplicates', methods=['POST'])
@@ -742,5 +744,5 @@ def find_duplicate_rules():
         })
 
     except Exception as e:
-        logger.error(f'Find duplicate rules failed: {e}', exc_info=True)
-        return jsonify({'success': False, 'message': f'查重失败: {str(e)}'}), 500
+        logger.error('Find duplicate rules failed: %s', safe_exception_details(e))
+        return jsonify({'success': False, 'message': '查重失败'}), 500

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -14,6 +14,7 @@ from backend.common.config_export import (
     prepare_config_export,
 )
 from backend.version import get_version_info
+from backend.utils.url_utils import safe_url_for_log
 
 
 @settings_bp.route('/server-domain', methods=['GET', 'POST'])
@@ -315,7 +316,7 @@ def handle_sub_store_url():
 
             config_data['system_config']['sub_store_url'] = new_url
 
-            current_app.logger.info(f"Updated Sub-Store URL to {new_url}")
+            current_app.logger.info(f"Updated Sub-Store URL to {safe_url_for_log(new_url)}")
 
             save_config()
             return jsonify({

--- a/backend/routes/subscriptions.py
+++ b/backend/routes/subscriptions.py
@@ -16,6 +16,7 @@ from backend.utils.sub_store_client import (
     parse_proxies_from_yaml,
     proxies_to_nodes,
 )
+from backend.utils.url_utils import safe_exception_details
 
 
 def clean_aggregations_subscription(sub_id):
@@ -131,7 +132,8 @@ def reorder_subscriptions():
         save_config()
         return jsonify({'success': True})
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        current_app.logger.error("订阅操作失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '订阅操作失败'}), 500
 
 
 @subscriptions_bp.route('/<sub_id>/nodes', methods=['GET'])
@@ -204,8 +206,8 @@ def fetch_subscription(sub_id):
             current_app.logger.info(f"成功获取订阅并写入缓存: {sub['name']}, 节点数: {len(nodes)}")
 
     except Exception as e:
-        fetch_error = str(e)
-        current_app.logger.warning(f"从URL获取订阅失败: {sub['name']}, 错误: {fetch_error}, 尝试读取本地缓存")
+        fetch_error = f"request_failed ({safe_exception_details(e)})"
+        current_app.logger.warning("从URL获取订阅失败: %s, 尝试读取本地缓存: %s", sub['name'], safe_exception_details(e))
 
         # 从URL获取失败，尝试读取本地缓存
         cache = load_subscription_cache(sub_id)
@@ -256,7 +258,8 @@ def fetch_subscription(sub_id):
             'cached_updated_at': cache_payload.get('updated_at') if cache_payload else None
         })
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        current_app.logger.error("订阅操作失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '订阅操作失败'}), 500
 
 
 @subscriptions_bp.route('/test', methods=['GET'])
@@ -305,7 +308,7 @@ def get_all_subscription_proxies():
                 yaml_text, _source = get_subscription_proxies_yaml(sub_id, sub_url)
                 proxies = parse_proxies_from_yaml(yaml_text)
             except Exception as e:
-                current_app.logger.warning(f"通过 Sub-Store 获取订阅 '{sub_name}' 失败: {e}，尝试本地缓存")
+                current_app.logger.warning("通过 Sub-Store 获取订阅 '%s' 失败，尝试本地缓存: %s", sub_name, safe_exception_details(e))
                 # 降级：从本地缓存加载并转换
                 cache = load_subscription_cache(sub_id)
                 if cache:
@@ -368,8 +371,8 @@ def get_all_subscription_proxies():
         )
 
     except Exception as e:
-        current_app.logger.error(f"获取订阅代理列表失败: {str(e)}")
-        return jsonify({'success': False, 'message': str(e)}), 500
+        current_app.logger.error("获取订阅代理列表失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '获取订阅代理列表失败'}), 500
 
 
 @subscriptions_bp.route('/<sub_id>/proxies', methods=['GET'])
@@ -438,8 +441,8 @@ def get_subscription_proxies(sub_id):
                     else:
                         current_app.logger.info(f"成功获取订阅并更新缓存: {sub_name}, 节点数: {len(proxies)}")
             except Exception as e:
-                fetch_error = str(e)
-                current_app.logger.warning(f"通过 Sub-Store 获取配置失败: {sub_name}, 错误: {fetch_error}, 将使用本地缓存")
+                fetch_error = f"request_failed ({safe_exception_details(e)})"
+                current_app.logger.warning("通过 Sub-Store 获取配置失败: %s, 将使用本地缓存: %s", sub_name, safe_exception_details(e))
 
         # 如果从 Sub-Store 获取失败或没有URL，则从本地缓存加载并转换
         if proxies is None:
@@ -467,7 +470,7 @@ def get_subscription_proxies(sub_id):
                     if proxy:
                         proxies.append(proxy)
                 except Exception as e:
-                    current_app.logger.error(f"转换节点失败: {node.get('name')}, 错误: {str(e)}")
+                    current_app.logger.error("转换节点失败: %s", safe_exception_details(e))
                     continue
 
         # 如果请求 Surge 格式，转换为 Surge 纯文本
@@ -517,5 +520,5 @@ def get_subscription_proxies(sub_id):
         )
 
     except Exception as e:
-        current_app.logger.error(f"获取订阅代理列表失败: {str(e)}")
-        return jsonify({'success': False, 'message': str(e)}), 500
+        current_app.logger.error("获取订阅代理列表失败: %s", safe_exception_details(e))
+        return jsonify({'success': False, 'message': '获取订阅代理列表失败'}), 500

--- a/backend/test_request_exception_redaction.py
+++ b/backend/test_request_exception_redaction.py
@@ -1,0 +1,176 @@
+import logging
+
+import pytest
+import requests
+from flask import Flask
+
+from backend.routes import aggregations, mosdns, rules, subscriptions
+from backend.utils import sub_store_client
+from backend.utils.url_utils import safe_exception_details
+
+
+SECRET_URL = "https://upstream.test/sub?token=dynamic-request-secret#secret-fragment"
+
+
+class _Response:
+    status_code = 200
+    headers = {"content-type": "text/yaml"}
+    text = "proxies:\n  - {name: safe-name, type: vless, server: safe.test, port: 443}\n"
+
+    def raise_for_status(self):
+        return None
+
+
+def test_safe_request_error_details_include_only_type_and_status():
+    response = requests.Response()
+    response.status_code = 502
+    error = requests.HTTPError(f"failed for {SECRET_URL}", response=response)
+
+    assert safe_exception_details(error) == "exception_type=HTTPError status=502"
+
+
+def test_convert_proxy_string_logs_only_event_type_and_length(monkeypatch, caplog):
+    proxy_uri = "vless://user-secret@example.test:443?token=converter-secret#fragment-secret"
+    monkeypatch.setattr(sub_store_client, "_get_base_url", lambda: "http://sub-store.test")
+    monkeypatch.setattr(sub_store_client, "_create_subscription", lambda *args: True)
+    monkeypatch.setattr(sub_store_client, "_delete_subscription", lambda *args: None)
+    monkeypatch.setattr(sub_store_client.requests, "get", lambda *args, **kwargs: _Response())
+
+    with caplog.at_level(logging.INFO):
+        result = sub_store_client.convert_proxy_string(proxy_uri)
+
+    assert result["type"] == "vless"
+    assert "vless://" not in caplog.text
+    for forbidden in ("user-secret", "example.test", "converter-secret", "fragment-secret"):
+        assert forbidden not in caplog.text
+    assert "proxy_type=vless" in caplog.text
+    assert f"input_length={len(proxy_uri)}" in caplog.text
+
+
+def test_sub_store_combined_requests_errors_keep_causes_without_leaking(monkeypatch, caplog):
+    first = requests.ConnectionError(f"sub-store request failed for {SECRET_URL}")
+    second = requests.Timeout(f"direct request failed for {SECRET_URL}")
+    monkeypatch.setattr(sub_store_client, "_looks_like_sub_store_rendered_yaml_response", lambda url: (False, None))
+    monkeypatch.setattr(sub_store_client, "_create_subscription", lambda *args: True)
+    monkeypatch.setattr(sub_store_client, "_delete_subscription", lambda *args: None)
+
+    errors = iter((first, second))
+    def fail_get(*args, **kwargs):
+        raise next(errors)
+    monkeypatch.setattr(sub_store_client.requests, "get", fail_get)
+
+    with caplog.at_level(logging.WARNING), pytest.raises(sub_store_client.SubscriptionFetchError) as caught:
+        sub_store_client.get_subscription_proxies_yaml("sub-1", SECRET_URL)
+
+    error = caught.value
+    assert error.sub_store_error is first
+    assert error.direct_error is second
+    assert error.__cause__ is second
+    assert "dynamic-request-secret" not in str(error)
+    assert "dynamic-request-secret" not in caplog.text
+    assert "upstream.test" not in caplog.text
+    assert "ConnectionError" in caplog.text
+    assert "Timeout" in caplog.text
+
+
+def test_rules_request_exception_log_does_not_leak_url(monkeypatch, caplog):
+    exc = requests.ConnectionError(f"GET failed for {SECRET_URL}")
+    monkeypatch.setattr(rules.requests, "get", lambda *args, **kwargs: (_ for _ in ()).throw(exc))
+
+    with caplog.at_level(logging.WARNING):
+        result = rules.get_ruleset_content({"name": "probe", "url": SECRET_URL})
+
+    assert result == ""
+    assert "dynamic-request-secret" not in caplog.text
+    assert "ConnectionError" in caplog.text
+
+
+def test_subscription_request_exception_response_and_log_do_not_leak(monkeypatch, caplog):
+    exc = requests.ConnectionError(f"GET failed for {SECRET_URL}")
+    monkeypatch.setattr(subscriptions, "get_config", lambda: {
+        "subscriptions": [{"id": "sub-1", "name": "Probe", "url": SECRET_URL}],
+        "nodes": [],
+    })
+    monkeypatch.setattr(subscriptions, "get_subscription_proxies_yaml", lambda *args: (_ for _ in ()).throw(exc))
+    monkeypatch.setattr(subscriptions, "load_subscription_cache", lambda *args, **kwargs: None)
+    app = Flask(__name__)
+
+    with app.test_request_context("/sub-1/fetch", method="POST", json={}), caplog.at_level(logging.WARNING):
+        response, status = subscriptions.fetch_subscription.__wrapped__("sub-1")
+
+    body = response.get_data(as_text=True)
+    assert status == 500
+    assert "dynamic-request-secret" not in body
+    assert "dynamic-request-secret" not in caplog.text
+    assert "ConnectionError" in caplog.text
+
+
+def test_aggregation_request_exception_log_does_not_leak(monkeypatch, tmp_path, caplog):
+    exc = requests.ConnectionError(f"GET failed for {SECRET_URL}")
+    monkeypatch.setattr(aggregations, "get_config", lambda profile_id=None: {
+        "subscriptions": [{"id": "sub-1", "name": "Probe", "url": SECRET_URL}],
+        "nodes": [],
+    })
+    monkeypatch.setattr(aggregations, "get_subscription_proxies_yaml", lambda *args: (_ for _ in ()).throw(exc))
+    monkeypatch.setattr(aggregations, "load_subscription_cache", lambda *args, **kwargs: None)
+    monkeypatch.setattr(aggregations, "AGGREGATION_PROVIDERS_DIR", str(tmp_path))
+    app = Flask(__name__)
+
+    with app.test_request_context("/"), caplog.at_level(logging.WARNING):
+        aggregations.generate_aggregation_provider({
+            "id": "agg-1", "name": "Probe", "subscriptions": ["sub-1"], "nodes": []
+        })
+
+    assert "dynamic-request-secret" not in caplog.text
+    assert "ConnectionError" in caplog.text
+
+
+def test_mosdns_rule_proxy_request_exception_response_does_not_leak(monkeypatch, caplog):
+    exc = requests.ConnectionError(f"GET failed for {SECRET_URL}")
+    monkeypatch.setattr(mosdns, "_require_rule_proxy_auth", lambda: True)
+    monkeypatch.setattr(mosdns, "apply_github_proxy_domain", lambda url, config: url)
+    monkeypatch.setattr(mosdns, "_validate_remote_url", lambda url: None)
+    monkeypatch.setattr(mosdns, "_fetch_remote_content", lambda url: (_ for _ in ()).throw(exc))
+    monkeypatch.setattr(mosdns, "_load_cached_rule_content_for_url", lambda url: "")
+    app = Flask(__name__)
+
+    with app.test_request_context(
+        "/rule-proxy", query_string={"url": SECRET_URL}
+    ), caplog.at_level(logging.WARNING):
+        response, status = mosdns.mosdns_rule_proxy()
+
+    body = response.get_data(as_text=True)
+    assert status == 500
+    assert "Failed to fetch original URL" in body
+    for forbidden in ("dynamic-request-secret", "secret-fragment", "upstream.test"):
+        assert forbidden not in body
+    for forbidden in ("dynamic-request-secret", "secret-fragment"):
+        assert forbidden not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_status", "expected_message"),
+    [
+        (ValueError(f"invalid URL {SECRET_URL}"), 400, "Invalid remote URL"),
+        (RuntimeError(f"internal failure {SECRET_URL}"), 500, "Failed to process rule proxy request"),
+    ],
+)
+def test_mosdns_rule_proxy_outer_exception_response_does_not_leak(
+    monkeypatch, caplog, exception, expected_status, expected_message
+):
+    monkeypatch.setattr(mosdns, "_require_rule_proxy_auth", lambda: True)
+    monkeypatch.setattr(mosdns, "apply_github_proxy_domain", lambda url, config: url)
+    monkeypatch.setattr(mosdns, "_validate_remote_url", lambda url: (_ for _ in ()).throw(exception))
+    app = Flask(__name__)
+
+    with app.test_request_context(
+        "/rule-proxy", query_string={"url": SECRET_URL}
+    ), caplog.at_level(logging.WARNING):
+        response, status = mosdns.mosdns_rule_proxy()
+
+    body = response.get_data(as_text=True)
+    assert status == expected_status
+    assert expected_message in body
+    for forbidden in ("dynamic-request-secret", "secret-fragment", "upstream.test", "internal failure"):
+        assert forbidden not in body
+        assert forbidden not in caplog.text

--- a/backend/test_safe_url_queries.py
+++ b/backend/test_safe_url_queries.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, quote, urlsplit
 
 import pytest
 import yaml
@@ -7,9 +7,84 @@ from backend.common import profile_context
 from backend.converters.mihomo import generate_mihomo_config, get_mihomo_provider_downloads
 from backend.converters.mosdns import get_mosdns_ruleset_downloads
 from backend.converters.surge import convert_proxy_group_to_surge, generate_surge_config
+from backend.utils.url_utils import safe_url_for_log
+from backend.agents.go_install_script import generate_go_agent_install_script
 
 
 SPECIAL_TOKEN = "token /&?"
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_parts"),
+    [
+        (
+            "https://alice:hunter2@example.test/path?config_token=raw-secret&api-key=key-secret&ok=visible",
+            ["https://example.test/path", "config_token=%5BREDACTED%5D", "api-key=%5BREDACTED%5D", "ok=visible"],
+        ),
+        (
+            "https%253A%252F%252Fbob%253Apass%2540example.test%252Fp%253F%252574oken%253Ddeep-secret",
+            ["https://example.test/p", "token=%5BREDACTED%5D"],
+        ),
+    ],
+)
+def test_safe_url_for_log_removes_userinfo_and_redacts_sensitive_query_variants(url, expected_parts):
+    redacted = safe_url_for_log(url)
+
+    for expected in expected_parts:
+        assert expected in redacted
+    for secret in ["alice", "hunter2", "bob", "pass", "raw-secret", "key-secret", "deep-secret"]:
+        assert secret not in redacted
+
+
+def test_safe_url_for_log_fails_closed_for_invalid_url():
+    invalid = "https://user:password@[broken?token=raw-secret"
+
+    redacted = safe_url_for_log(invalid)
+
+    assert redacted == "[INVALID URL REDACTED]"
+    assert "password" not in redacted
+    assert "raw-secret" not in redacted
+
+
+@pytest.mark.parametrize("url", [
+    "https://example.test/p?next=https%253A%252F%252Fnested.test%252Fp%253Ftoken%253Dnested-url-secret",
+    "https://example.test/p?next=token%253Dnested-expression-secret",
+    "https://example.test/p?next=api%252Bkey%253Dplus-layer-secret",
+])
+def test_safe_url_for_log_redacts_actual_review_nested_credentials(url):
+    redacted = safe_url_for_log(url)
+    assert "next=%5BREDACTED%5D" in redacted
+    for secret in ("nested-url-secret", "nested-expression-secret", "plus-layer-secret"):
+        assert secret not in redacted
+
+
+@pytest.mark.parametrize("encoded_control", ["%250d%250a", "%2500", "%251f", "%257f"])
+def test_safe_url_for_log_fails_closed_when_decoding_reveals_c0(encoded_control):
+    assert safe_url_for_log(f"https://example.test/p?next=ok{encoded_control}token=secret") == "[INVALID URL REDACTED]"
+
+
+@pytest.mark.parametrize("url", [
+    "https://example.test/path#token=plain-fragment-secret",
+    "https://example.test/path#token=encoded%2Dfragment%2Dsecret",
+    "https://example.test/path#outer=https%253A%252F%252Fexample.test%252F%253Ftoken%253Dnested-secret",
+    "https://example.test/path#safe=ok&api_key=mixed-fragment-secret",
+])
+def test_safe_url_for_log_never_preserves_fragment_credentials(url):
+    redacted = safe_url_for_log(url)
+    assert "#" not in redacted
+    for secret in ("plain-fragment-secret", "fragment-secret", "nested-secret"):
+        assert secret not in redacted
+
+
+def test_generated_go_installer_does_not_print_binary_download_url():
+    secret_url = "https://download.test/bin?token=installer-secret#key=fragment-secret"
+    script = generate_go_agent_install_script(
+        server_url="https://server.test/?token=server-secret",
+        agent_name="probe", service_type="mihomo", binary_download_url=secret_url,
+    )
+    assert "URL: $BINARY_URL" not in script
+    assert 'wget -O /tmp/configflow-agent "$BINARY_URL"' in script
+    assert 'curl -L -o /tmp/configflow-agent "$BINARY_URL"' in script
 
 
 def _provider_config(profile_id=None):
@@ -68,6 +143,23 @@ def test_mihomo_provider_and_aggregation_urls_round_trip_special_token(profile_i
     assert len(generated_urls) == len(download_urls) == 2
     for url in generated_urls + download_urls:
         _assert_query(url, token=SPECIAL_TOKEN)
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["raw-secret-token", "encoded secret/token"],
+    ids=["raw", "encoded"],
+)
+def test_mihomo_provider_log_redacts_config_token(caplog, token):
+    config = _provider_config()
+    config["system_config"]["config_token"] = token
+
+    generate_mihomo_config(config)
+
+    logs = caplog.text
+    assert token not in logs
+    assert quote(token, safe="") not in logs
+    assert "token=%5BREDACTED%5D" in logs or "token=[REDACTED]" in logs
 
 
 @pytest.mark.parametrize("profile_id", [None, "alpha"], ids=["legacy", "profile"])

--- a/backend/test_shell_agent_security.py
+++ b/backend/test_shell_agent_security.py
@@ -14,6 +14,7 @@ from backend.routes import register_blueprints
 
 
 SCRIPT = Path(__file__).parent / "agents" / "scripts" / "agent.sh"
+GO_INSTALL_SCRIPT = Path(__file__).parent / "agents" / "scripts" / "install-go.sh"
 GO_CLIENT = Path(__file__).parent / "agents" / "go-agent" / "client.go"
 
 
@@ -201,6 +202,63 @@ def test_shell_registers_against_real_flask_and_heartbeats_with_persisted_token(
     finally:
         server.shutdown()
         thread.join(timeout=5)
+
+
+def test_shell_agent_does_not_interpolate_urls_or_request_paths_into_logs():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    forbidden = [
+        'log "注册URL: $register_url"',
+        "'$heartbeat_url'",
+        'log "收到HTTP请求: $method $path"',
+        'log_error "规则集下载失败: $item_url"',
+        'url=$item_url',
+    ]
+    for fragment in forbidden:
+        assert fragment not in source
+
+
+def test_shell_installer_does_not_log_binary_download_url():
+    source = GO_INSTALL_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'URL: $BINARY_URL' not in source
+
+
+def test_shell_restart_logs_never_include_restart_url_or_command():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'log "执行重启命令: $RESTART_CMD"' not in source
+    assert 'curl -s' in source
+    assert 'eval "$RESTART_CMD"' in source
+
+
+def test_shell_restart_runtime_logs_only_fixed_descriptions(tmp_path):
+    source = SCRIPT.read_text(encoding="utf-8")
+    functions = source.split("# HTTP 服务器", 1)[0]
+    log_file = tmp_path / "agent.log"
+    functions = functions.replace('LOG_FILE="/var/log/configflow-agent.log"', f'LOG_FILE="{log_file.as_posix()}"')
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "curl").write_text('#!/bin/sh\nprintf "{}\\n200\\n"\n', encoding="utf-8")
+    os.chmod(fake_bin / "curl", 0o755)
+    harness = tmp_path / "restart-probe.sh"
+    harness.write_text(
+        functions + "\n"
+        "RESTART_CMD='https://restart.test/restart?token=url-secret#key=fragment-secret'\n"
+        "restart_service\n"
+        "RESTART_CMD='true # command-secret'\n"
+        "restart_service\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(["sh", str(harness)], env=env, text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+    logs = log_file.read_text(encoding="utf-8")
+    for secret in ("url-secret", "fragment-secret", "command-secret", "restart.test"):
+        assert secret not in logs
+    assert "执行服务重启操作" in logs
+    assert "检测到 URL，使用 curl 发送重启请求" in logs
+    assert "检测到命令，直接执行" in logs
 
 
 def test_shell_agent_has_portable_syntax():

--- a/backend/utils/rule_utils.py
+++ b/backend/utils/rule_utils.py
@@ -10,6 +10,7 @@ import re
 from typing import Dict, Any
 from backend.common.config import get_repository
 from backend.common.profile_context import resolve_profile_id
+from backend.utils.url_utils import safe_url_for_log
 
 
 def get_rules_dir(profile_id: str = None) -> str:
@@ -84,7 +85,7 @@ def save_rule_to_local(rule: Dict[str, Any], profile_id: str = None) -> str:
             return filename
 
         try:
-            logger.info(f"Fetching rule content from {url}")
+            logger.info(f"Fetching rule content from {safe_url_for_log(url)}")
             response = requests.get(url, timeout=10)
             response.raise_for_status()
 
@@ -94,10 +95,10 @@ def save_rule_to_local(rule: Dict[str, Any], profile_id: str = None) -> str:
                 response.text,
             )
 
-            logger.info(f"Downloaded and saved rule from {url} to {filepath}")
+            logger.info(f"Downloaded and saved rule from {safe_url_for_log(url)} to {filepath}")
 
         except requests.RequestException as e:
-            logger.error(f"Failed to download rule from {url}: {e}")
+            logger.error(f"Failed to download rule from {safe_url_for_log(url)}")
             # 下载失败时抛出异常，不创建占位符文件
             raise
 

--- a/backend/utils/sub_store_client.py
+++ b/backend/utils/sub_store_client.py
@@ -18,8 +18,18 @@ import yaml
 
 from backend.utils.logger import get_logger
 from backend.utils.proxy_utils import fix_proxy_fields
+from backend.utils.url_utils import safe_exception_details, safe_url_for_log
 
 logger = get_logger(__name__)
+
+
+class SubscriptionFetchError(Exception):
+    """Safe public error retaining both underlying failures for callers."""
+
+    def __init__(self, sub_store_error, direct_error):
+        super().__init__("subscription fetch failed via Sub-Store and direct fallback")
+        self.sub_store_error = sub_store_error
+        self.direct_error = direct_error
 
 
 def _get_base_url():
@@ -65,7 +75,7 @@ def _fetch_direct_subscription_yaml(url):
     headers = {
         'User-Agent': 'clash.meta'
     }
-    logger.info(f"直接拉取订阅 URL: {url}")
+    logger.info(f"直接拉取订阅 URL: {safe_url_for_log(url)}")
     resp = requests.get(url, headers=headers, timeout=30)
     resp.raise_for_status()
 
@@ -119,7 +129,7 @@ def _create_subscription(base, sub_id, url):
         logger.warning(f"Sub-Store 创建订阅 '{sub_id}' 返回状态码: {create_resp.status_code}")
         return False
     except Exception as e:
-        logger.warning(f"Sub-Store 创建订阅 '{sub_id}' 失败: {e}")
+        logger.warning("Sub-Store 创建订阅失败: %s", safe_exception_details(e))
         return False
 
 
@@ -132,7 +142,7 @@ def _delete_subscription(base, sub_id):
         else:
             logger.debug(f"Sub-Store 删除订阅 '{sub_id}' 返回状态码: {resp.status_code}")
     except Exception as e:
-        logger.debug(f"Sub-Store 删除订阅 '{sub_id}' 失败（可忽略）: {e}")
+        logger.debug("Sub-Store 删除订阅失败（可忽略）: %s", safe_exception_details(e))
 
 
 def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
@@ -159,11 +169,11 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
         is_rendered_yaml, rendered_yaml = _looks_like_sub_store_rendered_yaml_response(url)
         if is_rendered_yaml and rendered_yaml:
             return rendered_yaml, 'rendered_yaml'
-    except Exception as e:
-        logger.warning(f"探测订阅 URL 是否为 Sub-Store 成品失败，继续走标准流程: {e}")
+    except Exception:
+        logger.warning("探测订阅 URL 是否为 Sub-Store 成品失败，继续走标准流程")
 
     base = _get_base_url()
-    logger.info(f"Sub-Store base URL: {base}")
+    logger.info(f"Sub-Store base URL: {safe_url_for_log(base)}")
 
     # 使用带前缀和随机后缀的临时名称，避免和 Sub-Store 中已有订阅冲突，
     # 也避免并发请求同一订阅时临时订阅撞名导致 500
@@ -175,7 +185,7 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
     try:
         # 下载订阅（target 放在路径中，这是 Sub-Store 推荐的方式）
         download_url = f'{base}/download/{quote(temp_name, safe="")}/{target}'
-        logger.info(f"Sub-Store 下载: {download_url}")
+        logger.info(f"Sub-Store 下载: {safe_url_for_log(download_url)}")
 
         resp = requests.get(download_url, timeout=30)
         resp.raise_for_status()
@@ -193,7 +203,7 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
         return text, 'sub_store'
     except Exception as e:
         sub_store_error = e
-        logger.warning(f"Sub-Store 获取订阅失败，尝试直接拉取原始订阅 URL: {e}")
+        logger.warning("Sub-Store 获取订阅失败，尝试直接拉取原始订阅 URL: %s", safe_exception_details(e))
     finally:
         # 用完即删，不在 Sub-Store 中残留订阅数据
         _delete_subscription(base, temp_name)
@@ -202,11 +212,8 @@ def get_subscription_proxies_yaml(sub_id, url, target='ClashMeta'):
         text = _fetch_direct_subscription_yaml(url)
         return text, 'direct_url_fallback'
     except Exception as direct_error:
-        raise Exception(
-            "Sub-Store 获取失败，且直接拉取订阅也失败。"
-            f"Sub-Store 错误: {sub_store_error}; "
-            f"直接拉取错误: {direct_error}"
-        )
+        logger.warning("直接拉取订阅失败: %s", safe_exception_details(direct_error))
+        raise SubscriptionFetchError(sub_store_error, direct_error) from direct_error
 
 
 def convert_proxy_string(proxy_string, target='ClashMeta'):
@@ -220,7 +227,13 @@ def convert_proxy_string(proxy_string, target='ClashMeta'):
         dict 或 None: 转换后的 mihomo proxy dict，失败返回 None
     """
     base = _get_base_url()
-    logger.info(f"节点转换: proxy_string={proxy_string[:80]}...")
+    proxy_type = "unknown"
+    if isinstance(proxy_string, str) and '://' in proxy_string:
+        candidate = proxy_string.split('://', 1)[0].lower()
+        if candidate.replace('+', '').replace('-', '').replace('.', '').isalnum():
+            proxy_type = candidate[:32]
+    input_length = len(proxy_string) if isinstance(proxy_string, str) else 0
+    logger.info("节点转换开始: proxy_type=%s input_length=%d", proxy_type, input_length)
 
     # 创建临时订阅（需要一个名字才能调用 download）
     # 随机后缀避免并发节点转换时撞名导致 500
@@ -230,31 +243,27 @@ def convert_proxy_string(proxy_string, target='ClashMeta'):
     try:
         # 通过 content 参数直接传入节点内容，覆盖订阅 URL
         download_url = f'{base}/download/{quote(temp_name, safe="")}/{target}'
-        logger.info(f"节点转换下载: {download_url}")
         resp = requests.get(
             download_url,
             params={'content': proxy_string},
             timeout=15
         )
-        logger.info(f"节点转换响应: status={resp.status_code}, content-type={resp.headers.get('content-type', '')}")
         resp.raise_for_status()
 
         text = resp.text
-        logger.info(f"节点转换响应内容(前200字符): {text[:200]}")
 
         if not _is_yaml_response(text):
-            logger.warning(f"Sub-Store 节点转换返回非 YAML 内容: {text[:200]}")
+            logger.warning("节点转换返回无效内容: proxy_type=%s input_length=%d", proxy_type, input_length)
             return None
 
         proxies = parse_proxies_from_yaml(text)
-        logger.info(f"节点转换解析结果: {len(proxies)} 个 proxy")
         if proxies:
-            logger.info(f"节点转换成功: {proxies[0].get('name', '')} ({proxies[0].get('type', '')})")
+            logger.info("节点转换成功: proxy_type=%s input_length=%d", proxy_type, input_length)
             return proxies[0]
-        logger.warning("节点转换: YAML 解析成功但 proxies 列表为空")
+        logger.warning("节点转换结果为空: proxy_type=%s input_length=%d", proxy_type, input_length)
         return None
-    except Exception as e:
-        logger.warning(f"Sub-Store 节点转换失败: {e}")
+    except Exception:
+        logger.warning("节点转换失败: proxy_type=%s input_length=%d", proxy_type, input_length)
         return None
     finally:
         _delete_subscription(base, temp_name)

--- a/backend/utils/url_utils.py
+++ b/backend/utils/url_utils.py
@@ -1,0 +1,123 @@
+"""Helpers for rendering URLs in logs without exposing credentials."""
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qsl, unquote, unquote_plus, urlencode, urlsplit, urlunsplit
+
+_REDACTED = "[REDACTED]"
+_INVALID = "[INVALID URL REDACTED]"
+_MAX_DECODE_PASSES = 8
+_SENSITIVE_KEY_PARTS = (
+    "token",
+    "authorization",
+    "auth",
+    "key",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+)
+_BAD_PERCENT_ESCAPE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+
+
+def _has_control(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in value)
+
+
+def _decode_layers(value: str, *, plus: bool = False) -> str:
+    decoder = unquote_plus if plus else unquote
+    for _ in range(_MAX_DECODE_PASSES):
+        if _has_control(value) or _BAD_PERCENT_ESCAPE.search(value):
+            raise ValueError("unsafe encoded value")
+        decoded = decoder(value)
+        if decoded == value:
+            return value
+        value = decoded
+    if decoder(value) != value:
+        raise ValueError("too many encoding layers")
+    if _has_control(value) or _BAD_PERCENT_ESCAPE.search(value):
+        raise ValueError("unsafe decoded value")
+    return value
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", _decode_layers(key).lower())
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _contains_sensitive_expression(value: str) -> bool:
+    for component in re.split(r"[?&;]", value):
+        key, separator, _ = component.partition("=")
+        if separator and _is_sensitive_key(key.strip()):
+            return True
+    return False
+
+
+def _sanitize_nested_value(value: str, depth: int) -> str:
+    decoded = _decode_layers(value, plus=True)
+    if _contains_sensitive_expression(decoded):
+        return _REDACTED
+    if depth < 2 and ("://" in decoded or decoded.startswith("/")) and "?" in decoded:
+        nested = _safe_url(decoded, depth + 1)
+        return _REDACTED if _REDACTED in nested else nested
+    return decoded
+
+
+def _safe_url(value: str, depth: int = 0) -> str:
+    if not isinstance(value, str) or not value or _has_control(value):
+        raise ValueError("invalid URL")
+    if _BAD_PERCENT_ESCAPE.search(value):
+        raise ValueError("invalid percent escape")
+
+    decoded = _decode_layers(value)
+    parsed = urlsplit(decoded)
+    if parsed.scheme in ("http", "https") and not parsed.hostname:
+        raise ValueError("URL has no host")
+    if not parsed.scheme and not decoded.startswith("/"):
+        raise ValueError("URL is neither absolute nor relative")
+
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = parsed.port
+    netloc = hostname + (f":{port}" if port is not None else "")
+
+    query = []
+    for key, query_value in parse_qsl(parsed.query, keep_blank_values=True):
+        decoded_key = _decode_layers(key)
+        if _is_sensitive_key(decoded_key):
+            query.append((decoded_key, _REDACTED))
+        else:
+            query.append((decoded_key, _sanitize_nested_value(query_value, depth)))
+
+    # Fragments are commonly used for credentials by subscription providers.
+    # Drop them entirely: decoding and selectively redacting nested fragments
+    # is too easy to bypass with mixed encodings.
+    fragment = ""
+
+    return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(query, doseq=True), fragment))
+
+
+def safe_url_for_log(url: object) -> str:
+    """Return a log-safe URL, failing closed for malformed input.
+
+    User information is removed. Sensitive query keys (including encoded and
+    common compound variants) retain their names but have redacted values.
+    Several percent-encoding layers are decoded before inspection so encoding
+    cannot be used to bypass redaction.
+    """
+    try:
+        return _safe_url(url)  # type: ignore[arg-type]
+    except (TypeError, ValueError, UnicodeError):
+        return _INVALID
+
+
+def safe_exception_details(error: BaseException) -> str:
+    """Return bounded exception metadata without rendering its message or URL."""
+    exception_type = re.sub(r"[^A-Za-z0-9_.-]", "", type(error).__name__)[:80] or "Exception"
+    details = f"exception_type={exception_type}"
+    response = getattr(error, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        details += f" status={status}"
+    return details


### PR DESCRIPTION
## Summary

Follow-up security hardening discovered while validating the merged multi-profile implementation against an isolated copy of production data.

- Redacts credentials from Python, Go Agent, and Shell Agent URL logs.
- Removes URL userinfo, fragments, sensitive query values, nested encoded URLs, and nested token expressions from log output.
- Prevents proxy/node URIs and request exception URLs from reaching logs or HTTP error responses.
- Prevents Go/Shell restart command text and command output from reaching logs.
- Preserves Go `errors.Is` / `errors.As` behavior with sanitized error rendering.
- Removes download URL output from generated Agent installers.
- Adds fail-closed handling for malformed, over-encoded, and control-character URL inputs.

## Why this follow-up is separate

PR #53 was merged while the production-copy NAS migration rehearsal was still running. The rehearsal found that generated provider URLs containing `config_token` were present in ConfigFlow and Agent Docker logs. This PR contains only the follow-up remediation and regression tests.

## Validation

- Python: **381 passed, 1 skipped**
- Go 1.21: `go test ./...`, `go vet ./...`, `go build ./...` passed
- Frontend production build passed
- Python `compileall` passed
- Shell syntax checks passed
- Multiple independent adversarial reviews passed after fixing nested URL, fragment, exception response, and restart-command cases
