### PR TITLE
fix: render Agent Profile dropdown outside card

### DIFF
--- a/backend/test_agent_profile_dropdown.py
+++ b/backend/test_agent_profile_dropdown.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_agent_profile_select_teleports_dropdown_to_document_body():
+    source = (Path(__file__).resolve().parents[1] / "frontend" / "src" / "views" / "Agents.vue").read_text(encoding="utf-8")
+    marker = '配置 Profile'
+    start = source.index(marker)
+    select_start = source.index('<el-select', start)
+    select_end = source.index('>', select_start)
+    select_tag = source[select_start:select_end]
+
+    assert ':teleported="false"' not in select_tag
+    assert 'teleported="false"' not in select_tag

--- a/frontend/src/views/Agents.vue
+++ b/frontend/src/views/Agents.vue
@@ -129,7 +129,6 @@
           <el-select
             :model-value="agent.profile_id || 'default'"
             size="small"
-            :teleported="false"
             :disabled="bindingAgentId === agent.id"
             @change="bindAgentProfile(agent, $event)"
           >
@@ -2794,8 +2793,6 @@ onUnmounted(() => {
 :deep(.el-select .el-select__suffix) {
   color: #909399 !important;
 }
-
-/* Agent select popper 样式已移除（使用 teleported=false） */
 
 :deep(.el-input-number) {
   width: 100%;


### PR DESCRIPTION
## Summary
- restore Element Plus Select's default teleport-to-body behavior for the Agent Profile selector
- prevent the dropdown popper from being clipped or rendered as a blank panel inside Agent cards
- add a regression test that rejects disabling teleport on this selector

## Verification
- `python -m pytest backend -q`: 384 passed, 1 skipped
- `npm run build`: passed
- independent review: no security or logic findings
- production candidate `configflow:production-c4a50fbf` verified with 4 Profiles, 6 online/active Agents, MCP 41 tools, and unchanged DNS/proxy data plane