### PR TITLE
fix: show Agent Profile option labels

### DIFF
--- a/backend/test_agent_profile_dropdown.py
+++ b/backend/test_agent_profile_dropdown.py
@@ -11,3 +11,16 @@ def test_agent_profile_select_teleports_dropdown_to_document_body():
 
     assert ':teleported="false"' not in select_tag
     assert 'teleported="false"' not in select_tag
+
+
+def test_agent_profile_dropdown_has_visible_teleported_option_text():
+    source = (Path(__file__).resolve().parents[1] / "frontend" / "src" / "views" / "Agents.vue").read_text(encoding="utf-8")
+    marker = '配置 Profile'
+    start = source.index(marker)
+    select_start = source.index('<el-select', start)
+    select_end = source.index('>', select_start)
+    select_tag = source[select_start:select_end]
+
+    assert 'popper-class="agent-profile-select-popper"' in select_tag
+    assert ':global(.agent-profile-select-popper .el-select-dropdown__item)' in source
+    assert ':global(.agent-profile-select-popper .el-select-dropdown__item span)' in source

--- a/frontend/src/views/Agents.vue
+++ b/frontend/src/views/Agents.vue
@@ -129,6 +129,7 @@
           <el-select
             :model-value="agent.profile_id || 'default'"
             size="small"
+            popper-class="agent-profile-select-popper"
             :disabled="bindingAgentId === agent.id"
             @change="bindAgentProfile(agent, $event)"
           >
@@ -2792,6 +2793,26 @@ onUnmounted(() => {
 
 :deep(.el-select .el-select__suffix) {
   color: #909399 !important;
+}
+
+:global(.agent-profile-select-popper.el-popper),
+:global(.agent-profile-select-popper .el-select-dropdown) {
+  background: #fff !important;
+}
+
+:global(.agent-profile-select-popper .el-select-dropdown__item),
+:global(.agent-profile-select-popper .el-select-dropdown__item span) {
+  color: #30354d !important;
+}
+
+:global(.agent-profile-select-popper .el-select-dropdown__item.is-hovering) {
+  background: rgba(107, 115, 255, 0.08) !important;
+}
+
+:global(.agent-profile-select-popper .el-select-dropdown__item.is-selected),
+:global(.agent-profile-select-popper .el-select-dropdown__item.is-selected span) {
+  color: #000dff !important;
+  font-weight: 600;
 }
 
 :deep(.el-input-number) {


### PR DESCRIPTION
## Summary
- add a unique popper class to the Agent Profile selector
- apply body-level, class-scoped styles for option labels after the dropdown is teleported outside the scoped Agent component
- preserve visible hover and selected states without affecting other selects
- extend the regression test for popper class and visible option text rules

## Verification
- `python -m pytest backend -q`: 385 passed, 1 skipped
- `npm run build`: passed
- compiled CSS verified unscoped and limited to `.agent-profile-select-popper`
- independent review: no security or logic findings
- production candidate `configflow:production-65680129` verified with 4 Profiles, 6 online/active Agents, and unchanged DNS/proxy data plane