### PR TITLE
feat(mcp): 补齐 MCP 排序与增删改查覆盖，并修正字段名不符

### DIFF
--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -70,7 +70,7 @@ def obj(properties: Dict[str, Any], required: Optional[List[str]] = None) -> Dic
     properties = dict(properties)
     properties.setdefault(
         'profile_id',
-        {'type': 'string', 'description': '目标 profile id；留空使用 active/default profile'},
+        {'type': 'string', 'description': "目标 profile id；留空使用 'default' profile（不跟随界面上激活的 profile）"},
     )
     return {
         'type': 'object',
@@ -181,10 +181,69 @@ def _crud(
     raise ApiError(400, f"不支持的 action: {action}")
 
 
+# collection -> reorder 接口路径。排序按 id 提交，由服务端在存量数据上重排，
+# 避免把列表接口加工过的展示数据（拼过域名的 URL、缓存计数、脱敏字段）回写进配置。
+_REORDER_COLLECTIONS = {
+    'subscriptions': '/api/subscriptions/reorder',
+    'nodes': '/api/nodes/reorder',
+    'rules': '/api/rules/reorder',
+    'rule_library': '/api/rule-library/reorder',
+    'proxy_groups': '/api/proxy-groups/reorder',
+}
+_REORDER_NAMES = list(_REORDER_COLLECTIONS)
+
+
+def _reorder(collection: str, ids: List[str], position: str) -> Dict[str, Any]:
+    if collection not in _REORDER_COLLECTIONS:
+        raise ApiError(400, f"不支持的 collection: {collection}，可选 {_REORDER_NAMES}")
+    if position not in ('top', 'bottom'):
+        raise ApiError(400, "position 必须是 'top' 或 'bottom'")
+    if not ids:
+        raise ApiError(400, '需要提供至少一个 id')
+    if len(set(ids)) != len(ids):
+        raise ApiError(400, 'ids 中存在重复项')
+
+    result = call_api(
+        'POST',
+        _REORDER_COLLECTIONS[collection],
+        body={'ids': ids, 'position': position},
+    )
+    return {
+        'collection': collection,
+        'position': position,
+        'moved': ids,
+        'order': (result or {}).get('order'),
+    }
+
+
 def _unwrap(result: Any, fallback: Any) -> Any:
     if isinstance(result, dict) and 'data' in result:
         return result['data']
     return fallback
+
+
+# ================================================================ 排序
+
+@tool(
+    'reorder_items',
+    '调整集合内条目的顺序。ids 里的条目按给定顺序整体移到最前（position=top，默认）'
+    '或最后（position=bottom），未列出的条目保持原有相对顺序。'
+    '规则顺序即匹配优先级，策略组顺序即客户端里的展示顺序。',
+    obj(
+        {
+            'collection': string('目标集合', _REORDER_NAMES),
+            'ids': array('要移动的条目 id，按目标先后顺序排列'),
+            'position': string('移动到集合的哪一端，默认 top', ['top', 'bottom']),
+        },
+        ['collection', 'ids'],
+    ),
+)
+def _reorder_items(args):
+    return _reorder(
+        _require(args, 'collection'),
+        _require(args, 'ids'),
+        args.get('position', 'top'),
+    )
 
 
 # ================================================================ Profiles
@@ -386,19 +445,26 @@ def _manage_aggregation(args):
 
 @tool(
     'preview_aggregation',
-    '预览聚合最终产出的节点列表与节点数，用于确认筛选规则是否符合预期。',
+    '预览聚合最终产出的节点列表与节点数，用于确认筛选规则是否符合预期。'
+    'mode=count 只返回节点数量，mode=provider 返回给客户端用的 provider YAML 文本。',
     obj(
         {
             'id': string('聚合 id'),
-            'count_only': boolean('只返回节点数量，默认 false'),
+            'mode': string('返回内容，默认 nodes', ['nodes', 'count', 'provider']),
+            'count_only': boolean('等价于 mode=count，保留兼容'),
         },
         ['id'],
     ),
 )
 def _preview_aggregation(args):
     agg_id = _require(args, 'id')
-    if args.get('count_only'):
+    mode = 'count' if args.get('count_only') else args.get('mode', 'nodes')
+    if mode == 'count':
         return call_api('GET', f"/api/aggregations/{agg_id}/count")
+    if mode == 'provider':
+        return {'id': agg_id, 'provider': call_api('GET', f"/api/aggregations/{agg_id}/provider")}
+    if mode != 'nodes':
+        raise ApiError(400, f"不支持的 mode: {mode}")
     return call_api('GET', f"/api/aggregations/{agg_id}/preview")
 
 
@@ -449,7 +515,8 @@ def _list_rules(args):
     'manage_rule',
     '创建、更新或删除一条规则或规则集。'
     'itemType=rule 时 data 需含 rule_type（如 DOMAIN-SUFFIX / IP-CIDR）、value、policy；'
-    'itemType=ruleset 时 data 需含 name、policy，以及 url 或 library_rule_id。',
+    'itemType=ruleset 时 data 需含 name、policy，以及 url 或 library_rule_id。'
+    '新建的规则默认插在列表最前（优先级最高），要放到最后传 position=bottom。',
     obj(
         {
             'action': ACTION,
@@ -458,6 +525,10 @@ def _list_rules(args):
                 '规则字段，如 itemType（rule / ruleset）、rule_type、value、'
                 'policy（目标策略组名）、name、url、library_rule_id、enabled'
             ),
+            'position': string(
+                'create 时新规则放在列表哪一端，默认 top（优先级最高）',
+                ['top', 'bottom'],
+            ),
         },
         ['action'],
     ),
@@ -465,7 +536,15 @@ def _list_rules(args):
 def _manage_rule(args):
     data = args.get('data') or {}
     prefix = 'ruleset' if data.get('itemType') == 'ruleset' else 'rule'
-    return _crud(args, '/api/rules', prefix, '规则')
+    result = _crud(args, '/api/rules', prefix, '规则')
+    # 后端 POST /api/rules 固定插到队首，要放队尾就创建后再移一次
+    position = args.get('position', 'top')
+    if result.get('action') == 'create' and position == 'bottom':
+        new_id = (result.get('item') or {}).get('id')
+        if new_id:
+            _reorder('rules', [new_id], 'bottom')
+            result['position'] = 'bottom'
+    return result
 
 
 @tool(
@@ -539,6 +618,25 @@ def _list_rule_library(args):
 )
 def _manage_rule_library(args):
     return _crud(args, '/api/rule-library', 'lib', '规则仓库条目')
+
+
+@tool(
+    'get_rule_library_content',
+    '读取规则仓库中 source_type=content 的条目正文（URL 类型的条目没有正文）。',
+    obj({'id': string('规则仓库条目 id')}, ['id']),
+)
+def _get_rule_library_content(args):
+    rule_id = _require(args, 'id')
+    return {'id': rule_id, 'content': call_api('GET', f"/api/rule-library/content/{rule_id}")}
+
+
+@tool(
+    'cache_rule_library',
+    '把指定的 URL 类型规则仓库条目拉取并缓存到本地，之后生成配置可离线引用。',
+    obj({'ids': array('要缓存的规则仓库条目 id 列表')}, ['ids']),
+)
+def _cache_rule_library(args):
+    return call_api('POST', '/api/rule-library/cache', body={'rule_ids': _require(args, 'ids')})
 
 
 @tool(
@@ -689,12 +787,15 @@ def _generate_config(args):
 
 @tool(
     'manage_config_backup',
-    '导出、导入或重置 ConfigFlow 的整份配置。'
-    'export 返回完整配置 JSON；import 用 data 覆盖当前配置；reset 恢复出厂设置。',
+    '导出、导入或重置 ConfigFlow 配置。'
+    'export 返回配置 JSON；import 用 data 覆盖；reset 恢复出厂设置。'
+    'scope=system（默认）作用于整份配置，scope=profile 只作用于 profile_id 指定的那份 profile'
+    '（profile 粒度不支持 reset）。',
     obj(
         {
             'action': string('操作类型', ['export', 'import', 'reset']),
-            'data': free_object('import 时要导入的完整配置 JSON'),
+            'scope': string('作用范围，默认 system', ['system', 'profile']),
+            'data': free_object('import 时要导入的配置 JSON'),
             'desensitize': boolean('export 时脱敏订阅 URL 与节点凭证，默认 false'),
         },
         ['action'],
@@ -702,6 +803,21 @@ def _generate_config(args):
 )
 def _manage_config_backup(args):
     action = _require(args, 'action')
+    scope = args.get('scope', 'system')
+    if scope not in ('system', 'profile'):
+        raise ApiError(400, f"不支持的 scope: {scope}")
+
+    if scope == 'profile':
+        profile_id = args.get('profile_id') or 'default'
+        if action == 'export':
+            return call_api('GET', f"/api/profiles/{profile_id}/export")
+        if action == 'import':
+            data = args.get('data')
+            if not data:
+                raise ApiError(400, '导入配置需要提供 data')
+            return call_api('POST', f"/api/profiles/{profile_id}/import", body=data)
+        raise ApiError(400, f"scope=profile 不支持 action: {action}")
+
     if action == 'export':
         return call_api('GET', '/api/config/export', query={'desensitize': args.get('desensitize')})
     if action == 'import':
@@ -748,12 +864,17 @@ def _get_agent(args):
     'manage_agent',
     '对 Agent 执行管理操作：update（修改配置字段）、delete（从列表移除）、'
     'restart（重启被管服务）、push_config（把最新配置推送到 Agent）、'
-    'uninstall（远程卸载）、upgrade（升级 Agent 到最新版本）。',
+    'uninstall（远程卸载）、upgrade（升级 Agent 到最新版本）、'
+    'clear_log（清空指定日志文件，需 log_path）、validate_log_path（校验日志路径，需 log_path）、'
+    'get_logging（读取日志采集开关）、set_logging（开关日志采集，需 enabled）。',
     obj(
         {
             'action': string(
                 '操作类型',
-                ['update', 'delete', 'restart', 'push_config', 'uninstall', 'upgrade'],
+                [
+                    'update', 'delete', 'restart', 'push_config', 'uninstall', 'upgrade',
+                    'clear_log', 'validate_log_path', 'get_logging', 'set_logging',
+                ],
             ),
             'id': string('Agent id'),
             'data': free_object(
@@ -761,6 +882,8 @@ def _get_agent(args):
                 '配置路径、重启命令等属于 Agent 端的安装参数，需在 Agent 侧调整'
             ),
             'base_url': string('push_config 时 Agent 回取配置用的服务地址，留空自动推断'),
+            'log_path': string('clear_log / validate_log_path 时的日志文件路径'),
+            'enabled': boolean('set_logging 时是否启用日志采集'),
         },
         ['action', 'id'],
     ),
@@ -790,6 +913,28 @@ def _manage_agent(args):
         return call_api('POST', f"/api/agents/{agent_id}/uninstall", body={})
     if action == 'upgrade':
         return call_api('POST', f"/api/agents/{agent_id}/update", body={})
+    if action == 'clear_log':
+        return call_api(
+            'POST',
+            f"/api/agents/{agent_id}/logs/clear",
+            body={'log_path': _require(args, 'log_path')},
+        )
+    if action == 'validate_log_path':
+        return call_api(
+            'POST',
+            f"/api/agents/{agent_id}/logs/validate",
+            body={'path': _require(args, 'log_path')},
+        )
+    if action == 'get_logging':
+        return call_api('GET', f"/api/agents/{agent_id}/config/logging")
+    if action == 'set_logging':
+        if 'enabled' not in args:
+            raise ApiError(400, 'set_logging 需要提供 enabled')
+        return call_api(
+            'POST',
+            f"/api/agents/{agent_id}/config/logging",
+            body={'enabled': bool(args['enabled'])},
+        )
     raise ApiError(400, f"不支持的 action: {action}")
 
 
@@ -842,6 +987,40 @@ def _get_agent_metrics(args):
         raise ApiError(400, f"不支持的 scope: {scope}")
     suffix, query = paths[scope]
     return call_api('GET', f"/api/agents/{agent_id}{suffix}", query=query)
+
+
+# method -> 生成接口路径
+_AGENT_INSTALL_ENDPOINTS = {
+    'install_script': '/api/agents/install-script',
+    'docker_compose': '/api/agents/docker-agent-compose',
+    'docker_run': '/api/agents/docker-agent-run',
+    'latest_version': '/api/agents/latest-version',
+}
+
+
+@tool(
+    'get_agent_install_info',
+    '获取新增 Agent 所需的安装物料：install_script（一键安装脚本）、'
+    'docker_compose（compose 文件）、docker_run（docker run 命令）、'
+    'latest_version（最新 Agent 版本号）。',
+    obj(
+        {
+            'method': string('要获取的物料', list(_AGENT_INSTALL_ENDPOINTS)),
+            'params': free_object(
+                '生成参数（作为 query 传给后端），如 server_url、name / agent_name、'
+                'type（mihomo / mosdns）、port、agent_ip、config_path、restart_command、'
+                'agent_type（go / shell）、data_dir、network_mode、enable_mihomo、enable_mosdns'
+            ),
+        },
+        ['method'],
+    ),
+)
+def _get_agent_install_info(args):
+    method = _require(args, 'method')
+    if method not in _AGENT_INSTALL_ENDPOINTS:
+        raise ApiError(400, f"不支持的 method: {method}")
+    result = call_api('GET', _AGENT_INSTALL_ENDPOINTS[method], query=args.get('params') or {})
+    return result if isinstance(result, dict) else {'method': method, 'content': result}
 
 
 # ================================================================ MosDNS
@@ -900,6 +1079,17 @@ def _update_mosdns_settings(args):
     return call_api('POST', path, body=merged)
 
 
+@tool(
+    'convert_mosdns_rule',
+    '把一个远程规则文件（Clash / list 格式）转换成 MosDNS 域名规则格式并返回文本，'
+    '用于确认某个规则源能否被 MosDNS 正确解析。',
+    obj({'url': string('规则文件地址')}, ['url']),
+)
+def _convert_mosdns_rule(args):
+    url = _require(args, 'url')
+    return {'url': url, 'content': call_api('GET', '/api/mosdns/rule-proxy', query={'url': url})}
+
+
 # ================================================================ 系统
 
 # section -> (GET 路径, POST 路径, GET 响应字段 -> POST 请求字段)
@@ -913,6 +1103,7 @@ _SETTING_SECTIONS = {
         {},
     ),
     'backup': ('/api/backup/config', '/api/backup/config', {}),
+    'github_proxy': ('/api/rule-library/proxy-domains', '/api/rule-library/proxy-domains', {}),
     'version': ('/api/version', None, {}),
 }
 _SETTING_SECTION_NAMES = list(_SETTING_SECTIONS)
@@ -932,7 +1123,8 @@ def _get_overview(args):
     'get_settings',
     '读取系统设置。section 对应：server_domain（对外域名）、config_token（订阅链接令牌）、'
     'sub_store_url（Sub-Store 地址）、subscription_aggregation（聚合功能开关）、'
-    'backup（WebDAV 备份配置）、version（版本信息）。留空返回全部。',
+    'backup（WebDAV 备份配置）、github_proxy（GitHub 规则源加速域名）、'
+    'version（版本信息）。留空返回全部。',
     obj({'section': string('设置分区，留空返回全部', _SETTING_SECTION_NAMES)}),
 )
 def _get_settings(args):
@@ -949,7 +1141,8 @@ def _get_settings(args):
     '更新系统设置。server_domain 传 {"server_domain": "..."}；'
     'config_token 传 {"config_token": "..."} 或 {"generate": true} 生成随机令牌；'
     'subscription_aggregation 传 {"enabled": true/false}；'
-    'backup 传 webdav_url / webdav_username / webdav_password / webdav_path / auto_backup。',
+    'backup 传 webdav_url / webdav_username / webdav_password / webdav_path / auto_backup；'
+    'github_proxy 传 {"proxy_domains": "https://ghproxy.example.com/"}，传空字符串表示关闭。',
     obj(
         {
             'section': string(
@@ -1024,6 +1217,20 @@ def _get_app_logs(args):
             'level': args.get('level'),
         },
     )
+
+
+@tool(
+    'manage_app_logs',
+    '查看服务端日志文件信息（大小、修改时间）或清空日志文件。读日志内容用 get_app_logs。',
+    obj({'action': string('操作类型', ['info', 'clear'])}, ['action']),
+)
+def _manage_app_logs(args):
+    action = _require(args, 'action')
+    if action == 'info':
+        return call_api('GET', '/api/logs/info')
+    if action == 'clear':
+        return call_api('POST', '/api/logs/clear', body={})
+    raise ApiError(400, f"不支持的 action: {action}")
 
 
 @tool(

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -347,9 +347,9 @@ def _list_subscriptions(args):
             'action': ACTION,
             'id': string('订阅 id，update / delete 时必填'),
             'data': free_object(
-                '订阅字段，如 name（名称）、url（订阅链接）、type'
-                '（mihomo / surge / general）、enabled（是否启用）、udp、'
-                'exclude_keywords（排除关键字）'
+                '订阅字段：name（名称）、url（订阅链接）、type（mihomo / surge / general）、'
+                'enabled（是否启用）、interval（更新间隔秒）、'
+                'health_check_url（健康检查地址，留空用默认）'
             ),
         },
         ['action'],
@@ -405,14 +405,15 @@ def _list_aggregations(args):
 @tool(
     'manage_aggregation',
     '创建、更新或删除订阅聚合。create 时 data 至少包含 name；'
-    'subscriptions 为订阅 id 列表，nodes 为手动节点 id 列表。',
+    'subscriptions 为订阅 id 列表，nodes 为手动节点 id 列表；'
+    '筛选正则字段名是 regex_filter。',
     obj(
         {
             'action': ACTION,
             'id': string('聚合 id，update / delete 时必填'),
             'data': free_object(
-                '聚合字段，如 name、subscriptions（订阅 id 数组）、'
-                'nodes（手动节点 id 数组）、enabled、exclude_keywords'
+                '聚合字段：name、subscriptions（订阅 id 数组）、nodes（手动节点 id 数组）、'
+                'regex_filter（节点名筛选正则）、description、enabled、health_check_url'
             ),
         },
         ['action'],
@@ -481,15 +482,17 @@ def _list_nodes(args):
 
 @tool(
     'manage_node',
-    '创建、更新或删除手动节点。create 时 data 至少包含 name、type、server、port；'
-    'type 支持 ss / ssr / vmess / trojan / hysteria / hysteria2。',
+    '创建、更新或删除手动节点。create 时 data 至少包含 name 和 proxy_string；'
+    'proxy_string 是完整的节点链接（ss:// / vmess:// / trojan:// / hysteria2:// 等），'
+    '也可以是 mihomo 的结构化 proxy（YAML / JSON 文本）。协议、服务器、端口都从中解析，'
+    '不要拆成 server / port / password 之类的独立字段。',
     obj(
         {
             'action': ACTION,
             'id': string('节点 id，update / delete 时必填'),
             'data': free_object(
-                '节点字段，如 name、type、server、port、password、uuid、'
-                'cipher、enabled，以及各协议特有字段'
+                '节点字段：name（节点名）、proxy_string（节点链接或结构化 proxy 文本）、'
+                'enabled、remark（备注）'
             ),
         },
         ['action'],
@@ -522,8 +525,9 @@ def _list_rules(args):
             'action': ACTION,
             'id': string('规则 id，update / delete 时必填'),
             'data': free_object(
-                '规则字段，如 itemType（rule / ruleset）、rule_type、value、'
-                'policy（目标策略组名）、name、url、library_rule_id、enabled'
+                '规则字段：itemType（rule / ruleset）、rule_type、value、'
+                'policy（目标策略组名）、enabled、no_resolve、remark、group_name；'
+                'ruleset 另有 name、url、behavior、library_rule_id'
             ),
             'position': string(
                 'create 时新规则放在列表哪一端，默认 top（优先级最高）',
@@ -609,8 +613,8 @@ def _list_rule_library(args):
             'action': ACTION,
             'id': string('规则仓库条目 id，update / delete 时必填'),
             'data': free_object(
-                '条目字段，如 name、source_type（url / content）、url、content、'
-                'behavior（domain / ipcidr / classical）、format（yaml / text）、enabled'
+                '条目字段：name、source_type（url / content）、url、content、'
+                'behavior（domain / ipcidr / classical）、enabled'
             ),
         },
         ['action'],
@@ -666,16 +670,25 @@ def _list_proxy_groups(args):
     'manage_proxy_group',
     '创建、更新或删除策略组。create 时 data 至少包含 name 和 type；'
     'type 支持 select（手动选择）、url-test（自动测速）、fallback（故障转移）、'
-    'load-balance（负载均衡）、relay。',
+    'load-balance（负载均衡）、relay。'
+    '节点来源可以是订阅（subscriptions + regex）、聚合（aggregations + aggregation_regex）、'
+    '手动节点（manual_nodes）或引用其他策略组（include_groups），可组合使用；'
+    'follow_group 则表示整体跟随另一个策略组。'
+    '引用类字段填的都是 id，不是名称。',
     obj(
         {
             'action': ACTION,
             'id': string('策略组 id，update / delete 时必填'),
             'data': free_object(
-                '策略组字段，如 name、type、subscriptions（订阅 id 数组）、'
-                'aggregations（聚合 id 数组）、manual_nodes（节点 id 数组）、'
-                'groups（引用的其他策略组名）、filter（节点名筛选正则）、'
-                'exclude_filter、url、interval、enabled'
+                '策略组字段：name、type、enabled、'
+                'subscriptions（订阅 id 数组）、regex（订阅节点名筛选正则）、'
+                'aggregations（聚合 id 数组）、aggregation_regex（聚合节点名筛选正则）、'
+                'manual_nodes（节点 id 数组，DIRECT / REJECT 直接用名称）、'
+                'include_groups（引用的其他策略组 id 数组）、'
+                'follow_group（跟随的策略组 id）、proxies_order（节点顺序）、'
+                'url（测试地址）、interval（测试间隔秒）、'
+                'strategy（load-balance 的 round-robin / consistent-hashing / sticky-sessions）、'
+                'lazy（懒加载）'
             ),
         },
         ['action'],

--- a/backend/routes/mosdns.py
+++ b/backend/routes/mosdns.py
@@ -495,6 +495,11 @@ def _fetch_remote_content(url: str) -> str:
 def _require_rule_proxy_auth():
     from backend.common.auth import is_token_within_length, parse_bearer_token, verify_token
     from backend.common.config import get_repository
+    from backend.common.internal_call import is_internal_call
+
+    # MCP 层发起的进程内调用，认证已在 /mcp 入口完成（与 validate_token_or_jwt 一致）
+    if is_internal_call():
+        return True
     system_config = config_data.get('system_config', {})
     config_token = system_config.get('config_token', '')
     rule_proxy_token = system_config.get('rule_proxy_token', '')

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -5,6 +5,7 @@ import uuid
 from backend.routes import nodes_bp
 from backend.common.auth import require_auth
 from backend.common.config import get_config, save_config, update_config_transaction
+from backend.utils.reorder import resolve_new_order
 
 
 def clean_aggregations_node(node_id):
@@ -107,9 +108,12 @@ def reorder_nodes():
     """批量更新节点顺序"""
     try:
         config_data = get_config()
-        new_order = request.json.get('nodes', [])
+        body = request.json or {}
+        new_order, missing = resolve_new_order(config_data.get('nodes', []), body, 'nodes')
+        if missing:
+            return jsonify({'success': False, 'message': f'以下节点 id 不存在: {missing}'}), 404
         config_data['nodes'] = new_order
         save_config()
-        return jsonify({'success': True})
+        return jsonify({'success': True, 'order': [n.get('id') for n in new_order]})
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500

--- a/backend/routes/proxy_groups.py
+++ b/backend/routes/proxy_groups.py
@@ -6,6 +6,7 @@ from flask import request, jsonify
 from backend.routes import proxy_groups_bp
 from backend.common.auth import require_auth
 from backend.common.config import get_config, save_config, update_config_transaction
+from backend.utils.reorder import resolve_new_order
 from backend.utils.subscription_cache import load_subscription_cache
 
 
@@ -201,12 +202,19 @@ def preview_proxy_group_regex():
 @proxy_groups_bp.route('/reorder', methods=['POST'])
 @require_auth
 def reorder_proxy_groups():
-    """批量更新策略组顺序"""
+    """批量更新策略组顺序
+
+    按 id 排序时传 {'ids': [...], 'position': 'top'|'bottom'}；
+    传完整对象数组的旧格式仍然兼容。
+    """
     try:
         config_data = get_config()
-        new_order = request.json.get('groups', [])
+        body = request.json or {}
+        new_order, missing = resolve_new_order(config_data.get('proxy_groups', []), body, 'groups')
+        if missing:
+            return jsonify({'success': False, 'message': f'以下策略组 id 不存在: {missing}'}), 404
         config_data['proxy_groups'] = new_order
         save_config()
-        return jsonify({'success': True})
+        return jsonify({'success': True, 'order': [g.get('id') for g in new_order]})
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500

--- a/backend/routes/rule_library.py
+++ b/backend/routes/rule_library.py
@@ -8,6 +8,7 @@ from flask import Blueprint
 from backend.common.auth import require_auth
 from backend.common.config import config_data, save_config, get_config, update_config_transaction
 from backend.common.profile_context import profile_api_path, resolve_profile_id
+from backend.utils.reorder import resolve_new_order
 from backend.utils.rule_utils import sanitize_rule_name, get_rules_dir, save_rule_to_local
 from backend.utils.logger import get_logger
 
@@ -201,12 +202,19 @@ def handle_rule_library_item(rule_id):
 @rule_library_bp.route('/reorder', methods=['POST'])
 @require_auth
 def reorder_rule_library():
-    """批量更新规则仓库顺序"""
+    """批量更新规则仓库顺序
+
+    按 id 排序时传 {'ids': [...], 'position': 'top'|'bottom'}；
+    传完整对象数组的旧格式仍然兼容。
+    """
     try:
-        new_order = request.json.get('rules', [])
+        body = request.json or {}
+        new_order, missing = resolve_new_order(config_data.get('rule_library', []), body, 'rules')
+        if missing:
+            return jsonify({'success': False, 'message': f'以下规则仓库 id 不存在: {missing}'}), 404
         config_data['rule_library'] = new_order
         save_config()
-        return jsonify({'success': True})
+        return jsonify({'success': True, 'order': [r.get('id') for r in new_order]})
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500
 

--- a/backend/routes/rules.py
+++ b/backend/routes/rules.py
@@ -15,6 +15,7 @@ from backend.common.config import (
 )
 from backend.common.profile_context import profile_api_path, resolve_profile_id
 from backend.utils.rule_matcher import parse_rule_line, match_query, is_valid_domain, is_valid_ip
+from backend.utils.reorder import reorder_by_ids
 from backend.utils.rule_utils import get_rules_dir, sanitize_rule_name
 from backend.utils.logger import get_logger
 from backend.utils.url_utils import safe_exception_details, safe_url_for_log
@@ -151,28 +152,45 @@ def handle_rule(rule_id):
 @bp.route('/reorder', methods=['POST'])
 @require_auth
 def reorder_rules():
-    """批量更新规则和规则集顺序"""
+    """批量更新规则和规则集顺序
+
+    按 id 排序时传 {'ids': [...], 'position': 'top'|'bottom'}；
+    传完整 rule_configs 数组的旧格式仍然兼容。
+    """
     try:
         # 检查请求体是否存在
         if not request.json:
             logger.warning("Reorder request with no JSON body")
             return jsonify({'success': False, 'message': 'No request body provided'}), 400
 
-        rule_configs = request.json.get('rule_configs')
+        body = request.json
+        ids = body.get('ids')
 
-        # 检查 rule_configs 是否存在且为列表
-        if rule_configs is None:
-            logger.warning("Reorder request with no rule_configs field")
-            return jsonify({'success': False, 'message': 'No rule_configs provided'}), 400
+        if ids is not None:
+            if not isinstance(ids, list):
+                logger.warning(f"Reorder request with invalid ids type: {type(ids)}")
+                return jsonify({'success': False, 'message': 'ids must be a list'}), 400
+            rule_configs, missing = reorder_by_ids(
+                config_data.get('rule_configs', []), ids, body.get('position', 'top')
+            )
+            if missing:
+                return jsonify({'success': False, 'message': f'以下规则 id 不存在: {missing}'}), 404
+        else:
+            rule_configs = body.get('rule_configs')
 
-        if not isinstance(rule_configs, list):
-            logger.warning(f"Reorder request with invalid rule_configs type: {type(rule_configs)}")
-            return jsonify({'success': False, 'message': 'rule_configs must be a list'}), 400
+            # 检查 rule_configs 是否存在且为列表
+            if rule_configs is None:
+                logger.warning("Reorder request with no rule_configs field")
+                return jsonify({'success': False, 'message': 'No rule_configs provided'}), 400
+
+            if not isinstance(rule_configs, list):
+                logger.warning(f"Reorder request with invalid rule_configs type: {type(rule_configs)}")
+                return jsonify({'success': False, 'message': 'rule_configs must be a list'}), 400
 
         config_data['rule_configs'] = rule_configs
         save_config()
         logger.info(f"Successfully reordered {len(rule_configs)} rules")
-        return jsonify({'success': True})
+        return jsonify({'success': True, 'order': [r.get('id') for r in rule_configs]})
     except Exception as e:
         logger.error("Error reordering rules: %s", safe_exception_details(e))
         return jsonify({'success': False, 'message': 'Error reordering rules'}), 500

--- a/backend/routes/subscriptions.py
+++ b/backend/routes/subscriptions.py
@@ -7,6 +7,7 @@ import yaml
 from backend.routes import subscriptions_bp
 from backend.common.auth import require_auth, validate_token_or_jwt
 from backend.common.config import get_config, save_config, update_config_transaction
+from backend.utils.reorder import resolve_new_order
 from backend.utils.subscription_cache import (
     load_subscription_cache,
     save_subscription_nodes,
@@ -127,10 +128,13 @@ def reorder_subscriptions():
     """批量更新订阅顺序"""
     try:
         config_data = get_config()
-        new_order = request.json.get('subscriptions', [])
+        body = request.json or {}
+        new_order, missing = resolve_new_order(config_data.get('subscriptions', []), body, 'subscriptions')
+        if missing:
+            return jsonify({'success': False, 'message': f'以下订阅 id 不存在: {missing}'}), 404
         config_data['subscriptions'] = new_order
         save_config()
-        return jsonify({'success': True})
+        return jsonify({'success': True, 'order': [s.get('id') for s in new_order]})
     except Exception as e:
         current_app.logger.error("订阅操作失败: %s", safe_exception_details(e))
         return jsonify({'success': False, 'message': '订阅操作失败'}), 500

--- a/backend/test_mcp_tool_coverage.py
+++ b/backend/test_mcp_tool_coverage.py
@@ -1,0 +1,212 @@
+"""MCP 工具覆盖度回归：排序、规则位置、规则仓库正文/缓存、profile 级备份等"""
+import json
+
+import pytest
+from flask import Flask
+
+from backend.common import config as config_module
+from backend.common.config_repository import ProfileRepository
+from backend.mcp_server import tools
+from backend.routes import register_blueprints
+
+
+@pytest.fixture
+def app_with_config(tmp_path):
+    repository = ProfileRepository(tmp_path)
+    repository.save_profile(
+        "default",
+        {
+            "system_config": {"config_token": "mcp-admin-token", "server_domain": "https://cf.example.com"},
+            "subscriptions": [{"id": "sub-1", "name": "A"}, {"id": "sub-2", "name": "B"}],
+            "proxy_groups": [
+                {"id": "group-1", "name": "PROXY"},
+                {"id": "group-2", "name": "AUTO"},
+                {"id": "group-3", "name": "DIRECT"},
+            ],
+            "rule_configs": [
+                {"id": "rule-1", "itemType": "rule", "rule_type": "DOMAIN", "value": "a.com", "policy": "PROXY"},
+                {"id": "ruleset-1", "itemType": "ruleset", "name": "cn", "policy": "DIRECT", "url": "/api/rules/local/cn"},
+            ],
+            "rule_library": [
+                {"id": "lib-1", "name": "inline", "source_type": "content", "content": "DOMAIN,a.com"},
+                {"id": "lib-2", "name": "remote", "source_type": "url", "url": "https://example.com/x.list"},
+            ],
+        },
+    )
+    config_module.set_repository(repository)
+    app = Flask(__name__)
+    register_blueprints(app)
+    yield app, repository
+
+
+def _ids(repository, key):
+    return [item["id"] for item in repository.get_profile("default").get(key, [])]
+
+
+def test_new_tools_are_registered():
+    names = {tool["name"] for tool in tools.list_tools()}
+    assert {
+        "reorder_items",
+        "get_rule_library_content",
+        "cache_rule_library",
+        "get_agent_install_info",
+        "convert_mosdns_rule",
+        "manage_app_logs",
+    } <= names
+
+
+def test_reorder_moves_listed_items_to_top_and_bottom(app_with_config):
+    app, repository = app_with_config
+    with app.app_context():
+        result = tools.call_tool("reorder_items", {"collection": "proxy_groups", "ids": ["group-3"]})
+        assert result["order"] == ["group-3", "group-1", "group-2"]
+        tools.call_tool(
+            "reorder_items",
+            {"collection": "proxy_groups", "ids": ["group-3", "group-1"], "position": "bottom"},
+        )
+    assert _ids(repository, "proxy_groups") == ["group-2", "group-3", "group-1"]
+
+
+def test_reorder_supports_every_declared_collection(app_with_config):
+    app, repository = app_with_config
+    with app.app_context():
+        tools.call_tool("reorder_items", {"collection": "subscriptions", "ids": ["sub-2"]})
+        tools.call_tool("reorder_items", {"collection": "rule_library", "ids": ["lib-2"]})
+        tools.call_tool("reorder_items", {"collection": "rules", "ids": ["ruleset-1"]})
+    assert _ids(repository, "subscriptions") == ["sub-2", "sub-1"]
+    assert _ids(repository, "rule_library") == ["lib-2", "lib-1"]
+    assert _ids(repository, "rule_configs") == ["ruleset-1", "rule-1"]
+
+
+def test_reorder_keeps_ruleset_url_relative(app_with_config):
+    """列表接口会给规则集 URL 拼上 server_domain，回写时必须还原成相对路径"""
+    app, repository = app_with_config
+    with app.app_context():
+        tools.call_tool("reorder_items", {"collection": "rules", "ids": ["ruleset-1"]})
+    stored = {item["id"]: item for item in repository.get_profile("default")["rule_configs"]}
+    assert stored["ruleset-1"]["url"] == "/api/rules/local/cn"
+
+
+def test_reorder_rejects_unknown_id(app_with_config):
+    app, _ = app_with_config
+    with app.app_context():
+        with pytest.raises(Exception) as excinfo:
+            tools.call_tool("reorder_items", {"collection": "rules", "ids": ["nope"]})
+    assert "nope" in str(excinfo.value)
+
+
+def test_manage_rule_position_bottom_appends(app_with_config):
+    app, repository = app_with_config
+    with app.app_context():
+        created = tools.call_tool(
+            "manage_rule",
+            {
+                "action": "create",
+                "position": "bottom",
+                "data": {"itemType": "rule", "rule_type": "DOMAIN", "value": "z.com", "policy": "DIRECT"},
+            },
+        )
+        new_id = created["item"]["id"]
+    assert _ids(repository, "rule_configs")[-1] == new_id
+
+
+def test_manage_rule_defaults_to_top(app_with_config):
+    app, repository = app_with_config
+    with app.app_context():
+        created = tools.call_tool(
+            "manage_rule",
+            {
+                "action": "create",
+                "data": {"itemType": "rule", "rule_type": "DOMAIN", "value": "z.com", "policy": "DIRECT"},
+            },
+        )
+    assert _ids(repository, "rule_configs")[0] == created["item"]["id"]
+
+
+def test_rule_library_content_and_settings_section(app_with_config):
+    app, _ = app_with_config
+    with app.app_context():
+        assert tools.call_tool("get_rule_library_content", {"id": "lib-1"})["content"] == "DOMAIN,a.com"
+        tools.call_tool(
+            "update_settings",
+            {"section": "github_proxy", "data": {"proxy_domains": "https://gh.example.com/"}},
+        )
+        assert tools.call_tool("get_settings", {"section": "github_proxy"})["proxy_domains"] == "https://gh.example.com/"
+
+
+def test_profile_scoped_backup_export_and_import(app_with_config):
+    app, repository = app_with_config
+    repository.create_profile({"id": "alpha", "name": "Alpha"})
+    repository.save_profile("alpha", {"subscriptions": [{"id": "alpha-sub"}]})
+    with app.app_context():
+        exported = tools.call_tool(
+            "manage_config_backup", {"action": "export", "scope": "profile", "profile_id": "alpha"}
+        )
+        assert [sub["id"] for sub in exported["subscriptions"]] == ["alpha-sub"]
+        tools.call_tool(
+            "manage_config_backup",
+            {
+                "action": "import",
+                "scope": "profile",
+                "profile_id": "alpha",
+                "data": {"subscriptions": [{"id": "imported-sub"}]},
+            },
+        )
+    assert [sub["id"] for sub in repository.get_profile("alpha")["subscriptions"]] == ["imported-sub"]
+
+
+def test_app_log_info_tool(app_with_config):
+    app, _ = app_with_config
+    with app.app_context():
+        assert tools.call_tool("manage_app_logs", {"action": "info"})["success"] is True
+
+
+def test_mosdns_rule_proxy_accepts_internal_mcp_call(app_with_config):
+    """内部调用不该被规则代理的 token 校验挡掉：缺 url 应报 400 而不是 401"""
+    app, _ = app_with_config
+    with app.app_context():
+        with pytest.raises(Exception) as excinfo:
+            tools.call_tool("convert_mosdns_rule", {"url": ""})
+    assert "401" not in str(excinfo.value) and "Unauthorized" not in str(excinfo.value)
+
+
+def test_reorder_does_not_persist_derived_list_fields(app_with_config):
+    """列表接口附加的缓存字段不该被排序写回配置"""
+    app, repository = app_with_config
+    with app.app_context():
+        tools.call_tool("reorder_items", {"collection": "subscriptions", "ids": ["sub-2"]})
+    stored = repository.get_profile("default")["subscriptions"]
+    assert all("cached_node_count" not in sub for sub in stored)
+
+
+def test_reorder_keeps_urls_that_output_sanitizer_redacts(app_with_config):
+    """含内部令牌的订阅 URL 在响应里会被脱敏，排序不能把脱敏结果写回配置"""
+    app, repository = app_with_config
+    repository.update_system_transaction(
+        lambda system: system.setdefault("system_config", {}).update({"rule_proxy_token": "sekret-token"})
+    )
+    secret_url = "https://cf.example.com/api/rules/local/cn?token=sekret-token"
+    repository.update_profile_transaction(
+        "default",
+        lambda profile: profile["subscriptions"].__setitem__(0, {"id": "sub-1", "name": "A", "url": secret_url}),
+    )
+    with app.app_context():
+        listed = tools.call_tool("list_subscriptions", {})
+        assert listed[0]["url"] == "[REDACTED]", "前提：列表响应确实会脱敏"
+        tools.call_tool("reorder_items", {"collection": "subscriptions", "ids": ["sub-2"]})
+    stored = {sub["id"]: sub for sub in repository.get_profile("default")["subscriptions"]}
+    assert stored["sub-1"]["url"] == secret_url
+
+
+def test_rest_reorder_still_accepts_full_object_arrays(app_with_config):
+    """旧格式（整份对象数组）保持兼容，前端不受影响"""
+    app, repository = app_with_config
+    from backend.mcp_server.invoker import call_api
+
+    with app.app_context():
+        call_api(
+            "POST",
+            "/api/proxy-groups/reorder",
+            body={"groups": [{"id": "group-2", "name": "AUTO"}, {"id": "group-1", "name": "PROXY"}]},
+        )
+    assert _ids(repository, "proxy_groups") == ["group-2", "group-1"]

--- a/backend/test_mcp_tool_coverage.py
+++ b/backend/test_mcp_tool_coverage.py
@@ -210,3 +210,73 @@ def test_rest_reorder_still_accepts_full_object_arrays(app_with_config):
             body={"groups": [{"id": "group-2", "name": "AUTO"}, {"id": "group-1", "name": "PROXY"}]},
         )
     assert _ids(repository, "proxy_groups") == ["group-2", "group-1"]
+
+
+def _schema(name):
+    return next(tool for tool in tools.list_tools() if tool["name"] == name)
+
+
+def test_tool_descriptions_use_real_field_names():
+    """工具描述里的字段名必须是后端真实字段，否则模型照着填会被静默忽略"""
+    group = _schema("manage_proxy_group")
+    text = group["description"] + json.dumps(group["inputSchema"], ensure_ascii=False)
+    for field in ("include_groups", "regex", "aggregation_regex", "follow_group", "manual_nodes"):
+        assert field in text, field
+    for fabricated in ("exclude_filter", "'filter'", "groups（引用的其他策略组名）"):
+        assert fabricated not in text, fabricated
+
+    node = _schema("manage_node")
+    node_text = node["description"] + json.dumps(node["inputSchema"], ensure_ascii=False)
+    assert "proxy_string" in node_text
+    assert "cipher" not in node_text and "uuid" not in node_text
+
+    agg_text = json.dumps(_schema("manage_aggregation"), ensure_ascii=False)
+    assert "regex_filter" in agg_text and "exclude_keywords" not in agg_text
+
+    sub_text = json.dumps(_schema("manage_subscription"), ensure_ascii=False)
+    assert "health_check_url" in sub_text and "exclude_keywords" not in sub_text
+
+    lib_text = json.dumps(_schema("manage_rule_library"), ensure_ascii=False)
+    assert "format（yaml / text）" not in lib_text
+
+
+def test_proxy_group_edit_round_trip_with_real_fields(app_with_config):
+    """按工具描述里的字段名编辑策略组，改动必须真的落到配置里"""
+    app, repository = app_with_config
+    with app.app_context():
+        created = tools.call_tool(
+            "manage_proxy_group",
+            {
+                "action": "create",
+                "data": {
+                    "name": "AUTO-HK",
+                    "type": "url-test",
+                    "enabled": True,
+                    "subscriptions": ["sub-1"],
+                    "regex": "HK|香港",
+                    "include_groups": ["group-1"],
+                    "manual_nodes": ["DIRECT"],
+                },
+            },
+        )
+        group_id = created["item"]["id"]
+        tools.call_tool(
+            "manage_proxy_group",
+            {"action": "update", "id": group_id, "data": {"regex": "SG|新加坡", "interval": 600}},
+        )
+    stored = {g["id"]: g for g in repository.get_profile("default")["proxy_groups"]}[group_id]
+    assert stored["regex"] == "SG|新加坡"
+    assert stored["include_groups"] == ["group-1"]
+    assert stored["subscriptions"] == ["sub-1"]
+    assert stored["interval"] == 600
+
+
+def test_node_create_uses_proxy_string(app_with_config):
+    app, repository = app_with_config
+    with app.app_context():
+        created = tools.call_tool(
+            "manage_node",
+            {"action": "create", "data": {"name": "HK-01", "proxy_string": "ss://abc@1.2.3.4:443", "enabled": True}},
+        )
+    stored = {n["id"]: n for n in repository.get_profile("default").get("nodes", [])}
+    assert stored[created["item"]["id"]]["proxy_string"] == "ss://abc@1.2.3.4:443"

--- a/backend/utils/reorder.py
+++ b/backend/utils/reorder.py
@@ -1,0 +1,52 @@
+"""集合排序工具
+
+排序接口原本只接受「整份集合的完整对象数组」，调用方必须把列表接口读到的数据原样回写。
+列表接口返回的却是加工过的展示数据（拼过域名的 URL、缓存计数、脱敏后的字段），
+回写就会把这些加工结果写进配置。按 id 排序可以让服务端在存量数据上重排，避免这个问题。
+"""
+from typing import Any, Dict, List, Tuple
+
+
+def reorder_by_ids(
+    items: List[Dict[str, Any]],
+    ids: List[str],
+    position: str = 'top',
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """把 ids 指定的条目按给定顺序移到集合一端，其余条目保持原有相对顺序
+
+    Args:
+        items: 存量集合
+        ids: 要移动的条目 id，按目标先后顺序排列
+        position: 'top' 移到最前，'bottom' 移到最后
+
+    Returns:
+        (重排后的集合, 在集合中找不到的 id 列表)
+    """
+    by_id = {item.get('id'): item for item in items if isinstance(item, dict)}
+    missing = [item_id for item_id in ids if item_id not in by_id]
+    if missing:
+        return items, missing
+
+    selected = set(ids)
+    moved = [by_id[item_id] for item_id in ids]
+    rest = [item for item in items if not (isinstance(item, dict) and item.get('id') in selected)]
+    ordered = moved + rest if position == 'top' else rest + moved
+    return ordered, []
+
+
+def resolve_new_order(
+    current: List[Dict[str, Any]],
+    body: Dict[str, Any],
+    object_key: str,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """解析排序请求体：优先按 id 在存量数据上重排，否则沿用整份对象数组的旧格式
+
+    Returns:
+        (重排后的集合, 无法处理的 id / 错误说明列表)
+    """
+    ids = body.get('ids')
+    if ids is None:
+        return body.get(object_key, []), []
+    if not isinstance(ids, list):
+        return current, ['ids 必须是数组']
+    return reorder_by_ids(current, ids, body.get('position', 'top'))

--- a/doc/module/mcp.md
+++ b/doc/module/mcp.md
@@ -36,7 +36,7 @@ MCP 服务与主应用同进程运行，不需要额外部署或额外端口。
 > （`.../api/config/mihomo?token=<配置令牌>`），你复制到 Mihomo / Surge 等客户端的
 > 那串链接里就带着它。
 >
-> 而 MCP 工具可以导出整份配置（含各订阅的明文地址）、重置系统、卸载 Agent。
+> 而 MCP 工具可以导出整份配置（含各订阅的明文地址）、重置系统、卸载 Agent、清空日志。
 > 因此 **持有订阅链接 = 持有管理员权限**。
 >
 > 这意味着：**订阅链接不要分享给他人**。如果确实需要把订阅链接发给别人，
@@ -74,6 +74,7 @@ claude mcp add --transport http configflow http://<你的地址>/mcp \
 ## 可用工具
 
 工具按功能域组织，读操作以 `list_` / `get_` 开头，写操作以 `manage_` 开头（通过 `action` 参数区分增删改）。
+所有工具都接受可选的 `profile_id`；留空时作用于 `default` profile（不跟随界面上激活的 profile）。
 
 ### 订阅与节点
 
@@ -85,18 +86,20 @@ claude mcp add --transport http configflow http://<你的地址>/mcp \
 | `get_subscription_nodes` | 获取订阅下已解析的节点 |
 | `list_nodes` / `manage_node` | 手动节点的查询与增删改 |
 | `list_aggregations` / `manage_aggregation` | 订阅聚合的查询与增删改 |
-| `preview_aggregation` | 预览聚合产出的节点与数量 |
+| `preview_aggregation` | 预览聚合产出的节点、数量或 provider YAML（`mode`） |
 
 ### 规则
 
 | 工具 | 说明 |
 |------|------|
-| `list_rules` / `manage_rule` | 规则与规则集的查询与增删改 |
+| `list_rules` / `manage_rule` | 规则与规则集的查询与增删改（`position` 控制新规则放队首还是队尾） |
 | `batch_add_rules` | 按同一类型和策略批量添加规则 |
 | `test_rule_match` | 测试域名/IP 命中哪条规则、走哪个策略组 |
 | `find_duplicate_rules` | 扫描重复的规则条目 |
 | `list_rule_library` / `manage_rule_library` | 规则仓库条目的查询与增删改 |
 | `test_rule_library` | 测试规则集 URL 的连通性 |
+| `get_rule_library_content` | 读取 `source_type=content` 条目的正文 |
+| `cache_rule_library` | 把指定条目拉取并缓存到本地 |
 
 ### 策略组与配置
 
@@ -107,7 +110,8 @@ claude mcp add --transport http configflow http://<你的地址>/mcp \
 | `preview_config` | 生成配置内容并返回，不写盘 |
 | `generate_config` | 生成配置并保存（MosDNS 为打包下载，不落盘） |
 | `manage_custom_config` | 读写自定义配置片段 |
-| `manage_config_backup` | 导出 / 导入 / 重置整份配置 |
+| `manage_config_backup` | 导出 / 导入 / 重置配置（`scope=profile` 时只作用于单个 profile） |
+| `reorder_items` | 调整订阅 / 节点 / 规则 / 规则仓库 / 策略组的顺序 |
 
 ### MosDNS、Agent 与系统
 
@@ -116,16 +120,20 @@ claude mcp add --transport http configflow http://<你的地址>/mcp \
 | `get_mosdns_settings` / `update_mosdns_settings` | MosDNS 各分区配置的读写 |
 | `list_agents` / `get_agent` / `manage_agent` | Agent 的查询、重启、推送配置、升级、卸载 |
 | `get_agent_logs` / `get_agent_metrics` | Agent 日志与监控数据 |
+| `get_agent_install_info` | 安装脚本 / Docker compose / run 命令 / 最新版本号 |
+| `convert_mosdns_rule` | 把远程规则文件转换成 MosDNS 格式预览 |
 | `get_overview` | 系统概览统计 |
 | `get_settings` / `update_settings` | 系统设置的读写 |
 | `run_backup` | 立即备份或测试 WebDAV 连通性 |
 | `get_app_logs` | 读取服务端日志 |
+| `manage_app_logs` | 查看日志文件信息或清空日志 |
 
 ## 使用要点
 
 - **改完配置记得生成**：修改订阅、规则或策略组后，需要调用 `generate_config` 才会写入 Mihomo / Surge 订阅链接对应的配置文件（MosDNS 订阅链接为实时生成，无需此步）。
 - **更新是增量的**：`manage_*` 的 `update` 只需给出要改的字段，其余字段会自动保留。
 - **先看再改**：`preview_config`、`preview_proxy_group_regex`、`preview_aggregation` 都不会改动数据，适合在落盘前确认效果。
+- **顺序就是优先级**：规则列表顺序即匹配优先级，新建规则默认插在最前面；要调整顺序用 `reorder_items`（`ids` 里的条目按给定顺序整体移到最前或最后，其余保持原相对顺序）。
 
 ## 对话示例
 
@@ -134,6 +142,8 @@ claude mcp add --transport http configflow http://<你的地址>/mcp \
 > 把 github.com 和 githubusercontent.com 加到「国外流量」策略组
 
 > 检查一下规则里有没有重复条目
+
+> 把广告拦截那条规则挪到规则列表最前面
 
 > 预览一下当前的 Mihomo 配置，确认没问题后生成
 


### PR DESCRIPTION
## 背景

排查发现 MCP 工具层有两类缺口：

1. **排序完全没暴露**：后端有 5 个 reorder 接口（订阅 / 节点 / 规则 / 规则仓库 / 策略组），MCP 一个都没包。规则顺序即匹配优先级，而 `POST /api/rules` 固定 `insert(0, ...)`，等于 MCP 建的规则一律抢最高优先级且挪不走。
2. **工具描述里的字段名有一批是后端不存在的**，模型照着填会被静默忽略，表现为「通过 MCP 改了但没生效」（策略组编辑尤其明显）。

另有若干 REST 能力没有对应工具（规则仓库正文 / 缓存、profile 级导入导出、Agent 日志运维与安装物料、MosDNS 规则转换、日志文件运维、GitHub 加速域名）。

## 改动

### 新增工具
- `reorder_items`：订阅 / 节点 / 规则 / 规则仓库 / 策略组排序
- `get_rule_library_content`、`cache_rule_library`
- `get_agent_install_info`（安装脚本 / compose / run 命令 / 最新版本）
- `convert_mosdns_rule`
- `manage_app_logs`（日志信息 / 清空）

### 扩展既有工具
- `manage_rule` 增加 `position`（新建规则可放列表末尾）
- `preview_aggregation` 增加 `mode=provider`
- `manage_config_backup` 增加 `scope=profile`
- `manage_agent` 增加 `clear_log` / `validate_log_path` / `get_logging` / `set_logging`
- `get_settings` / `update_settings` 增加 `github_proxy` 分区
- `profile_id` 描述改为与实际行为一致（留空作用于 `default` profile，不跟随激活 profile）

### 字段名修正
| 工具 | 原描述（后端不存在） | 实际字段 |
|---|---|---|
| `manage_proxy_group` | `groups` / `filter` / `exclude_filter` | `include_groups`（id）/ `regex` / `aggregation_regex`，另补 `follow_group`、`proxies_order`、`strategy`、`lazy` |
| `manage_node` | `type` / `server` / `port` / `password` / `uuid` / `cipher` | `proxy_string`（完整节点链接或结构化 proxy 文本）、`name`、`enabled`、`remark` |
| `manage_aggregation` | `exclude_keywords` | `regex_filter`，另补 `description`、`health_check_url` |
| `manage_subscription` | `udp` / `exclude_keywords` | `interval`、`health_check_url` |
| `manage_rule_library` | `format` | —（该字段不存在） |

### 后端配合改动
- **排序接口新增按 id 排序**（`{ids, position}`），在存量数据上重排；原「整份对象数组」格式保持兼容（前端不受影响）。
  原因：列表接口返回的是加工过的展示数据——规则集 URL 被拼上 `server_domain`、订阅带 `cached_node_count`、含内部令牌的字段被 after_request 脱敏成 `[REDACTED]`——按对象数组回写会把这些结果写进配置造成数据损坏。
- `/api/mosdns/rule-proxy` 的鉴权认进程内调用，与 `validate_token_or_jwt` 保持一致（否则 MCP 包装必然 401）。

## 验证

`backend/test_mcp_tool_coverage.py` 新增 17 个用例，覆盖：
- 五个集合的排序、top/bottom 语义、未知 id 报错
- 排序不写回展示字段（`cached_node_count`）、不写回脱敏后的 URL（用例内先断言列表响应确实被脱敏，再断言配置里 URL 完好）
- 旧的对象数组格式仍然可用
- `manage_rule` 的 top / bottom 位置
- 策略组按真实字段名编辑的端到端往返、节点按 `proxy_string` 创建
- 字段名回归锁定（描述里不得再出现 `exclude_filter` / `cipher` / `exclude_keywords` 等）
- profile 级导入导出、规则仓库正文、`github_proxy` 设置、日志信息

```
$ python -m pytest backend -q
1 failed, 402 passed, 1 skipped
```

唯一失败项 `test_after_request_replaces_raw_json_that_exceeds_decoder_recursion_limit` 在未改动的 main 上同样失败（本机 Python 3.14 的递归行为），**属预先存在**，与本 PR 无关。