### PR TITLE
fix(ci): 前端构建镜像升级到 Node 20

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ==============================================================================
 # Stage 2: 构建前端
 # ==============================================================================
-FROM node:18-alpine AS frontend-builder
+# vite-plugin-pwa 依赖的 workbox-build 要求 node >= 20；
+# Node 18 已于 2025-04 结束维护，直接升到 20 LTS。
+FROM node:20-alpine AS frontend-builder
 
 WORKDIR /app/frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "config-flow-frontend",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## 问题

GitHub Actions 的 Docker 构建失败。

UI 重构引入的 `vite-plugin-pwa` 依赖 `workbox-build@7.4.1`，后者在 `package-lock.json` 中声明：

```json
"node_modules/workbox-build": {
  "version": "7.4.1",
  "engines": { "node": ">=20.0.0" }
}
```

而 `docker/Dockerfile` 的前端构建阶段使用 `node:18-alpine`。

本地开发环境是 Node 24，所以该问题在提交前没有暴露——这是一个「本地能过、CI 挂掉」的典型环境差异。

## 修复

- 前端构建阶段 `node:18-alpine` → `node:20-alpine`（Node 18 已于 2025-04 结束维护，本就该升）
- `frontend/package.json` 声明 `engines.node >= 20`，让不满足要求的环境在 `npm ci` 阶段直接报错，而不是构建到一半才失败

选择升 Node 而非降级 PWA 插件：Node 18 已 EOL，继续钉在上面会持续阻塞依赖升级。

## 验证

- 确认 `package-lock.json` 中 `workbox-build@7.4.1` 的 `engines` 为 `{"node": ">=20.0.0"}`
- `npm ci` 与 `npm run build` 通过，PWA 生成 38 条预缓存
- 未能在本地用 Docker 实机复现（本机无 docker，生产机拉取 node:18-alpine 镜像超时），根因判定依据为 package-lock 中的 engines 声明与 Dockerfile 基础镜像版本的直接冲突
