### PR TITLE
fix: use native Agent Profile selector

### DIFF
--- a/backend/test_agent_profile_dropdown.py
+++ b/backend/test_agent_profile_dropdown.py
@@ -1,26 +1,35 @@
 from pathlib import Path
 
 
-def test_agent_profile_select_teleports_dropdown_to_document_body():
-    source = (Path(__file__).resolve().parents[1] / "frontend" / "src" / "views" / "Agents.vue").read_text(encoding="utf-8")
-    marker = '配置 Profile'
-    start = source.index(marker)
-    select_start = source.index('<el-select', start)
-    select_end = source.index('>', select_start)
-    select_tag = source[select_start:select_end]
-
-    assert ':teleported="false"' not in select_tag
-    assert 'teleported="false"' not in select_tag
+def _agents_source() -> str:
+    return (Path(__file__).resolve().parents[1] / "frontend" / "src" / "views" / "Agents.vue").read_text(encoding="utf-8")
 
 
-def test_agent_profile_dropdown_has_visible_teleported_option_text():
-    source = (Path(__file__).resolve().parents[1] / "frontend" / "src" / "views" / "Agents.vue").read_text(encoding="utf-8")
-    marker = '配置 Profile'
-    start = source.index(marker)
-    select_start = source.index('<el-select', start)
-    select_end = source.index('>', select_start)
-    select_tag = source[select_start:select_end]
+def test_agent_profile_binding_uses_visible_native_select():
+    source = _agents_source()
+    marker = "配置 Profile"
+    section = source[source.index(marker):source.index(marker) + 900]
 
-    assert 'popper-class="agent-profile-select-popper"' in select_tag
-    assert ':global(.agent-profile-select-popper .el-select-dropdown__item)' in source
-    assert ':global(.agent-profile-select-popper .el-select-dropdown__item span)' in source
+    assert "<select" in section
+    assert 'class="agent-profile-native-select"' in section
+    assert ':value="agent.profile_id || \'default\'"' in section
+    assert '@change="handleAgentProfileChange(agent, $event)"' in section
+    assert "<el-select" not in section
+    assert "<option" in section
+    assert "profile.name" in section
+    assert ".agent-profile-native-select {" in source
+    assert "-webkit-text-fill-color: #30354d;" in source
+    assert "color-scheme: light;" in source
+
+
+def test_agent_profile_native_change_forwards_selected_profile_id():
+    source = _agents_source()
+    start = source.index("const handleAgentProfileChange")
+    handler = source[start:start + 400]
+
+    assert "event.target" in handler
+    assert "select instanceof HTMLSelectElement" in handler
+    assert "const previousProfileId = agent.profile_id || 'default'" in handler
+    assert "await bindAgentProfile(agent, select.value)" in handler
+    assert "select.value = previousProfileId" in handler
+    assert "agent-profile-select-popper" not in source

--- a/frontend/src/views/Agents.vue
+++ b/frontend/src/views/Agents.vue
@@ -126,20 +126,20 @@
             <el-icon><Setting /></el-icon>
             配置 Profile
           </div>
-          <el-select
-            :model-value="agent.profile_id || 'default'"
-            size="small"
-            popper-class="agent-profile-select-popper"
+          <select
+            class="agent-profile-native-select"
+            :value="agent.profile_id || 'default'"
             :disabled="bindingAgentId === agent.id"
-            @change="bindAgentProfile(agent, $event)"
+            @change="handleAgentProfileChange(agent, $event)"
           >
-            <el-option
+            <option
               v-for="profile in profileStore.profiles"
               :key="profile.id"
-              :label="profile.name"
               :value="profile.id"
-            />
-          </el-select>
+            >
+              {{ profile.name }}
+            </option>
+          </select>
         </div>
 
         <!-- 系统监控指标 -->
@@ -1333,19 +1333,29 @@ const loadAgents = async () => {
   }
 }
 
-const bindAgentProfile = async (agent: Agent, profileId: string) => {
+const bindAgentProfile = async (agent: Agent, profileId: string): Promise<boolean> => {
   const previousProfileId = agent.profile_id || 'default'
-  if (profileId === previousProfileId) return
+  if (profileId === previousProfileId) return true
   bindingAgentId.value = agent.id
   try {
     await agentApi.bindProfile(agent.id, profileId)
     agent.profile_id = profileId
     ElMessage.success('Agent 配置 Profile 已更新')
+    return true
   } catch (error: any) {
     ElMessage.error(error.response?.data?.message || 'Agent 配置 Profile 更新失败')
+    return false
   } finally {
     bindingAgentId.value = null
   }
+}
+
+const handleAgentProfileChange = async (agent: Agent, event: Event) => {
+  const select = event.target
+  if (!(select instanceof HTMLSelectElement)) return
+  const previousProfileId = agent.profile_id || 'default'
+  const updated = await bindAgentProfile(agent, select.value)
+  if (!updated) select.value = previousProfileId
 }
 
 // 格式化时间
@@ -2795,24 +2805,33 @@ onUnmounted(() => {
   color: #909399 !important;
 }
 
-:global(.agent-profile-select-popper.el-popper),
-:global(.agent-profile-select-popper .el-select-dropdown) {
-  background: #fff !important;
+.agent-profile-native-select {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid #dcdfe6;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #30354d;
+  -webkit-text-fill-color: #30354d;
+  color-scheme: light;
+  font-size: 14px;
+  cursor: pointer;
 }
 
-:global(.agent-profile-select-popper .el-select-dropdown__item),
-:global(.agent-profile-select-popper .el-select-dropdown__item span) {
-  color: #30354d !important;
+.agent-profile-native-select:focus {
+  border-color: #409eff;
+  outline: none;
 }
 
-:global(.agent-profile-select-popper .el-select-dropdown__item.is-hovering) {
-  background: rgba(107, 115, 255, 0.08) !important;
+.agent-profile-native-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
-:global(.agent-profile-select-popper .el-select-dropdown__item.is-selected),
-:global(.agent-profile-select-popper .el-select-dropdown__item.is-selected span) {
-  color: #000dff !important;
-  font-weight: 600;
+.agent-profile-native-select option {
+  background: #fff;
+  color: #30354d;
 }
 
 :deep(.el-input-number) {


### PR DESCRIPTION
## Summary
- replace the Agent card Profile Element Plus select with a native HTML select after repeated invisible-label rendering across browsers
- preserve the same Profile binding API and option source
- force visible light-scheme text without teleported/scoped popper behavior
- explicitly restore the previous selected value when a binding request fails
- replace prior popper-specific regression assertions with native control and rollback checks

## Verification
- `python -m pytest backend -q`: 385 passed, 1 skipped
- `npm run build`: passed
- compiled assets contain native selector CSS/JS and no old popper class
- two independent reviews; final review found no security or logic issues