### PR TITLE
fix: 修复 Agent 卡片配置 Profile 下拉框渲染空白选项

### DIFF
--- a/backend/test_agent_profile_dropdown.py
+++ b/backend/test_agent_profile_dropdown.py
@@ -33,3 +33,13 @@ def test_agent_profile_native_change_forwards_selected_profile_id():
     assert "await bindAgentProfile(agent, select.value)" in handler
     assert "select.value = previousProfileId" in handler
     assert "agent-profile-select-popper" not in source
+
+
+def test_agent_profile_options_bind_to_unwrapped_profiles_ref():
+    """模板里访问 useProfileStore() 返回对象的 ref 属性不会自动解包，
+    v-for 会遍历到 ref 自身的内部键，渲染出一批空白 <option>。"""
+    source = _agents_source()
+
+    assert 'const { profiles, refreshProfiles } = useProfileStore()' in source
+    assert 'v-for="profile in profiles"' in source
+    assert 'profileStore.profiles' not in source

--- a/frontend/src/views/Agents.vue
+++ b/frontend/src/views/Agents.vue
@@ -133,7 +133,7 @@
             @change="handleAgentProfileChange(agent, $event)"
           >
             <option
-              v-for="profile in profileStore.profiles"
+              v-for="profile in profiles"
               :key="profile.id"
               :value="profile.id"
             >
@@ -898,7 +898,7 @@ import VChart from 'vue-echarts'
 use([LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer])
 
 const agents = ref<Agent[]>([])
-const profileStore = useProfileStore()
+const { profiles, refreshProfiles } = useProfileStore()
 const bindingAgentId = ref<string | null>(null)
 const scriptDialogVisible = ref(false)
 const logsDialogVisible = ref(false)
@@ -2145,7 +2145,7 @@ const stopAutoRefresh = () => {
 
 onMounted(() => {
   loadAgents()
-  profileStore.refreshProfiles().catch(() => undefined)
+  refreshProfiles().catch(() => undefined)
   startAutoRefresh()
 })
 


### PR DESCRIPTION
## 问题
多配置（Profile）场景下，Agents 页面卡片里的「配置 Profile」下拉框展开后是一片空白，选中值也不显示。

## 根因
`Agents.vue` 里模板用的是 `profileStore.profiles`。`useProfileStore()` 返回的是一个**普通对象**（不是 `reactive`），Vue 只在「顶层 setup 绑定」或「reactive 对象属性」上自动解包 ref；普通对象属性不会解包。于是 `v-for="profile in profileStore.profiles"` 遍历的是 ref 实例本身，得到它的自有可枚举键：

```
[ '__v_isShallow', 'dep', '__v_isRef', '_rawValue', '_value' ]
```

即渲染出 5 个 `profile.name === undefined` 的空白 `<option>`，`:value` 也全是 undefined，导致 select 选中项匹配不上、显示为空——正好是截图里那一片空白列表。

同仓库的 `ProfileSwitcher.vue`、`Profiles.vue` 都是解构写法，所以顶部切换器正常，只有 Agents 卡片异常。这也解释了前面 #56 / #57 / #58 三次按「样式/文字颜色/换原生 select」方向的修复为什么都没生效——那三次修的是症状，选项数据自始至终就是空的。

## 改动
`Agents.vue` 改为与其他消费方一致的解构写法：`const { profiles, refreshProfiles } = useProfileStore()`。

## 验证
1. **机制复现（Vue 3.4 真实渲染）**：同一个 store，两种写法对比
   - `profileStore.profiles` 写法：渲染报错 `Cannot read properties of undefined (reading 'id')`（客户端渲染下即为一批空白 option）
   - 解构写法：`<select><option value="default">默认配置</option><option value="p2">家庭配置</option></select>` ✅
2. **回归测试**（红→绿）：新增 `test_agent_profile_options_bind_to_unwrapped_profiles_ref`
   - 修复前：`1 failed, 2 passed`
   - 修复后：`/usr/local/bin/python3 -m pytest backend/test_agent_profile_dropdown.py -q` → `3 passed`